### PR TITLE
Agent/Master daemon endpoint

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -39,3 +39,4 @@ dependencies:
     - pytest-mock
     - simple-parsing
     - asyncssh
+    - aiofiles

--- a/environment.yml
+++ b/environment.yml
@@ -38,3 +38,4 @@ dependencies:
     - pytest-asyncio
     - pytest-mock
     - simple-parsing
+    - asyncssh

--- a/examples/gpt2.yaml
+++ b/examples/gpt2.yaml
@@ -1,0 +1,14 @@
+# python -m oobleck.run --config_path examples/gpt2.yaml --master_ip ip --master_port port --node_ips=[node_ips]
+
+node_ips:
+  - 127.0.0.1
+
+job_config:
+  model_name: gpt2
+  model_tag: medium
+  dataset_path: wikitext
+  dataset_name: wikitext-2-raw-v1
+  fault_threshold: 3
+  microbatch_size: 2
+  global_microbatch_size: 128
+  steps: 30

--- a/examples/gpt2.yaml
+++ b/examples/gpt2.yaml
@@ -1,9 +1,10 @@
-# python -m oobleck.run --config_path examples/gpt2.yaml --master_ip ip --master_port port --node_ips=[node_ips]
+# python -m oobleck.run --config_path examples/gpt2.yaml --master_ip ip --master_port port
+
 
 node_ips:
   - 127.0.0.1
 
-job_config:
+job_args:
   model_name: gpt2
   model_tag: medium
   dataset_path: wikitext

--- a/examples/gpt2.yaml
+++ b/examples/gpt2.yaml
@@ -1,8 +1,4 @@
-# python -m oobleck.run --config_path examples/gpt2.yaml --master_ip ip --master_port port
-
-
-node_ips:
-  - 127.0.0.1
+# python -m oobleck.run --config_path examples/gpt2.yaml --node_ips [agent_ips] --master_ip ip --master_port port
 
 job_args:
   model_name: gpt2

--- a/oobleck/csrc/planning/bind.cpp
+++ b/oobleck/csrc/planning/bind.cpp
@@ -54,7 +54,11 @@ PYBIND11_MODULE(pipeline_template, m) {
                              &PipelineTemplate::get_iteration_time)
       .def_property_readonly("_num_nodes", &PipelineTemplate::get_num_nodes)
       .def_property_readonly("_num_gpus_per_node",
-                             &PipelineTemplate::get_num_gpus_per_node);
+                             &PipelineTemplate::get_num_gpus_per_node)
+      .def("__repr__", [](const PipelineTemplate& pt) {
+        return "<oobleck.PipelineTemplate." +
+               std::to_string(pt.get_num_nodes()) + "nodes>";
+      });
 
   py::class_<PipelineTemplateGenerator>(m, "PipelineTemplateGenerator")
       .def(py::init<>())

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -1,5 +1,4 @@
 import asyncio
-import concurrent.futures
 import logging
 import multiprocessing as mp
 import os

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -146,8 +146,11 @@ class OobleckAgent:
 
     async def on_receive_reconfiguration(self):
         logger.debug("reconfiguration request received")
+        lost_ranks: list[int] = await message_util.recv(self.conn_[0], need_pickle=True)
+
         # Send SIGUSR1 signal to workers
         for worker in self._workers:
+            worker.pipe.send(lost_ranks)
             os.kill(worker.process.pid, signal.SIGUSR1)
 
     async def on_receive_response(self):

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -77,10 +77,6 @@ class OobleckAgent:
         ):
             raise ConnectionError("Failed to register agent")
 
-        # When success, start pinging the master
-        # asyncio.create_task(self.ping())
-        asyncio.create_task(self.on_receive_response())
-
     def _run_profiler(self, num_workers: int, args: OobleckArguments):
         ctx = multiprocessing.get_context("spawn")
         profiler_processes: list[multiprocessing.Process] = []

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -5,13 +5,12 @@ import os
 import signal
 from dataclasses import dataclass
 from multiprocessing import connection
-from typing import Any
 
 import simple_parsing
 from multiprocess.context import SpawnProcess
 
 import oobleck.elastic.message_util as message_util
-from oobleck.elastic.training_util import OobleckArguments
+from oobleck.elastic.training_util import OobleckAgentArguments, OobleckArguments
 from oobleck.elastic.worker import worker_main
 
 logger = logging.getLogger(__name__)
@@ -21,14 +20,6 @@ logger = logging.getLogger(__name__)
 class Worker:
     pipe: connection.Connection
     process: SpawnProcess
-
-
-@dataclass
-class OobleckAgentArguments:
-    master_ip: str
-    master_port: int
-    oobleck_training_args: dict[str, Any]
-    num_workers: int
 
 
 class OobleckAgent:
@@ -210,9 +201,7 @@ async def main():
     agent = OobleckAgent()
     await agent.connect_to_master(args.master_ip, args.master_port)
     await agent.register_agent()
-    agent.launch_workers(
-        args.num_workers, OobleckArguments(**args.oobleck_training_args)
-    )
+    agent.launch_workers(args.num_workers, args)
     await agent.get_dist_info()
 
 

--- a/oobleck/elastic/master.py
+++ b/oobleck/elastic/master.py
@@ -163,6 +163,15 @@ class OobleckMasterDaemon:
         # TODO: find another unique identifier than IP address.
         client_ip = w.get_extra_info("peername")[0]
 
+        if self._job is None or client_ip not in self._job.node_ips:
+            logger.warning(f"Agent {client_ip} is not registered")
+            return await message_util.send_response(
+                w,
+                message_util.RequestType.REGISTER_AGENT,
+                message_util.Response.FAILURE,
+                close=True,
+            )
+
         if client_ip in self._agent_connections:
             logger.warning(f"Agent {client_ip} already registered")
             return await message_util.send_response(

--- a/oobleck/elastic/master.py
+++ b/oobleck/elastic/master.py
@@ -79,7 +79,7 @@ class OobleckMasterDaemon:
                 master_port=self._port,
                 node_ips=job_config.node_ips,
                 job_args=job_config.job_args,
-                num_workers=4,
+                num_workers=1,
             )
             cmd += " ".join(
                 [f"--{k}={v}" for k, v in flatten_configurations(agent_args).items()]
@@ -94,9 +94,12 @@ class OobleckMasterDaemon:
                 cmd,
                 term_type="xterm",
             ) as process:
-                while not process.is_closing():
-                    output = await process.stdout.readline()
-                    await log_file.write(output)
+                logger.info(
+                    f"Agent {node_ip} output will be written at {log_file_path}."
+                )
+                async for data in process.stdout:
+                    await log_file.write(data)
+                    await log_file.flush()
 
     async def request_job_handler(
         self,

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -55,6 +55,11 @@ def flatten_configurations(
     for k, v in asdict(dataclass).items():
         if is_dataclass(v):
             result.update(flatten_configurations(v))
+        elif isinstance(v, dict):
+            v = {k: v for k, v in v.items() if v is not None}
+            result.update(v)
+        elif isinstance(v, list):
+            result[k] = ",".join(v)
         else:
             result[k] = v
     return result

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -28,6 +28,7 @@ class OobleckAgentArguments(Serializable):
 
     master_ip: str
     master_port: int
+    node_ips: list[str]
     job_args: OobleckArguments
     num_workers: int
 

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -14,3 +14,11 @@ class OobleckArguments(Serializable):
     global_microbatch_size: int = 128
     model_args: dict[str, any] | None = None
     steps: int = 50
+
+
+@dataclass
+class DistributedJobConfiguration(Serializable):
+    node_ips: list[str]
+    arguments: OobleckArguments
+    node_port: int = 22
+    username: str | None = None

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -13,3 +13,4 @@ class OobleckArguments(Serializable):
     microbatch_size: int = 1
     global_microbatch_size: int = 128
     model_args: dict[str, any] | None = None
+    steps: int = 50

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -1,10 +1,14 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 
 from simple_parsing import Serializable
 
 
 @dataclass
 class OobleckArguments(Serializable):
+    """Data class that contains information about the training job.
+    OobleckAgent -> OobleckEngine
+    """
+
     model_name: str
     model_tag: str
     dataset_path: str
@@ -17,8 +21,39 @@ class OobleckArguments(Serializable):
 
 
 @dataclass
+class OobleckAgentArguments(Serializable):
+    """Data class that contains information about the training job.
+    OobleckMasterDaemon -> OobleckAgent
+    """
+
+    master_ip: str
+    master_port: int
+    job_args: OobleckArguments
+    num_workers: int
+
+
+@dataclass
 class DistributedJobConfiguration(Serializable):
+    """Data class that contains information about distributed training.
+    run.py -> OobleckMasterDaemon
+    """
+
+    master_ip: str
+    master_port: int
     node_ips: list[str]
-    arguments: OobleckArguments
+    job_args: OobleckArguments
     node_port: int = 22
     username: str | None = None
+
+
+def flatten_configurations(
+    dataclass: OobleckAgentArguments | DistributedJobConfiguration,
+) -> dict:
+    """Flatten the configuration dataclass into a dict."""
+    result = {}
+    for k, v in asdict(dataclass).items():
+        if is_dataclass(v):
+            result.update(flatten_configurations(v))
+        else:
+            result[k] = v
+    return result

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -4,7 +4,7 @@ from simple_parsing import Serializable
 
 
 @dataclass
-class TrainingArguments(Serializable):
+class OobleckArguments(Serializable):
     model_name: str
     model_tag: str
     dataset_path: str

--- a/oobleck/elastic/worker.py
+++ b/oobleck/elastic/worker.py
@@ -19,12 +19,16 @@ def worker_main(
 ):
     assert torch.cuda.device_count() == 1 and torch.cuda.current_device() == 0
 
+    logger.info("Initializing Oobleck Engine...")
     engine = OobleckEngine(local_rank, num_nodes, num_gpus_per_node, pipe, args)
+    logger.info("Initializing torch.distributed...")
     engine.initialize_distributed()
 
     if args.global_microbatch_size % args.microbatch_size != 0:
         raise ValueError("global_microbatch_size must be divisible by microbatch_size")
 
     global_num_microbatch = args.global_microbatch_size // args.microbatch_size
+    logger.info("Instantiating pipelines...")
     engine.instantiate_pipelines(global_num_microbatch)
+    logger.info("Begin training...")
     engine.train()

--- a/oobleck/elastic/worker.py
+++ b/oobleck/elastic/worker.py
@@ -1,21 +1,25 @@
-import os
+import multiprocessing
 from multiprocessing import connection
 
 import torch
+from deepspeed.utils.logging import LoggerFactory
 
 from oobleck.elastic.training_util import OobleckArguments
 from oobleck.execution.engine import OobleckEngine
 
+logger = LoggerFactory.create_logger("oobleck_worker")
+
 
 def worker_main(
     local_rank: int,
+    num_nodes: int,
     num_gpus_per_node: int,
     pipe: connection.Connection,
     args: OobleckArguments,
 ):
     assert torch.cuda.device_count() == 1 and torch.cuda.current_device() == 0
 
-    engine = OobleckEngine(local_rank, num_gpus_per_node, pipe, args)
+    engine = OobleckEngine(local_rank, num_nodes, num_gpus_per_node, pipe, args)
     engine.initialize_distributed()
 
     if args.global_microbatch_size % args.microbatch_size != 0:

--- a/oobleck/elastic/worker.py
+++ b/oobleck/elastic/worker.py
@@ -1,2 +1,26 @@
-def worker_main():
-    pass
+import os
+from multiprocessing import connection
+
+import torch
+
+from oobleck.elastic.training_util import OobleckArguments
+from oobleck.execution.engine import OobleckEngine
+
+
+def worker_main(
+    local_rank: int,
+    num_gpus_per_node: int,
+    pipe: connection.Connection,
+    args: OobleckArguments,
+):
+    assert torch.cuda.device_count() == 1 and torch.cuda.current_device() == 0
+
+    engine = OobleckEngine(local_rank, num_gpus_per_node, pipe, args)
+    engine.initialize_distributed()
+
+    if args.global_microbatch_size % args.microbatch_size != 0:
+        raise ValueError("global_microbatch_size must be divisible by microbatch_size")
+
+    global_num_microbatch = args.global_microbatch_size // args.microbatch_size
+    engine.instantiate_pipelines(global_num_microbatch)
+    engine.train()

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -353,6 +353,7 @@ class OobleckEngine:
     def __init__(
         self,
         local_rank: int,
+        num_nodes: int,
         num_gpus_per_node: int,
         pipe: connection.Connection,
         args: OobleckArguments,
@@ -376,6 +377,7 @@ class OobleckEngine:
         )
 
         self._local_rank: int = local_rank
+        self._num_nodes: int = num_nodes
         self._num_gpus_per_node: int = num_gpus_per_node
 
         # Initialize without distributed
@@ -387,10 +389,10 @@ class OobleckEngine:
             self._model,
             self._profile_results,
             self._pipeline_templates,
-        ) = self.initialize_engine(self._num_gpus_per_node)
+        ) = self._initialize_engine(self._num_nodes, self._num_gpus_per_node)
 
-    def initialize_engine(
-        self, num_gpus_per_node: int
+    def _initialize_engine(
+        self, num_nodes: int, num_gpus_per_node: int
     ) -> tuple[
         OobleckDataset,
         OobleckModel,
@@ -425,7 +427,7 @@ class OobleckEngine:
         pipeline_templates: list[
             PipelineTemplate
         ] = template_generator.create_pipeline_templates(
-            profile_results, (1, num_gpus_per_node), num_gpus_per_node
+            profile_results, (1, num_nodes), 1
         )
 
         return dataset, model, profile_results, pipeline_templates

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -18,7 +18,7 @@ from oobleck.csrc.planning.pipeline_template import (
     get_profile_results,
 )
 from oobleck.elastic.message_util import DistributionInfo
-from oobleck.elastic.training_util import TrainingArguments as OobleckArguments
+from oobleck.elastic.training_util import OobleckArguments
 from oobleck.execution.dataloader import LoaderType, OobleckDataLoader, OobleckSampler
 from oobleck.execution.dataset import OobleckDataset
 from oobleck.execution.pipeline import OobleckPipeline

--- a/oobleck/run.py
+++ b/oobleck/run.py
@@ -1,0 +1,74 @@
+import asyncio
+import getpass
+import logging
+
+import simple_parsing
+
+import oobleck.elastic.message_util as message_util
+from oobleck.elastic.training_util import DistributedJobConfiguration, OobleckArguments
+
+logger = logging.getLogger(__name__)
+
+
+class OobleckClient:
+    def __init__(self):
+        pass
+
+    async def connect_to_master(self, master_ip: str, master_port: int):
+        logger.info("Connecting to master...")
+        self.conn_ = await asyncio.wait_for(
+            asyncio.open_connection(master_ip, master_port),
+            timeout=message_util.TIMEOUT,
+        )
+
+    async def request_job_launch(self, job_config: DistributedJobConfiguration):
+        reader, writer = self.conn_
+        await message_util.send_request_type(
+            writer, message_util.RequestType.LAUNCH_JOB
+        )
+        await message_util.send(
+            writer, job_config, need_pickle=True, drain=True, close=False
+        )
+        response, request_type = await message_util.recv_response(reader)
+        assert request_type == message_util.RequestType.LAUNCH_JOB
+        if response == message_util.Response.SUCCESS:
+            logger.info("Job launch request is accepted by the master.")
+        else:
+            logger.error("Job launch request is rejected by the master.")
+            raise RuntimeError("Job launch request is rejected by the master.")
+
+
+async def main(job_config: DistributedJobConfiguration, master: tuple[str, int]):
+    client = OobleckClient()
+    await client.connect_to_master(master[0], master[1])
+    await client.request_job_launch(job_config)
+
+
+"""
+Send a training job run request to the master.
+Information to send
+1. List of node IPs where agents and workers will be running
+2. Job configuration (oobleck.elastic.training_util.OobleckArguments)
+"""
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
+    parser = simple_parsing.ArgumentParser()
+    parser.add_arguments(OobleckArguments, dest="job_config")
+    parser.add_argument("--username", type=str, default="")
+    parser.add_argument("--node-port", type=int)
+    parser.add_argument("--node-ips", type=str, nargs="+", required=True)
+    parser.add_argument("--master-ip", type=str, required=True)
+    parser.add_argument("--master-port", type=int, required=True)
+    parser.add_config_path_arg = True
+
+    args = parser.parse_args()
+    if not args.username:
+        args.username = getpass.getuser()
+    job_config: DistributedJobConfiguration = DistributedJobConfiguration(
+        node_ips=args.node_ips,
+        node_port=args.node_port,
+        arguments=args.job_config,
+        username=args.username,
+    )
+    asyncio.run(main(job_config, (args.master_ip, args.master_port)))

--- a/oobleck/run.py
+++ b/oobleck/run.py
@@ -38,10 +38,10 @@ class OobleckClient:
             raise RuntimeError("Job launch request is rejected by the master.")
 
 
-async def main(job_config: DistributedJobConfiguration, master: tuple[str, int]):
+async def main(args: DistributedJobConfiguration):
     client = OobleckClient()
-    await client.connect_to_master(master[0], master[1])
-    await client.request_job_launch(job_config)
+    await client.connect_to_master(args.master_ip, args.master_port)
+    await client.request_job_launch(args)
 
 
 """
@@ -53,22 +53,10 @@ Information to send
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
-    parser = simple_parsing.ArgumentParser()
-    parser.add_arguments(OobleckArguments, dest="job_config")
-    parser.add_argument("--username", type=str, default="")
-    parser.add_argument("--node-port", type=int)
-    parser.add_argument("--node-ips", type=str, nargs="+", required=True)
-    parser.add_argument("--master-ip", type=str, required=True)
-    parser.add_argument("--master-port", type=int, required=True)
-    parser.add_config_path_arg = True
+    args: DistributedJobConfiguration = simple_parsing.parse(
+        DistributedJobConfiguration, add_config_path_arg=True
+    )
 
-    args = parser.parse_args()
     if not args.username:
         args.username = getpass.getuser()
-    job_config: DistributedJobConfiguration = DistributedJobConfiguration(
-        node_ips=args.node_ips,
-        node_port=args.node_port,
-        arguments=args.job_config,
-        username=args.username,
-    )
-    asyncio.run(main(job_config, (args.master_ip, args.master_port)))
+    asyncio.run(main(args))

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
-import shutil
 
-from setuptools import Extension, setup
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 
 __version__ = "0.1.0"
@@ -119,4 +119,5 @@ setup(
     cmdclass={"build_ext": CmakeBuild},
     zip_safe=False,
     python_requires=">=3.8",
+    packages=find_packages(),
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,8 +425,8 @@ class OobleckMultiProcessTestCase:
 
         try:
             for _ in range(len(processes)):
-                # result = queue.get(timeout=60)
-                result = queue.get()
+                result = queue.get(timeout=60)
+                # result = queue.get()
 
                 if "error" in result:
                     # If any process get an error,

--- a/tests/elastic/conftest.py
+++ b/tests/elastic/conftest.py
@@ -1,9 +1,11 @@
 import asyncio
 
+import pytest
 import pytest_asyncio
 
 from oobleck.elastic.agent import OobleckAgent
-from oobleck.elastic.master import OobleckMasterDaemon, _AgentInfo, _Job
+from oobleck.elastic.master import OobleckMasterDaemon
+from oobleck.elastic.training_util import DistributedJobConfiguration, OobleckArguments
 
 
 class OobleckElasticTestCase:
@@ -23,10 +25,23 @@ class OobleckElasticTestCase:
 
     @pytest_asyncio.fixture
     async def agent(self, daemon: OobleckMasterDaemon) -> OobleckAgent:
-        daemon._job = _Job("test", [_AgentInfo("127.0.0.1", [0])])
-
         agent = OobleckAgent()
         await agent.connect_to_master("localhost", daemon.port)
         yield agent
         agent.conn_[1].close()
         await agent.conn_[1].wait_closed()
+
+    @pytest.fixture
+    def sample_job(self, daemon: OobleckMasterDaemon) -> DistributedJobConfiguration:
+        return DistributedJobConfiguration(
+            master_ip="127.0.0.1",
+            master_port=daemon.port,
+            node_ips=["127.0.0.1", "127.0.0.2"],
+            job_args=OobleckArguments(
+                model_name="gpt2",
+                model_tag="test",
+                dataset_path="test",
+                dataset_name=None,
+            ),
+            username="test",
+        )

--- a/tests/elastic/conftest.py
+++ b/tests/elastic/conftest.py
@@ -1,0 +1,32 @@
+import asyncio
+
+import pytest_asyncio
+
+from oobleck.elastic.agent import OobleckAgent
+from oobleck.elastic.master import OobleckMasterDaemon, _AgentInfo, _Job
+
+
+class OobleckElasticTestCase:
+    @pytest_asyncio.fixture(autouse=True)
+    async def daemon(
+        self, event_loop: asyncio.AbstractEventLoop
+    ) -> OobleckMasterDaemon:
+        daemon = await OobleckMasterDaemon.create()
+        event_loop.create_task(daemon.run())
+
+        yield daemon
+
+        if not daemon._server.is_serving():
+            return
+        daemon._server.close()
+        await daemon._server.wait_closed()
+
+    @pytest_asyncio.fixture
+    async def agent(self, daemon: OobleckMasterDaemon) -> OobleckAgent:
+        daemon._job = _Job("test", [_AgentInfo("127.0.0.1", [0])])
+
+        agent = OobleckAgent()
+        await agent.connect_to_master("localhost", daemon.port)
+        yield agent
+        agent.conn_[1].close()
+        await agent.conn_[1].wait_closed()

--- a/tests/elastic/test_agent.py
+++ b/tests/elastic/test_agent.py
@@ -11,7 +11,7 @@ from pytest_mock import MockerFixture
 
 import oobleck.elastic.message_util as message_util
 from oobleck.elastic.agent import OobleckAgent
-from oobleck.elastic.master import OobleckMasterDaemon, _AgentInfo
+from oobleck.elastic.master import OobleckMasterDaemon
 from oobleck.elastic.training_util import OobleckArguments
 from oobleck.elastic.worker import worker_main
 from tests.conftest import OobleckStaticClassFactory, datasets, model_args
@@ -45,28 +45,28 @@ class TestOobleckAgentClass(OobleckElasticTestCase):
         )
         agent.on_receive_dist_info.assert_called()
 
-    @pytest.mark.asyncio
-    async def test_receive_reconfiguration(
-        self, daemon: OobleckMasterDaemon, agent: OobleckAgent
-    ):
-        await agent.register_agent()
-        # TODO: daemon only check IP when registering agent, then use streams.
-        # To open another connection, we change the agent's ip.
-        daemon._job.agent_info[0].ip = "127.0.0.2"
-        daemon._job.agent_info.append(_AgentInfo("127.0.0.1", [1]))
+    # @pytest.mark.asyncio
+    # async def test_receive_reconfiguration(
+    #     self, daemon: OobleckMasterDaemon, agent: OobleckAgent
+    # ):
+    #     await agent.register_agent()
+    #     # TODO: daemon only check IP when registering agent, then use streams.
+    #     # To open another connection, we change the agent's ip.
+    #     daemon._job.agent_info[0].ip = "127.0.0.2"
+    #     daemon._job.agent_info.append(_AgentInfo("127.0.0.1", [1]))
 
-        agent2 = OobleckAgent()
-        await agent2.connect_to_master("localhost", daemon.port)
-        await agent2.register_agent()
+    #     agent2 = OobleckAgent()
+    #     await agent2.connect_to_master("localhost", daemon.port)
+    #     await agent2.register_agent()
 
-        agent.on_receive_reconfiguration = AsyncMock(
-            wraps=agent.on_receive_reconfiguration
-        )
+    #     agent.on_receive_reconfiguration = AsyncMock(
+    #         wraps=agent.on_receive_reconfiguration
+    #     )
 
-        # disconnect agent2
-        agent2.conn_[1].close()
-        await asyncio.sleep(0.1)
-        agent.on_receive_reconfiguration.assert_called()
+    #     # disconnect agent2
+    #     agent2.conn_[1].close()
+    #     await asyncio.sleep(0.1)
+    #     agent.on_receive_reconfiguration.assert_called()
 
     @staticmethod
     def fake_worker_main(

--- a/tests/elastic/test_agent.py
+++ b/tests/elastic/test_agent.py
@@ -56,7 +56,8 @@ class TestOobleckAgentClass(OobleckElasticTestCase):
         await agent._register_agent()
         await agent._launch_workers(self.sample_num_workers, daemon._job.job_args)
         assert len(agent._workers) == self.sample_num_workers
-        await asyncio.wait([worker.process for worker in agent._workers])
+        for worker in agent._workers:
+            worker.process.join()
 
     @staticmethod
     def fake_worker_main_echo_lost_ranks(

--- a/tests/elastic/test_master.py
+++ b/tests/elastic/test_master.py
@@ -7,7 +7,7 @@ import pytest_asyncio
 
 import oobleck.elastic.message_util as message_util
 from oobleck.elastic.master import OobleckMasterDaemon, _AgentInfo, _Job
-from tests.conftest import OobleckElasticTestCase
+from tests.elastic.conftest import OobleckElasticTestCase
 
 
 class TestOobleckMasterDaemonClass(OobleckElasticTestCase):

--- a/tests/elastic/test_master.py
+++ b/tests/elastic/test_master.py
@@ -1,57 +1,50 @@
 import asyncio
-import copy
 from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
+from pytest_mock import MockerFixture
 
 import oobleck.elastic.message_util as message_util
-from oobleck.elastic.master import OobleckMasterDaemon, _AgentInfo, _Job
+from oobleck.elastic.agent import OobleckAgent
+from oobleck.elastic.master import OobleckMasterDaemon
+from oobleck.elastic.training_util import DistributedJobConfiguration
 from tests.elastic.conftest import OobleckElasticTestCase
+
+"""
+MasterDaemon test cases
+
+1. request job handler (from run.py)
+2. launch agent (to OobleckAgent)
+3. agent register handler (from OobleckAgent)
+4. agent disconnection handler (from OobleckAgent)
+"""
 
 
 class TestOobleckMasterDaemonClass(OobleckElasticTestCase):
-    @pytest.fixture
-    def sample_job(self) -> _Job:
-        return _Job("test", [_AgentInfo("127.0.0.1", [0])])
-
     @pytest_asyncio.fixture(autouse=True)
-    async def conns(self, daemon: OobleckMasterDaemon):
+    async def client_conns(
+        self, daemon: OobleckMasterDaemon
+    ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         r, w = await asyncio.open_connection("localhost", daemon._port)
         yield r, w
         w.close()
         await w.wait_closed()
 
     @pytest.mark.asyncio
-    async def test_request_job_fail(
-        self,
-        daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-    ):
-        r, w = conns
-
-        daemon.request_job_handler = AsyncMock(wraps=daemon.request_job_handler)
-        daemon.request_job_handler.assert_not_awaited()
-
-        await message_util.send_request_type(w, message_util.RequestType.LAUNCH_JOB)
-
-        # Not providing job information within 5 seconds should return failure.
-        assert (await message_util.recv_response(r, timeout=None)) == (
-            message_util.Response.FAILURE,
-            message_util.RequestType.LAUNCH_JOB,
-        )
-
-        daemon.request_job_handler.assert_called_once()
-
-    @pytest.mark.asyncio
     async def test_request_job(
         self,
         daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-        sample_job: _Job,
+        client_conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
+        sample_job: DistributedJobConfiguration,
+        mocker: MockerFixture,
     ):
-        r, w = conns
+        mock_run_agents = mocker.patch.object(
+            daemon, "run_node_agent", return_value=AsyncMock(return_value=None)
+        )
 
+        r, w = client_conns
+        """Cehck if master launches agents."""
         await message_util.send_request_type(w, message_util.RequestType.LAUNCH_JOB)
         await message_util.send(w, sample_job, need_pickle=True, close=False)
 
@@ -64,245 +57,125 @@ class TestOobleckMasterDaemonClass(OobleckElasticTestCase):
         w.close()
         await w.wait_closed()
 
-        assert daemon._job
-        assert daemon._job.name == sample_job.name
+        assert mock_run_agents.call_count == len(sample_job.node_ips)
+        assert daemon._job == sample_job
 
     @pytest.mark.asyncio
-    async def test_get_dist_info_fail_no_job(
-        self,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-    ):
-        r, w = conns
-
-        await message_util.send_request_type(w, message_util.RequestType.GET_DIST_INFO)
-
-        with pytest.raises(asyncio.IncompleteReadError):
-            await message_util.recv_response(r)
-
-    @pytest.mark.asyncio
-    async def test_get_dist_info(
+    async def test_request_job_fail(
         self,
         daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-        sample_job: _Job,
+        client_conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
+        sample_job: DistributedJobConfiguration,
     ):
-        r, w = conns
-
+        # If daemon already has a job, it should return failure.
         daemon._job = sample_job
-        await message_util.send_request_type(w, message_util.RequestType.REGISTER_AGENT)
-        await message_util.recv_response(r)
 
-        await message_util.send_request_type(w, message_util.RequestType.GET_DIST_INFO)
-
-        assert await message_util.recv_response(r) == (
-            message_util.Response.SUCCESS,
-            message_util.RequestType.GET_DIST_INFO,
+        r, w = client_conns
+        await message_util.send_request_type(w, message_util.RequestType.LAUNCH_JOB)
+        assert (await message_util.recv_response(r)) == (
+            message_util.Response.FAILURE,
+            message_util.RequestType.LAUNCH_JOB,
         )
-
-        dist_info: message_util.DistributionInfo = await message_util.recv(
-            r, need_pickle=True
-        )
-        assert len(dist_info.agent_ips) == 1
-        assert dist_info.agent_ips[0] == "127.0.0.1"
-        assert dist_info.world_size == 1
-
-    @pytest.mark.asyncio
-    async def test_get_dist_info_blocked(
-        self,
-        daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-        sample_job: _Job,
-    ):
-        r, w = conns
-
-        # Make ips have two to simulate two nodes must call get_dist_info()
-        # to get information.
-        sample_job: _Job = copy.deepcopy(sample_job)
-        sample_job.agent_info = [
-            _AgentInfo("127.0.0.1", [0]),
-            _AgentInfo("127.0.0.2", [1]),
-        ]
-
-        daemon._job = sample_job
-        await message_util.send_request_type(w, message_util.RequestType.REGISTER_AGENT)
-        await message_util.recv_response(r)
-
-        # The node calling get_dist_info() should be blocked
-        await message_util.send_request_type(w, message_util.RequestType.GET_DIST_INFO)
-
-        with pytest.raises(asyncio.TimeoutError):
-            await message_util.recv_response(r)
-
-    @pytest.mark.asyncio
-    async def test_get_dist_info_by_multiple_clients(
-        self,
-        daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-        sample_job: _Job,
-    ):
-        r, w = conns
-
-        sample_job: _Job = copy.deepcopy(sample_job)
-        sample_job.agent_info = [
-            _AgentInfo("127.0.0.1", [0]),
-            _AgentInfo("127.0.0.2", [1]),
-        ]
-
-        daemon._job = sample_job
-        await message_util.send_request_type(w, message_util.RequestType.REGISTER_AGENT)
-        await message_util.recv_response(r)
-
-        r2, w2 = await asyncio.open_connection("localhost", daemon.port)
-        await message_util.send_request_type(
-            w2, message_util.RequestType.REGISTER_AGENT
-        )
-        await message_util.recv_response(r2)
-
-        # First client
-        await message_util.send_request_type(w, message_util.RequestType.GET_DIST_INFO)
-        task = asyncio.create_task(message_util.recv_response(r))
-
-        await asyncio.sleep(2)
-        assert len(daemon._nodes_to_rendezvous) == 1
-        assert not task.done(), "First client must be blocked."
-
-        # Second client
-        await message_util.send_request_type(w2, message_util.RequestType.GET_DIST_INFO)
-
-        # Both must succeed
-        while not task.done():
-            await asyncio.sleep(0.1)
-        assert task.result() == (
-            message_util.Response.SUCCESS,
-            message_util.RequestType.GET_DIST_INFO,
-        )
-        assert (await message_util.recv_response(r2)) == (
-            message_util.Response.SUCCESS,
-            message_util.RequestType.GET_DIST_INFO,
-        )
-
-        # Both must receive the same information
-        dist_info: message_util.DistributionInfo = await message_util.recv(
-            r, need_pickle=True
-        )
-        dist_info2: message_util.DistributionInfo = await message_util.recv(
-            r2, need_pickle=True
-        )
-        assert dist_info == dist_info2
-
-        w2.close()
-        await w2.wait_closed()
 
     @pytest.mark.asyncio
     async def test_register_agent(
         self,
         daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-        sample_job: _Job,
+        agent: OobleckAgent,
+        sample_job: DistributedJobConfiguration,
     ):
-        r, w = conns
         daemon._job = sample_job
+        assert not daemon._agent_connections
 
-        assert daemon._job.agent_info[0].streams is None
-
+        r, w = agent._conn
         await message_util.send_request_type(w, message_util.RequestType.REGISTER_AGENT)
         assert await message_util.recv_response(r) == (
             message_util.Response.SUCCESS,
             message_util.RequestType.REGISTER_AGENT,
         )
-        assert daemon._job.agent_info[0].streams
 
-    @pytest.mark.asyncio
-    async def test_ping_fail(
-        self,
-        daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-        sample_job: _Job,
-    ):
-        r, w = conns
-        daemon._job = sample_job
-
-        # Check agent is not registered
-        assert not daemon._job.agent_info[0].streams
-
-        await message_util.send_request_type(w, message_util.RequestType.PING)
-
-        # Without agent registration, expected to fail
-        with pytest.raises(asyncio.IncompleteReadError):
-            await message_util.recv_response(r)
-
-    @pytest.mark.asyncio
-    async def test_ping(
-        self,
-        daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-        sample_job: _Job,
-    ):
-        r, w = conns
-        daemon._job = sample_job
-
-        # Register agent then ping
-        await message_util.send_request_type(w, message_util.RequestType.REGISTER_AGENT)
-        assert (await message_util.recv_response(r)) == (
-            message_util.Response.SUCCESS,
-            message_util.RequestType.REGISTER_AGENT,
-        )
-
-        assert daemon._job.agent_info[0].streams
-
-        # Reuse the connection
-        await message_util.send_request_type(w, message_util.RequestType.PING)
-        assert (await message_util.recv_response(r, timeout=10)) == (
-            message_util.Response.PONG,
-            message_util.RequestType.PING,
-        )
+        assert "127.0.0.1" in daemon._agent_connections
 
     @pytest.mark.asyncio
     async def test_agent_disconnect(
         self,
         daemon: OobleckMasterDaemon,
-        conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-        sample_job: _Job,
+        mocker: MockerFixture,
     ):
-        r, w = conns
-        daemon._job = sample_job
-        daemon._job.agent_info.append(_AgentInfo("127.0.0.1", [1]))
+        close_agent_handler_spy = mocker.spy(daemon, "close_agent")
 
-        daemon.agent_handler = AsyncMock(wraps=daemon.agent_handler)
-        daemon.close_agent = AsyncMock(wraps=daemon.close_agent)
+        agents: list[OobleckAgent] = []
 
-        # Register agent streams (technically same with registering agent)
-        await message_util.send_request_type(w, message_util.RequestType.REGISTER_AGENT)
-        assert await message_util.recv_response(r) == (
-            message_util.Response.SUCCESS,
-            message_util.RequestType.REGISTER_AGENT,
-        )
+        for agent_ip in ["127.0.0.1", "127.0.0.2"]:
+            agent = OobleckAgent()
+            await agent.connect_to_master("localhost", daemon.port)
+            mocker.patch(
+                "asyncio.StreamWriter.get_extra_info", return_value=(agent_ip, 0)
+            )
+            await message_util.send_request_type(
+                agent._conn[1], message_util.RequestType.REGISTER_AGENT
+            )
+            result, _ = await message_util.recv_response(agent._conn[0])
+            assert result == message_util.Response.SUCCESS
+            agents.append(agent)
 
-        # FIXME: currently daemon uses IP for identifier, thus always the first `_AgentInfo``
-        # will be chosen during registration.
-        # For simulating two agents are registered, move streams to the second _AgentInfo.
-        daemon._job.agent_info[1].streams = daemon._job.agent_info[0].streams
-        daemon._job.agent_info[0].streams = None
+        # close the second agent and check if notification goes to the first agent
+        agents[1]._conn[1].close()
+        await agents[1]._conn[1].wait_closed()
 
-        # create another agent
-        r2, w2 = await asyncio.open_connection("localhost", daemon._port)
-        await message_util.send_request_type(
-            w2, message_util.RequestType.REGISTER_AGENT
-        )
-        assert await message_util.recv_response(r2) == (
-            message_util.Response.SUCCESS,
-            message_util.RequestType.REGISTER_AGENT,
-        )
+        await asyncio.sleep(1)
+        close_agent_handler_spy.assert_called_once_with("127.0.0.2")
 
-        second_agent = daemon._job.agent_info[0]
+        # check first agent receives reconfiguration broadcast
+        result, req = await message_util.recv_response(agents[0]._conn[0])
+        assert req == message_util.RequestType.UNDEFINED
+        assert result == message_util.Response.RECONFIGURATION
 
-        # Disconnect an agent
-        w2.close()
-        await w2.wait_closed()
+        # cleanup
+        agents[0]._conn[1].close()
+        await agents[0]._conn[1].wait_closed()
 
-        assert (await message_util.recv_response(r, timeout=None)) == (
-            message_util.Response.RECONFIGURATION,
-            message_util.RequestType.UNDEFINED,
-        )
-        daemon.close_agent.assert_called_once_with(second_agent)
-        assert len(daemon._job.agent_info) == 1
+    # @pytest.mark.asyncio
+    # async def test_ping_fail(
+    #     self,
+    #     daemon: OobleckMasterDaemon,
+    #     conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
+    #     sample_job: DistributedJobConfiguration,
+    # ):
+    #     r, w = conns
+    #     daemon._job = sample_job
+
+    #     # Check agent is not registered
+    #     assert not daemon._job.agent_info[0].streams
+
+    #     await message_util.send_request_type(w, message_util.RequestType.PING)
+
+    #     # Without agent registration, expected to fail
+    #     with pytest.raises(asyncio.IncompleteReadError):
+    #         await message_util.recv_response(r)
+
+    # @pytest.mark.asyncio
+    # async def test_ping(
+    #     self,
+    #     daemon: OobleckMasterDaemon,
+    #     conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
+    #     sample_job: DistributedJobConfiguration,
+    # ):
+    #     r, w = conns
+    #     daemon._job = sample_job
+
+    #     # Register agent then ping
+    #     await message_util.send_request_type(w, message_util.RequestType.REGISTER_AGENT)
+    #     assert (await message_util.recv_response(r)) == (
+    #         message_util.Response.SUCCESS,
+    #         message_util.RequestType.REGISTER_AGENT,
+    #     )
+
+    #     assert daemon._job.agent_info[0].streams
+
+    #     # Reuse the connection
+    #     await message_util.send_request_type(w, message_util.RequestType.PING)
+    #     assert (await message_util.recv_response(r, timeout=10)) == (
+    #         message_util.Response.PONG,
+    #         message_util.RequestType.PING,
+    #     )

--- a/tests/elastic/test_master.py
+++ b/tests/elastic/test_master.py
@@ -64,18 +64,6 @@ class TestOobleckMasterDaemonClass(OobleckElasticTestCase):
         await w.wait_closed()
 
     @pytest.mark.asyncio
-    async def test_request_job_fail(
-        self,
-        client_conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
-    ):
-        r, w = client_conns
-        await message_util.send_request_type(w, message_util.RequestType.LAUNCH_JOB)
-        assert (await message_util.recv_response(r)) == (
-            message_util.Response.FAILURE,
-            message_util.RequestType.LAUNCH_JOB,
-        )
-
-    @pytest.mark.asyncio
     async def test_agent_disconnect(
         self,
         daemon: OobleckMasterDaemon,

--- a/tests/elastic/test_master.py
+++ b/tests/elastic/test_master.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 import oobleck.elastic.message_util as message_util
 from oobleck.elastic.agent import OobleckAgent
 from oobleck.elastic.master import OobleckMasterDaemon
-from oobleck.elastic.training_util import DistributedJobConfiguration
+from oobleck.elastic.training_util import OobleckAgentArguments
 from tests.elastic.conftest import OobleckElasticTestCase
 
 """
@@ -84,10 +84,17 @@ class TestOobleckMasterDaemonClass(OobleckElasticTestCase):
         close_agent_handler_spy = mocker.spy(daemon, "close_agent")
 
         agents: list[OobleckAgent] = []
+        args = OobleckAgentArguments(
+            master_ip=daemon._job.master_ip,
+            master_port=daemon.port,
+            node_ips=daemon._job.node_ips,
+            job_args=daemon._job.job_args,
+            num_workers=self.sample_num_workers,
+        )
 
         for agent_ip in ["127.0.0.1", "127.0.0.2"]:
-            agent = OobleckAgent()
-            await agent.connect_to_master("localhost", daemon.port)
+            agent = OobleckAgent(args)
+            await agent._connect_to_master(args.master_ip, args.master_port)
             mocker.patch(
                 "asyncio.StreamWriter.get_extra_info", return_value=(agent_ip, 0)
             )

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -18,7 +18,7 @@ from pytest_mock import MockerFixture
 
 from oobleck.csrc.planning.pipeline_template import PipelineTemplate
 from oobleck.elastic.message_util import DistributionInfo
-from oobleck.elastic.training_util import TrainingArguments as OobleckArguments
+from oobleck.elastic.training_util import OobleckArguments
 from oobleck.execution.dataloader import LoaderType, OobleckDataLoader, OobleckSampler
 from oobleck.execution.engine import OobleckEngine, ReconfigurationEngine
 from oobleck.execution.pipeline import OobleckPipeline

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -65,14 +65,10 @@ class TestOobleckEngineClass(OobleckElasticTestCase):
     def setup_class(
         cls,
         class_mocker: MockerFixture,
-        pipe: tuple[connection.Connection, connection.Connection],
         model_name_fixture: str,
         tmp_path_factory: pytest.TempPathFactory,
         request: pytest.FixtureRequest,
     ) -> None:
-        # max num GPUs
-        pipe[0].send(4)
-
         directory = tmp_path_factory.getbasetemp()
         request.cls.factory = OobleckStaticClassFactory(model_name_fixture, directory)
 
@@ -113,6 +109,10 @@ class TestOobleckEngineClass(OobleckElasticTestCase):
     ) -> OobleckEngine:
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
         mocker.patch("torch.cuda.device_count", return_value=1)
+
+        # max num GPUs
+        pipe[0].send(4)
+
         engine = OobleckEngine(pipe[1], sample_args)
         yield engine
 

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -24,13 +24,13 @@ from oobleck.execution.engine import OobleckEngine, ReconfigurationEngine
 from oobleck.execution.pipeline import OobleckPipeline
 from tests.conftest import (
     TRAIN_BATCH_SIZE,
-    OobleckElasticTestCase,
     OobleckMultiProcessTestCase,
     OobleckSingleProcessTestCase,
     OobleckStaticClassFactory,
     datasets,
     model_args,
 )
+from tests.elastic.conftest import OobleckElasticTestCase
 
 
 @pytest.fixture(scope="module")
@@ -48,7 +48,6 @@ def sample_args(model_name_fixture: str) -> OobleckArguments:
     )
 
 
-@pytest.mark.skip(reason="asyncio hangs when running multiple tests")
 class TestOobleckEngineClass(OobleckElasticTestCase):
     factory: OobleckStaticClassFactory
 

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -110,10 +110,7 @@ class TestOobleckEngineClass(OobleckElasticTestCase):
         monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
         mocker.patch("torch.cuda.device_count", return_value=1)
 
-        # max num GPUs
-        pipe[0].send(4)
-
-        engine = OobleckEngine(pipe[1], sample_args)
+        engine = OobleckEngine(0, 1, pipe[1], sample_args)
         yield engine
 
     def test_init_engine(self, engine: OobleckEngine):
@@ -285,7 +282,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
         )
         pt_patcher.start()
 
-        engine = OobleckEngine(pipe, arguments)
+        engine = OobleckEngine(0, num_gpus_per_node, pipe, arguments)
         engine.initialize_distributed()
         assert dist.get_rank() < dist.get_world_size()
         assert dist.get_world_size() == 4, "This test must run with 4 GPUs"
@@ -319,8 +316,6 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
         agent_ips: list[str] = ["127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"]
         pipes = [ctx.Pipe(duplex=True) for _ in range(len(agent_ips))]
         for pipe, _ in pipes:
-            # max num GPUs
-            pipe.send(num_gpus_per_node)
             # DistributionInfo
             pipe.send(DistributionInfo(agent_ips, len(agent_ips)))
 
@@ -372,7 +367,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
         )
         pt_patcher.start()
 
-        engine = OobleckEngine(pipe, arguments)
+        engine = OobleckEngine(0, num_gpus_per_node, pipe, arguments)
         engine.initialize_distributed()
         engine.instantiate_pipelines(global_num_microbatch)
 
@@ -407,8 +402,6 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
         agent_ips: list[str] = ["127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"]
         pipes = [ctx.Pipe(duplex=True) for _ in range(len(agent_ips))]
         for pipe, _ in pipes:
-            # max num GPUs
-            pipe.send(num_gpus_per_node)
             # DistributionInfo
             pipe.send(DistributionInfo(agent_ips, len(agent_ips)))
 
@@ -485,7 +478,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
             )
         pt_patcher.start()
 
-        engine = OobleckEngine(pipe, arguments)
+        engine = OobleckEngine(0, num_gpus_per_node, pipe, arguments)
         engine.initialize_distributed()
         engine.instantiate_pipelines(global_num_microbatch)
 
@@ -565,8 +558,6 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
 
         def broadcast_rank0_port():
             for pipe, _ in pipes:
-                # max num GPUs
-                pipe.send(num_gpus_per_node)
                 # DistributionInfo
                 pipe.send(DistributionInfo(agent_ips, len(agent_ips)))
 

--- a/tests/planning/test_profiler.py
+++ b/tests/planning/test_profiler.py
@@ -16,7 +16,7 @@ from oobleck.csrc.planning.pipeline_template import (
     get_profile_results,
 )
 from oobleck.module.model import OobleckModel
-from oobleck.planning.profiler import Profiler, profile
+from oobleck.planning.profiler import Profiler
 from tests.conftest import OobleckMultiProcessTestCase, OobleckSingleProcessTestCase
 
 


### PR DESCRIPTION
This PR provides an interface to users that runs a job thorough OobleckMasterDaemon, OobleckAgent, and worker.

OobleckMasterDaemon: single instance, handle node failure notification via TCP connections with OobleckAgent
OobleckAgent: one per node, handle workers. Maintain a TCP connection with master daemon; when agent dies, this connection is lost and MasterDaemon will notify the disconnection to other agents via the TCP connection.