### PR TITLE
Support hybrid parallelism with FSDP

### DIFF
--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -340,6 +340,13 @@ class DataParallelEngine:
     ):
         self._engine = weakref.ref(engine)
         self._dp_process_groups = dp_process_groups
+        self._fsdp_index = next(
+            i
+            for i, process_group in dp_process_groups[
+                self.engine._pipeline.execution._layers[0].layer_id
+            ].items()
+            if dist.get_rank(process_group) >= 0
+        )
 
     @property
     def engine(self):
@@ -347,8 +354,8 @@ class DataParallelEngine:
 
     def do_allreduce(self):
         for layer in self.engine._pipeline.execution._layers:
-            process_groups_per_layer = self._dp_process_groups[layer.layer_id]
-            layer.reduce_gradients(list(process_groups_per_layer.values()))
+            process_group = self._dp_process_groups[layer.layer_id][self._fsdp_index]
+            layer.reduce_gradients(process_group)
 
 
 class OobleckEngine:

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -255,18 +255,18 @@ class ReconfigurationEngine:
                         param = next(
                             layer
                             for layer in self.engine._pipeline.execution._layers
-                            if layer._layer_id == layer_index
+                            if layer.layer_id == layer_index
                         )._param_handle.flat_param
                         next(
                             layer
                             for layer in new_pipeline.execution._layers
-                            if layer._layer_id == layer_index
+                            if layer.layer_id == layer_index
                         )._param_handle.flat_param.data = param.data
                     else:
                         param = next(
                             layer
                             for layer in new_pipeline.execution._layers
-                            if layer._layer_id == layer_index
+                            if layer.layer_id == layer_index
                         )._param_handle.flat_param
 
                     dist.broadcast(
@@ -347,7 +347,7 @@ class DataParallelEngine:
 
     def do_allreduce(self):
         for layer in self.engine._pipeline.execution._layers:
-            process_groups_per_layer = self._dp_process_groups[layer._layer_id]
+            process_groups_per_layer = self._dp_process_groups[layer.layer_id]
             layer.reduce_gradients(list(process_groups_per_layer.values()))
 
 

--- a/oobleck/execution/layer.py
+++ b/oobleck/execution/layer.py
@@ -269,11 +269,6 @@ class Layer(torch.nn.Module):
         self._param_handle.prepare_gradient_for_optim()
 
         assert torch.distributed.get_rank(process_group) >= 0
-
-        grad = (
-            self._param_handle.flat_param._saved_grad_shard
-            if self._param_handle.uses_sharded_strategy
-            else self._param_handle.flat_param.grad
+        torch.distributed.all_reduce(
+            tensor=self._param_handle.flat_param.grad, group=process_group
         )
-
-        torch.distributed.all_reduce(tensor=grad, group=process_group)

--- a/oobleck/execution/layer.py
+++ b/oobleck/execution/layer.py
@@ -59,7 +59,7 @@ class Layer(torch.nn.Module):
             mp_reduce_dtype=torch.float32,
             keep_low_precision_grads=False,
             process_group=process_group,
-            use_orig_params=False,
+            use_orig_params=True,
         )
         self._param_handle.shard()
         self._param_handle.init_flat_param_attributes()

--- a/oobleck/execution/pipeline.py
+++ b/oobleck/execution/pipeline.py
@@ -116,7 +116,9 @@ class PipelineExecution:
 
         # TODO: use HF arguments to initialize optimizer and LR properly
         self._optimizer = AdamW(
-            [l._param_handle.flat_param for l in layers],
+            itertools.chain.from_iterable(
+                [l._param_handle._fully_sharded_module.parameters() for l in layers]
+            ),
             lr=self._training_args.learning_rate,
             betas=(self._training_args.adam_beta1, self._training_args.adam_beta2),
             eps=self._training_args.adam_epsilon,

--- a/oobleck/execution/pipeline.py
+++ b/oobleck/execution/pipeline.py
@@ -116,9 +116,7 @@ class PipelineExecution:
 
         # TODO: use HF arguments to initialize optimizer and LR properly
         self._optimizer = AdamW(
-            itertools.chain.from_iterable(
-                [l._param_handle._fully_sharded_module.parameters() for l in layers]
-            ),
+            [l._param_handle.flat_param for l in layers],
             lr=self._training_args.learning_rate,
             betas=(self._training_args.adam_beta1, self._training_args.adam_beta2),
             eps=self._training_args.adam_epsilon,

--- a/oobleck/execution/pipeline.py
+++ b/oobleck/execution/pipeline.py
@@ -510,7 +510,7 @@ class OobleckPipeline:
                 existing_layer = next(
                     layer
                     for layer in existing_pipeline.execution._layers
-                    if layer._layer_id == layer_id
+                    if layer.layer_id == layer_id
                 )
                 layers.append(Layer.create_layer_from_layer(existing_layer, pg))
             except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,8 +425,8 @@ class OobleckMultiProcessTestCase:
 
         try:
             for _ in range(len(processes)):
-                result = queue.get(timeout=60)
-                # result = queue.get()
+                # result = queue.get(timeout=60)
+                result = queue.get()
 
                 if "error" in result:
                     # If any process get an error,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -425,8 +425,8 @@ class OobleckMultiProcessTestCase:
 
         try:
             for _ in range(len(processes)):
-                # result = queue.get(timeout=60)
-                result = queue.get()
+                result = queue.get(timeout=120)
+                # result = queue.get()
 
                 if "error" in result:
                     # If any process get an error,

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -535,7 +535,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
                     layer = next(
                         layer
                         for layer in engine._pipeline.execution._layers
-                        if layer._layer_id == layer_id
+                        if layer.layer_id == layer_id
                     )
                     assert layer._param_handle.flat_param is not None
                     assert layer._param_handle.world_size == len(ranks_per_layer)
@@ -544,7 +544,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
                         next(
                             layer
                             for layer in engine._pipeline.execution._layers
-                            if layer._layer_id == layer_id
+                            if layer.layer_id == layer_id
                         )
         else:
             # We only have one pipeline and lose one node.

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -15,6 +15,7 @@ import pytest
 import torch._C._distributed_c10d as c10d
 import torch.distributed
 from pytest_mock import MockerFixture
+from torch.distributed.fsdp.flat_param import HandleShardingStrategy
 
 from oobleck.csrc.planning.pipeline_template import PipelineTemplate
 from oobleck.elastic.message_util import DistributionInfo
@@ -44,7 +45,7 @@ def sample_args(model_name_fixture: str) -> OobleckArguments:
         fault_threshold=1,
         model_args=model_args[model_name_fixture],
         microbatch_size=TRAIN_BATCH_SIZE,
-        global_microbatch_size=16 * TRAIN_BATCH_SIZE,
+        global_microbatch_size=4 * TRAIN_BATCH_SIZE,
     )
 
 
@@ -423,6 +424,99 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
             num_gpus_per_node,
             [p[1] for p in pipes],
             agent_ips,
+            sample_args,
+        )
+        thread.join()
+
+    @staticmethod
+    def _run_fsdp_allreduce(
+        factory: OobleckStaticClassFactory,
+        rank: int,
+        num_stages: int,
+        num_nodes: int,
+        pipe: list[connection.Connection],
+        my_ip: str,
+        arguments: OobleckArguments,
+    ):
+        # Assume all GPUs are in one GPUs
+        num_gpus_per_node = 4
+        num_nodes_per_pipeline = 1
+        pipe = pipe[rank]
+        global_num_microbatch = (
+            arguments.global_microbatch_size // arguments.microbatch_size
+        )
+
+        socket_patcher = patch("socket.gethostbyname", return_value=my_ip)
+        socket_patcher.start()
+        pt_patcher = patch(
+            "oobleck.execution.engine.PipelineTemplateGenerator.create_pipeline_templates",
+            return_value=[
+                factory.get_dummy_pipeline_template(
+                    num_stages=num_stages,
+                    num_gpus_per_node=num_gpus_per_node,
+                    num_nodes=num_nodes_per_pipeline,
+                )
+            ],
+        )
+        pt_patcher.start()
+
+        engine = OobleckEngine(rank, num_nodes, num_gpus_per_node, pipe, arguments)
+        engine.initialize_distributed()
+        engine.instantiate_pipelines(global_num_microbatch)
+
+        # Check only one pipelines are instantiated
+        assert len(engine._reconfiguration._pipelines) == 1
+
+        # Check all 4 GPUs are used
+        assert len(engine._pipeline._ranks) == 4
+
+        # Check FSDP is used
+        for layer in engine._pipeline.execution._layers:
+            if num_stages == 4:
+                assert (
+                    layer._param_handle._sharding_strategy
+                    == HandleShardingStrategy.NO_SHARD
+                )
+                assert layer._group_size == 1
+            else:
+                assert (
+                    layer._param_handle._sharding_strategy
+                    == HandleShardingStrategy.FULL_SHARD
+                )
+                assert layer._group_size == 4 // num_stages
+
+        with torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ]
+        ) as prof:
+            engine._train_step()
+
+        prof.export_chrome_trace(f"/tmp/rank{rank}.json")
+
+        torch.cuda.synchronize()
+        print(f"Rank {rank} finished training step")
+
+    def test_fsdp_engine_train(self, num_stages: int, sample_args: OobleckArguments):
+        ctx = multiprocessing.get_context("spawn")
+        agent_ip: str = "127.0.0.1"
+        pipes = [ctx.Pipe(duplex=True) for _ in range(4)]
+        for pipe, _ in pipes:
+            # DistributionInfo
+            pipe.send(DistributionInfo([agent_ip], 4))
+
+        thread = threading.Thread(target=self.broadcast_rank0_port, args=(pipes,))
+        thread.start()
+
+        num_gpus_per_node = 4 // num_stages
+        self.run_in_parallel(
+            4,
+            self._run_fsdp_allreduce,
+            num_stages,
+            4,
+            [p[1] for p in pipes],
+            agent_ip,
             sample_args,
         )
         thread.join()

--- a/tests/execution/test_layer.py
+++ b/tests/execution/test_layer.py
@@ -225,6 +225,8 @@ class TestShardedLayer(OobleckMultiProcessTestCase):
                 == layer._param_handle.flat_param._saved_grad_shard.shape
             )
 
+            layer.remove_post_backward_hooks()
+
     @staticmethod
     def step(
         factory: OobleckStaticClassFactory,

--- a/tests/execution/test_pipeline.py
+++ b/tests/execution/test_pipeline.py
@@ -124,7 +124,11 @@ class TestSingleStagePipeline(OobleckMultiProcessTestCase):
         # If FSDP is used, some too small tensors might be only on rank 0,
         # thus pass if size is 0.
         assert all(
-            layer._param_handle.flat_param.grad is not None
+            (
+                param.grad is not None
+                for param in layer.parameters()
+                if param.requires_grad
+            )
             for layer in pipeline.execution._layers
         )
 


### PR DESCRIPTION
This PR integrates `torch.distributed.FullyShardedDataParallel` into hybrid data parallel + pipeline parallel execution.
PyTorch FSDP implementation is incompatible to pipeline execution, heavily relying on state transition, thus use a little lower framework `torch.distributed.fsdp.flat_param.FlatParamHandle` to implement it.

For high throughput, it interleaves `torch.distributed.all_gather` and `torch.distributed.reduce_scatter` with computation using separate `torch.cuda.Stream()`s and synchronization at the same time to ensure data data dependency so that (un)sharding will not happen during execution.