### PR TITLE
Minimum required number of nodes for large model pipeline templates

### DIFF
--- a/oobleck/csrc/planning/pipeline_template.cpp
+++ b/oobleck/csrc/planning/pipeline_template.cpp
@@ -33,7 +33,11 @@ std::shared_ptr<LayerExecutionResults> get_profile_results(
   auto get_cache = [](const std::string& cache_path) -> nlohmann::json {
     std::ifstream ifs(cache_path);
     assert(ifs.is_open());
-    return nlohmann::json::parse(ifs);
+    try {
+      return nlohmann::json::parse(ifs);
+    } catch (std::exception& e) {
+      throw pybind11::value_error("Error parsing json file: " + cache_path);
+    }
   };
 
   std::string profile_path =

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import asyncio
 import copy
 import multiprocessing
+import re
 import socket
 import threading
 import traceback
+from contextlib import nullcontext
+from dataclasses import dataclass
 from multiprocessing import connection
 from pathlib import Path
 from unittest.mock import patch
@@ -17,6 +20,10 @@ import torch.distributed
 from pytest_mock import MockerFixture
 from torch.distributed.fsdp.flat_param import HandleShardingStrategy
 
+from oobleck.csrc.planning.pipeline_template import (
+    LayerExecutionResult,
+    LayerExecutionResults,
+)
 from oobleck.elastic.message_util import DistributionInfo
 from oobleck.elastic.training_util import OobleckArguments
 from oobleck.execution.dataloader import OobleckSampler
@@ -25,9 +32,141 @@ from oobleck.execution.pipeline import OobleckPipeline
 from tests.conftest import (
     TRAIN_BATCH_SIZE,
     OobleckMultiProcessTestCase,
+    OobleckSingleProcessTestCase,
     OobleckStaticClassFactory,
 )
 from tests.elastic.conftest import OobleckElasticTestCase
+
+
+class TestOobleckNumNodeComputationClass(OobleckSingleProcessTestCase):
+    """
+    Number of nodes calculation test
+    Calculating minimum required number of nodes is based on
+    profile results and device memory capacity.
+    """
+
+    factory: OobleckStaticClassFactory
+
+    def get_fake_profile_results(self, num_layers: int) -> LayerExecutionResults:
+        results: list[LayerExecutionResult] = []
+        for index in range(num_layers):
+            results.append(
+                LayerExecutionResult(
+                    layer_index=index,
+                    forward=0.1,
+                    backward=0.1,
+                    allreduce_in_node={i + 1: 0.1 for i in range(8)},
+                    allreduce_across_nodes={i + 1: 0.1 for i in range(64)},
+                    mem_required=(1024, 0),
+                )
+            )
+        return LayerExecutionResults(results)
+
+    @pytest.fixture(scope="class")
+    def pipe(self) -> tuple[connection.Connection, connection.Connection]:
+        p1: connection.Connection
+        p2: connection.Connection
+        p1, p2 = multiprocessing.Pipe()
+        yield p1, p2
+        p1.close()
+        p2.close()
+
+    @dataclass
+    class FakeDeviceProperties:
+        total_memory: int
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup_class(
+        cls,
+        class_mocker: MockerFixture,
+        model_name_fixture: str,
+        tmp_path_factory: pytest.TempPathFactory,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        directory = tmp_path_factory.getbasetemp()
+        request.cls.factory = OobleckStaticClassFactory(model_name_fixture, directory)
+
+        class_mocker.patch(
+            "oobleck.execution.engine.OobleckDataset",
+            return_value=cls.factory.get_dataset(),
+        )
+        class_mocker.patch(
+            "oobleck.execution.engine.OobleckModel",
+            return_value=cls.factory.get_model(),
+        )
+
+        class_mocker.patch("torch.cuda.device_count", return_value=1)
+
+        # This class does not mock get_pipeline_templates
+
+    @pytest.fixture(autouse=True)
+    def setup(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+
+    @pytest.mark.parametrize(
+        [
+            "num_nodes",
+            "num_gpus_per_node",
+            "gpu_mem",
+            "num_layers",
+            "expected_min_num_nodes",
+            "expect_fail",
+        ],
+        [
+            (1, 1, 1024 * 32 * 6, 32, 1, False),
+            (1, 1, 1024 * 32 * 6, 64, 2, True),
+            (1, 1, 1024 * 128 * 6, 64, 1, False),
+            (4, 1, 1024 * 32 * 6, 64, 2, False),
+            (4, 1, 1024 * 16 * 6, 64, 4, False),
+            (4, 1, 1024 * 16 * 6, 128, 8, True),
+            (1, 4, 1024 * 16 * 6, 128, 2, True),
+            (1, 4, 1024 * 32 * 6, 128, 1, False),
+            (4, 4, 1024 * 16 * 6, 128, 2, False),
+            (4, 4, 1024 * 1 * 6, 32, 8, True),
+        ],
+    )
+    def test_multi_nodes_template_configuration(
+        self,
+        pipe: tuple[connection.Connection, connection.Connection],
+        sample_args: OobleckArguments,
+        num_nodes: int,
+        num_gpus_per_node: int,
+        gpu_mem: int,
+        num_layers: int,
+        expected_min_num_nodes: int,
+        expect_fail: bool,
+        mocker: MockerFixture,
+    ):
+        fake_profile = self.get_fake_profile_results(num_layers)
+
+        # Fake device memory capacity so that number of nodes match with our simulated ones
+        mocker.patch(
+            "torch.cuda.get_device_properties",
+            return_value=TestOobleckNumNodeComputationClass.FakeDeviceProperties(
+                gpu_mem
+            ),
+        )
+        mocker.patch(
+            "oobleck.execution.engine.get_profile_results",
+            return_value=fake_profile,
+        )
+        pt_create_mock = mocker.patch(
+            "oobleck.csrc.planning.pipeline_template.PipelineTemplateGenerator.create_pipeline_templates",
+            return_value=None,
+        )
+
+        if expect_fail:
+            with pytest.raises(AssertionError) as e:
+                OobleckEngine(0, num_nodes, num_gpus_per_node, pipe[1], sample_args)
+
+            assert e.value.args[0].startswith("Minimum required number of nodes")
+            match = re.search(r"minimum required: (\d+),", e.value.args[0])
+            assert int(match[1]) == expected_min_num_nodes
+        else:
+            OobleckEngine(0, num_nodes, num_gpus_per_node, pipe[1], sample_args)
+            pt_create_mock.assert_called_once_with(
+                fake_profile, (expected_min_num_nodes, num_nodes), num_gpus_per_node
+            )
 
 
 class TestOobleckEngineClass(OobleckElasticTestCase):


### PR DESCRIPTION
For simplicity, the refactored code was using `min_num_nodes=1` for creating pipeline templates, which fails to train for large models.
This PR enables calculating the minimum required number of nodes to train large model and using it in creating pipeline templates.