### PR TITLE
FSDP layer-wise gradient allreduce

### DIFF
--- a/oobleck/csrc/planning/pipeline_template.cpp
+++ b/oobleck/csrc/planning/pipeline_template.cpp
@@ -235,6 +235,10 @@ PipelineTemplateGenerator::divide_and_conquer(
       // Split GPUs in a node
       for (int num_gpus_left :
            std::ranges::iota_view<int, int>(1, num_gpus_per_node)) {
+        if (num_gpus_left != num_gpus_per_node - num_gpus_left) {
+          continue;
+        }
+
         for (int num_stages_left :
              std::ranges::iota_view<int, int>(1, num_stages)) {
           std::shared_ptr<DCExecutionResult> result_left(nullptr);

--- a/oobleck/csrc/planning/pipeline_template.h
+++ b/oobleck/csrc/planning/pipeline_template.h
@@ -75,7 +75,7 @@ class PipelineTemplate {
 
       // push per-layer ranks to the result
       for (const int layer_index : stage->layer_indices_) {
-        rank_grid[layer_index] = stage_ranks;
+        rank_grid[layer_index] = layer_ranks;
       }
     }
 

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -404,7 +404,7 @@ class DataParallelEngine:
             process_groups = {
                 fsdp_index: pg
                 for fsdp_index, pg in self._dp_process_groups[layer.layer_id].items()
-                if pg.rank() >= 0
+                if torch.distributed.get_rank(pg) >= 0
             }
             if process_groups:
                 layer.reduce_gradients(process_groups)

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -213,7 +213,6 @@ class ReconfigurationEngine:
         (
             new_pipeline,
             pipelines,
-            process_groups_dp,
         ) = execution_plan.instantiate(
             model=self.engine._model,
             dataloader=new_dataloader,
@@ -228,7 +227,7 @@ class ReconfigurationEngine:
             pipeline.initialize_distributed_pipeline()
         new_pipeline.initialize_execution(self.engine._model, self.engine._pipeline)
 
-        self.engine._dp_engine = DataParallelEngine(self.engine, process_groups_dp)
+        self.engine._dp_engine = DataParallelEngine(self.engine, pipelines)
         self._pipelines = pipelines
 
         return new_pipeline

--- a/oobleck/execution/layer.py
+++ b/oobleck/execution/layer.py
@@ -258,7 +258,7 @@ class Layer(torch.nn.Module):
             torch.autograd.backward(output, gradients)
 
     def _shard_param(self, tensor: torch.Tensor, number: int) -> list[torch.Tensor]:
-        chunks = torch.flatten(tensor).chunk(number)
+        chunks = list(torch.flatten(tensor).chunk(number))
         if len(chunks) < number:
             chunks = chunks + [torch.zeros_like(chunks[0])] * (number - len(chunks))
 

--- a/oobleck/execution/layer.py
+++ b/oobleck/execution/layer.py
@@ -47,6 +47,8 @@ class Layer(torch.nn.Module):
         assert torch.distributed.get_rank(process_group) >= 0
 
         layer = cls.__new__(cls)
+        super(Layer, cls).__init__(layer)
+
         layer.layer_id = existing_layer.layer_id
         layer._rank_index = torch.distributed.get_rank(process_group)
         layer._group_size = torch.distributed.get_world_size(process_group)

--- a/oobleck/execution/pipeline.py
+++ b/oobleck/execution/pipeline.py
@@ -504,17 +504,22 @@ class OobleckPipeline:
                 continue
 
             shard_id = id
-            if existing_pipeline is None:
-                layers.append(
-                    Layer(layer_id, model.layers[layer_id], pg, pre_stream, post_stream)
-                )
-            else:
+            if existing_pipeline is not None:
                 existing_layer = next(
-                    layer
-                    for layer in existing_pipeline.execution._layers
-                    if layer.layer_id == layer_id
+                    (
+                        layer
+                        for layer in existing_pipeline.execution._layers
+                        if layer.layer_id == layer_id
+                    ),
+                    None,
                 )
-                layers.append(Layer.create_layer_from_layer(existing_layer, pg))
+                if existing_layer is not None:
+                    layers.append(Layer.create_layer_from_layer(existing_layer, pg))
+                    continue
+
+            layers.append(
+                Layer(layer_id, model.layers[layer_id], pg, pre_stream, post_stream)
+            )
 
         self.execution = PipelineExecution(
             pipeline=self,

--- a/oobleck/execution/pipeline.py
+++ b/oobleck/execution/pipeline.py
@@ -504,17 +504,17 @@ class OobleckPipeline:
                 continue
 
             shard_id = id
-            try:
+            if existing_pipeline is None:
+                layers.append(
+                    Layer(layer_id, model.layers[layer_id], pg, pre_stream, post_stream)
+                )
+            else:
                 existing_layer = next(
                     layer
                     for layer in existing_pipeline.execution._layers
                     if layer.layer_id == layer_id
                 )
                 layers.append(Layer.create_layer_from_layer(existing_layer, pg))
-            except Exception:
-                layers.append(
-                    Layer(layer_id, model.layers[layer_id], pg, pre_stream, post_stream)
-                )
 
         self.execution = PipelineExecution(
             pipeline=self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -450,8 +450,8 @@ class OobleckMultiProcessTestCase:
 
         try:
             for _ in range(len(processes)):
-                # result = queue.get(timeout=120)
-                result = queue.get()
+                result = queue.get(timeout=120)
+                # result = queue.get()
 
                 if "error" in result:
                     # If any process get an error,

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -984,7 +984,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
                     for layer_index, ranks in pipeline.rank_grid.items():
                         # This test didn't use FSDP
                         assert len(ranks) == 1
-                        assert ranks[0] == 0
+                        assert ranks[0] in [0, 2]
                 else:
                     for layer_index, ranks in pipeline.rank_grid.items():
                         # This test didn't use FSDP

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -126,7 +126,9 @@ class TestOobleckDataParallelEngineClass(OobleckSingleProcessTestCase):
                 params, process_groups.items()
             ):
                 assert my_rank in process_group.ranks
-                allreduce_called[(my_rank, fsdp_index)].append(param.size())
+                allreduce_called[(tuple(process_group.ranks), fsdp_index)].append(
+                    param.size()
+                )
 
     @pytest.mark.parametrize(
         [
@@ -143,16 +145,80 @@ class TestOobleckDataParallelEngineClass(OobleckSingleProcessTestCase):
                 [1, 1],
                 [2, 2],
                 [
-                    [(0, 0), (4, 0)],
-                    [(0, 1), (5, 1)],
-                    [(1, 2), (6, 2)],
-                    [(1, 3), (7, 3)],
-                    [(2, 0), (8, 0)],
-                    [(2, 1), (9, 1)],
-                    [(3, 2), (10, 2)],
-                    [(3, 3), (11, 3)],
+                    [((0, 4), 0)],
+                    [((0, 5), 1)],
+                    [((1, 6), 2)],
+                    [((1, 7), 3)],
+                    [((2, 8), 0)],
+                    [((2, 9), 1)],
+                    [((3, 10), 2)],
+                    [((3, 11), 3)],
                 ],
-            )
+            ),
+            (
+                4,
+                [3],
+                [2],
+                [4],
+                [
+                    [((0, 12), 0)],
+                    [((0, 12), 1)],
+                    [((1, 13), 2)],
+                    [((1, 13), 3)],
+                    [((2, 14), 0)],
+                    [((2, 14), 1)],
+                    [((3, 15), 2)],
+                    [((3, 15), 3)],
+                    [((4, 16), 0)],
+                    [((5, 17), 1)],
+                    [((6, 18), 2)],
+                    [((7, 19), 3)],
+                    [((8, 20), 0)],
+                    [((9, 21), 1)],
+                    [((10, 22), 2)],
+                    [((11, 23), 3)],
+                ],
+            ),
+            (
+                4,
+                [3, 5],
+                [2, 1],
+                [4, 5],
+                [
+                    [((0, 12, 24), 0)],
+                    [((0, 12, 25), 1)],
+                    [((1, 13, 26), 2)],
+                    [((1, 13, 27), 3)],
+                    [((0, 12, 28), 0)],
+                    [((0, 12, 29), 1)],
+                    [((1, 13, 30), 2)],
+                    [((1, 13, 31), 3)],
+                    [((2, 14, 28), 0)],
+                    [((2, 14, 29), 1)],
+                    [((3, 15, 30), 2)],
+                    [((3, 15, 31), 3)],
+                    [((2, 14, 32), 0)],
+                    [((2, 14, 33), 1)],
+                    [((3, 15, 34), 2)],
+                    [((3, 15, 35), 3)],
+                    [((4, 16, 32), 0)],
+                    [((5, 17, 33), 1)],
+                    [((6, 18, 34), 2)],
+                    [((7, 19, 35), 3)],
+                    [((4, 16, 36), 0)],
+                    [((5, 17, 37), 1)],
+                    [((6, 18, 38), 2)],
+                    [((7, 19, 39), 3)],
+                    [((8, 20, 36), 0)],
+                    [((9, 21, 37), 1)],
+                    [((10, 22, 38), 2)],
+                    [((11, 23, 39), 3)],
+                    [((8, 20, 40), 0)],
+                    [((9, 21, 41), 1)],
+                    [((10, 22, 42), 2)],
+                    [((11, 23, 43), 3)],
+                ],
+            ),
         ],
     )
     def test_data_parallel_groups(
@@ -224,11 +290,12 @@ class TestOobleckDataParallelEngineClass(OobleckSingleProcessTestCase):
             dp_engine.do_allreduce()
 
         global allreduce_called
-        # TODO: check allreduce_called to see if allreduce is called correctly
         for dp_rank_sets in expected_dp_ranks:
             for rank, fsdp_index in dp_rank_sets:
                 key = (rank, fsdp_index)
+                # this rank should have called allreduce
                 assert key in allreduce_called
+                # all ranks in the dp should call allreduces for the same size of tensors in the same order
                 assert allreduce_called[dp_rank_sets[0]] == allreduce_called[key]
 
 


### PR DESCRIPTION
Enable layer-wise allreduce gradient when FSDP is enabled.
In Oobleck heterogeneous pipeline execution, heterogeneous pipeline may have different layer distribution, thus all-reduce should happen in layer-wise. Plus, even the same layer may have be sharded in a different way (to 2 GPUs for a pipeline + 4 GPUs for another one), all-reduce should carefully consider such sharding.
`tests/execution/test_engine.py::TestOobleckDataParallelEngineClass` is implemented to test all-reduce in such heterogeneous data parallel execution.