### PR TITLE
Bugfix for multinode job launch

### DIFF
--- a/examples/gpt3.yaml
+++ b/examples/gpt3.yaml
@@ -1,15 +1,22 @@
 # python -m oobleck.run --config_path examples/gpt2.yaml --node_ips [agent_ips] --master_ip ip --master_port port
 
+dist:
+  num_agents_per_node: 1
+  num_workers: 1
+
 job:
   fault_threshold: 3
-  microbatch_size: 8
+  microbatch_size: 2
   global_microbatch_size: 128
   steps: 30
 
 model:
   model_name: gpt2 # Must use model name gpt2
-  model_tag: 2.7b
+  model_tag: gpt2-xl
   dataset_path: wikitext
   dataset_name: wikitext-2-raw-v1
-  num_hidden_layers: 24
-  hidden_size: 2048
+  model_args:
+    n_positions: 1024
+    num_hidden_layers: 48
+    n_embd: 1600
+    n_head: 25

--- a/examples/gpt3.yaml
+++ b/examples/gpt3.yaml
@@ -7,7 +7,9 @@ job:
   steps: 30
 
 model:
-  model_name: gpt2
-  model_tag: medium
+  model_name: gpt2 # Must use model name gpt2
+  model_tag: 2.7b
   dataset_path: wikitext
   dataset_name: wikitext-2-raw-v1
+  num_hidden_layers: 24
+  hidden_size: 2048

--- a/oobleck/csrc/planning/execution_result.h
+++ b/oobleck/csrc/planning/execution_result.h
@@ -79,8 +79,8 @@ class StageExecutionResult
       backward_ += layer.backward_ / num_gpus_;
 
       if (num_gpus_ > 1) {
-        forward_ += layer.allreduce_in_node_.at(num_gpus_ - 1);
-        backward_ += layer.allreduce_in_node_.at(num_gpus_ - 1);
+        forward_ += layer.allreduce_in_node_.at(num_gpus_);
+        backward_ += layer.allreduce_in_node_.at(num_gpus_);
       }
 
       for (const auto& it : layer.allreduce_across_nodes_) {

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -13,7 +13,7 @@ import oobleck.elastic.message_util as message_util
 from oobleck.csrc.planning.pipeline_template import get_profile_results
 from oobleck.elastic.training_util import OobleckArguments
 from oobleck.elastic.worker import worker_main
-from oobleck.planning.profiler import profile
+from oobleck.planning.profiler import profile, validate_model_args
 
 logger = LoggerFactory.create_logger("oobleck_agent")
 
@@ -109,8 +109,6 @@ class OobleckAgent:
             process.join()
 
     async def _launch_workers(self, args: OobleckArguments):
-        logger.info(f"Job arguments: {args}")
-
         # Test if profile data exists
         try:
             get_profile_results(
@@ -118,6 +116,12 @@ class OobleckAgent:
                 args.model.model_tag,
                 args.job.microbatch_size,
             )
+
+            assert validate_model_args(args), (
+                "Model arguments are inconsistent: "
+                f"{args.model.model_args} != model_args.json."
+            )
+            logger.info(f"Job arguments: {args}")
         except Exception:
             # Run profiler
             logger.warning(

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -117,10 +117,13 @@ class OobleckAgent:
                 args.job.microbatch_size,
             )
 
-            assert validate_model_args(args), (
-                "Model arguments are inconsistent: "
-                f"{args.model.model_args} != model_args.json."
-            )
+            if not validate_model_args(args):
+                logger.warning(
+                    "Model arguments are inconsistent: "
+                    f"{args.model.model_args} != model_args.json."
+                )
+                raise RuntimeError("Model arguments are inconsistent")
+
             logger.info(f"Job arguments: {args}")
         except Exception:
             # Run profiler

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -11,12 +11,7 @@ from deepspeed.utils.logging import LoggerFactory
 
 import oobleck.elastic.message_util as message_util
 from oobleck.csrc.planning.pipeline_template import get_profile_results
-from oobleck.elastic.training_util import (
-    DistributedArguments,
-    JobArguments,
-    ModelArguments,
-    OobleckArguments,
-)
+from oobleck.elastic.training_util import OobleckArguments
 from oobleck.elastic.worker import worker_main
 from oobleck.planning.profiler import profile
 

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -121,8 +121,8 @@ class OobleckAgent:
                 target=worker_main,
                 args=(
                     index,
-                    len(self._args.node_ips) * num_workers,
-                    1,
+                    len(self._args.node_ips),
+                    num_workers,
                     child_pipe,
                     args,
                 ),

--- a/oobleck/elastic/master.py
+++ b/oobleck/elastic/master.py
@@ -82,7 +82,7 @@ class OobleckMasterDaemon:
                 num_workers=1,
             )
             cmd += " ".join(
-                [f"--{k}={v}" for k, v in flatten_configurations(agent_args).items()]
+                [f"--{k} {v}" for k, v in flatten_configurations(agent_args).items()]
             )
             cmd += '"'
             logger.info(f"Launching an agent on {node_ip}: {cmd}")
@@ -278,9 +278,11 @@ async def main(ip: str | None, port: int):
 
 if __name__ == "__main__":
     parser = simple_parsing.ArgumentParser()
-    parser.add_argument("--ip", type=Optional[str], default=None)
+    parser.add_argument("--ip", type=str, default="")
     parser.add_argument("--port", type=int, default=0)
 
     args = parser.parse_args()
+    if not args.ip:
+        args.ip = "127.0.0.1"
 
     asyncio.run(main(args.ip, args.port))

--- a/oobleck/elastic/master.py
+++ b/oobleck/elastic/master.py
@@ -79,7 +79,7 @@ class OobleckMasterDaemon:
                 master_port=self._port,
                 node_ips=job_config.node_ips,
                 job_args=job_config.job_args,
-                num_workers=1,
+                num_workers=4,
             )
             cmd += " ".join(
                 [f"--{k} {v}" for k, v in flatten_configurations(agent_args).items()]

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -1,65 +1,53 @@
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import dataclass, fields, is_dataclass
 
 from simple_parsing import Serializable
 
 
 @dataclass
-class OobleckArguments(Serializable):
-    """Data class that contains information about the training job.
-    OobleckAgent -> OobleckEngine
-    """
+class DistributedArguments(Serializable):
+    master_ip: str
+    master_port: int
+    node_ips: list[str]
+    node_port: int = 22
+    num_workers: int = 0
+    num_agents_per_node: int = 1
+    username: str | None = None
+
+
+@dataclass
+class JobArguments(Serializable):
+    fault_threshold: int = 3
+    microbatch_size: int = 1
+    global_microbatch_size: int = 128
+    steps: int = 50
+
+
+@dataclass
+class ModelArguments(Serializable):
+    def __init__(
+        self,
+        model_name: str,
+        model_tag: str,
+        dataset_path: str,
+        dataset_name: str | None = None,
+        **kwargs,
+    ):
+        self.model_name = model_name
+        self.model_tag = model_tag
+        self.dataset_path = dataset_path
+        self.dataset_name = dataset_name
+        for key, value in kwargs.items():
+            setattr(self, key, value)
 
     model_name: str
     model_tag: str
     dataset_path: str
     dataset_name: str | None = None
-    fault_threshold: int = 3
-    microbatch_size: int = 1
-    global_microbatch_size: int = 128
-    model_args: dict[str, any] | None = None
-    steps: int = 50
+    # Other arbitrary model configuration can be here..
 
 
 @dataclass
-class OobleckAgentArguments(Serializable):
-    """Data class that contains information about the training job.
-    OobleckMasterDaemon -> OobleckAgent
-    """
-
-    master_ip: str
-    master_port: int
-    node_ips: list[str]
-    job_args: OobleckArguments
-    num_workers: int
-
-
-@dataclass
-class DistributedJobConfiguration(Serializable):
-    """Data class that contains information about distributed training.
-    run.py -> OobleckMasterDaemon
-    """
-
-    master_ip: str
-    master_port: int
-    node_ips: list[str]
-    job_args: OobleckArguments
-    node_port: int = 22
-    username: str | None = None
-
-
-def flatten_configurations(
-    dataclass: OobleckAgentArguments | DistributedJobConfiguration,
-) -> dict:
-    """Flatten the configuration dataclass into a dict."""
-    result = {}
-    for k, v in asdict(dataclass).items():
-        if is_dataclass(v):
-            result.update(flatten_configurations(v))
-        elif isinstance(v, dict):
-            v = {k: v for k, v in v.items() if v is not None}
-            result.update(v)
-        elif isinstance(v, list):
-            result[k] = " ".join(v)
-        else:
-            result[k] = v
-    return result
+class OobleckArguments(Serializable):
+    dist: DistributedArguments
+    job: JobArguments
+    model: ModelArguments

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, field
+from typing import Any
 
 from simple_parsing import Serializable
 
@@ -43,7 +44,7 @@ class ModelArguments(Serializable):
     model_tag: str
     dataset_path: str
     dataset_name: str | None = None
-    # Other arbitrary model configuration can be here..
+    model_args: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -59,7 +59,7 @@ def flatten_configurations(
             v = {k: v for k, v in v.items() if v is not None}
             result.update(v)
         elif isinstance(v, list):
-            result[k] = ",".join(v)
+            result[k] = " ".join(v)
         else:
             result[k] = v
     return result

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -9,7 +9,7 @@ class DistributedArguments(Serializable):
     master_port: int
     node_ips: list[str]
     node_port: int = 22
-    num_workers: int = 0
+    num_workers: int = 1
     num_agents_per_node: int = 1
     username: str | None = None
 

--- a/oobleck/elastic/training_util.py
+++ b/oobleck/elastic/training_util.py
@@ -25,21 +25,6 @@ class JobArguments(Serializable):
 
 @dataclass
 class ModelArguments(Serializable):
-    def __init__(
-        self,
-        model_name: str,
-        model_tag: str,
-        dataset_path: str,
-        dataset_name: str | None = None,
-        **kwargs,
-    ):
-        self.model_name = model_name
-        self.model_tag = model_tag
-        self.dataset_path = dataset_path
-        self.dataset_name = dataset_name
-        for key, value in kwargs.items():
-            setattr(self, key, value)
-
     model_name: str
     model_tag: str
     dataset_path: str

--- a/oobleck/elastic/worker.py
+++ b/oobleck/elastic/worker.py
@@ -24,10 +24,10 @@ def worker_main(
     logger.info("Initializing torch.distributed...")
     engine.initialize_distributed()
 
-    if args.global_microbatch_size % args.microbatch_size != 0:
+    if args.job.global_microbatch_size % args.job.microbatch_size != 0:
         raise ValueError("global_microbatch_size must be divisible by microbatch_size")
 
-    global_num_microbatch = args.global_microbatch_size // args.microbatch_size
+    global_num_microbatch = args.job.global_microbatch_size // args.job.microbatch_size
     logger.info("Instantiating pipelines...")
     engine.instantiate_pipelines(global_num_microbatch)
     logger.info("Begin training...")

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -6,6 +6,7 @@ import socket
 import threading
 import weakref
 from collections import defaultdict
+from dataclasses import asdict
 from multiprocessing import connection
 
 import deepspeed.comm as dist
@@ -427,12 +428,12 @@ class OobleckEngine:
         self._agent_pipe: connection.Connection = pipe
         self._args: OobleckArguments = args
         training_args = {
-            "output_dir": f"/tmp/oobleck/output/{args.model_name}-{args.model_tag}",
-            "per_device_train_batch_size": args.microbatch_size,
+            "output_dir": f"/tmp/oobleck/output/{args.model.model_name}-{args.model.model_tag}",
+            "per_device_train_batch_size": args.job.microbatch_size,
             "no_cuda": True,  # don't use cuda in HFTrainingArguments
             "log_level": "error",  # omit warning messages from HFTrainingArguments
             # do not set gradient_accumulation_steps in HFTrainingArguments
-            "max_steps": args.steps,
+            "max_steps": args.job.steps,
         }
         self._hf_training_args: HFTrainingArguments = HFTrainingArguments(
             **training_args
@@ -462,25 +463,25 @@ class OobleckEngine:
         list[PipelineTemplate],
     ]:
         dataset = OobleckDataset(
-            self._args.model_name,
-            self._args.dataset_path,
-            self._args.dataset_name,
-            self._args.model_args["n_positions"]
-            if self._args.model_args and "n_positions" in self._args.model_args
+            self._args.model.model_name,
+            self._args.model.dataset_path,
+            self._args.model.dataset_name,
+            self._args.model.n_positions
+            if hasattr(self._args.model, "n_positions")
             else None,
         )
 
         model = OobleckModel(
-            self._args.model_name,
+            self._args.model.model_name,
             dataset.sample,
             self._hf_training_args,
-            self._args.model_tag,
-            self._args.model_args,
+            self._args.model.model_tag,
+            asdict(self._args.model),
         )
 
         profile_results: LayerExecutionResults = get_profile_results(
-            self._args.model_name,
-            self._args.model_tag,
+            self._args.model.model_name,
+            self._args.model.model_tag,
             self._hf_training_args.per_device_train_batch_size,
         )
 

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -547,7 +547,9 @@ class OobleckEngine:
         dist_info = self._dist_info
 
         my_ip: str = socket.gethostbyname(socket.gethostname())
-        assert my_ip in dist_info.agent_ips, "My IP is not in dist info."
+        assert (
+            my_ip in dist_info.agent_ips
+        ), f"My IP {my_ip} is not in dist info {dist_info.agent_ips}."
 
         self._num_nodes = len(dist_info.agent_ips)
         self._world_size = dist_info.world_size
@@ -644,5 +646,9 @@ class OobleckEngine:
         assert self._hf_training_args.max_steps > 0
 
         for step in range(self._hf_training_args.max_steps):
-            logger.info(f"Step {step}")
-            self._train_step()
+            try:
+                logger.info(f"Step {step}")
+                self._train_step()
+            except StopIteration:
+                logger.info("Epoch is done.")
+                self._pipeline.reset_iterator()

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -476,7 +476,7 @@ class OobleckEngine:
             dataset.sample,
             self._hf_training_args,
             self._args.model.model_tag,
-            asdict(self._args.model),
+            self._args.model.model_args,
         )
 
         profile_results: LayerExecutionResults = get_profile_results(

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -466,10 +466,12 @@ class OobleckEngine:
             self._args.model.model_name,
             self._args.model.dataset_path,
             self._args.model.dataset_name,
-            self._args.model.n_positions
-            if hasattr(self._args.model, "n_positions")
+            self._args.model.model_args["n_positions"]
+            if "n_positions" in self._args.model.model_args
             else None,
         )
+
+        logger.info(f"model arguments: {self._args.model.model_args}")
 
         model = OobleckModel(
             self._args.model.model_name,

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -647,13 +647,13 @@ class OobleckEngine:
 
     def train(self):
         assert self._hf_training_args.max_steps > 0
+        step_timer: SynchronizedWallClockTimer.Timer = sync_timer("step")
 
         for step in range(self._hf_training_args.max_steps):
             try:
                 self._train_step()
-
-                step_timer: SynchronizedWallClockTimer.Timer = sync_timer("step")
                 logger.info(f"Step {step} time: {step_timer.elapsed()} ms")
             except StopIteration:
                 logger.info("Epoch is done.")
+                step_timer.reset()
                 self._pipeline.reset_iterator()

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -30,7 +30,7 @@ from oobleck.planning.instantiator import (
     HeterogeneousPipelinesExecutionPlan,
     PipelineInstantiator,
 )
-from oobleck.utils.timer import measure_time, timer
+from oobleck.utils.timer import measure_time, sync_timer
 
 logger = LoggerFactory.create_logger("oobleck_engine")
 
@@ -652,7 +652,7 @@ class OobleckEngine:
             try:
                 self._train_step()
 
-                step_timer: SynchronizedWallClockTimer.Timer = timer.timer("step")
+                step_timer: SynchronizedWallClockTimer.Timer = sync_timer("step")
                 logger.info(f"Step {step} time: {step_timer.elapsed()} ms")
             except StopIteration:
                 logger.info("Epoch is done.")

--- a/oobleck/execution/engine.py
+++ b/oobleck/execution/engine.py
@@ -185,8 +185,8 @@ class ReconfigurationEngine:
         new_ranks_list: list[list[int]],
     ) -> OobleckPipeline:
         global_num_microbatch = (
-            self.engine._args.global_microbatch_size
-            // self.engine._args.microbatch_size
+            self.engine._args.job.global_microbatch_size
+            // self.engine._args.job.microbatch_size
         )
         instantiator = PipelineInstantiator()
         execution_plan: HeterogeneousPipelinesExecutionPlan = (

--- a/oobleck/execution/pipeline.py
+++ b/oobleck/execution/pipeline.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 import weakref
 from collections.abc import Mapping
 from typing import Any
@@ -486,6 +485,9 @@ class OobleckPipeline:
             self.pipe_buffers[name] = [None] * len(pipe_buffers)
 
         self._global_step += 1
+
+    def reset_iterator(self):
+        self.execution._data_iterator = iter(self.execution._dataloader)
 
     def initialize_execution(
         self,

--- a/oobleck/module/model.py
+++ b/oobleck/module/model.py
@@ -1,5 +1,5 @@
 import random
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Optional, Type
 
 import torch
 from accelerate import init_empty_weights
@@ -47,10 +47,10 @@ class OobleckModel:
     def __init__(
         self,
         model_name: str,
-        sample_inputs: Dict[str, Any],
+        sample_inputs: dict[str, Any],
         training_args: Optional[TrainingArguments] = None,
         model_tag: Optional[str] = None,
-        config_args: Optional[Dict[str, Any]] = None,
+        config_args: Optional[dict[str, Any]] = None,
     ):
         # Initialize CPU seed
         random.seed(RANDOM_SEED)

--- a/oobleck/planning/instantiator.py
+++ b/oobleck/planning/instantiator.py
@@ -313,7 +313,7 @@ class PipelineInstantiator:
         # model.constraint2 = pyomo.Constraint(range(len(model.I)), rule=c2)
 
         pyomo.SolverFactory("mindtpy").solve(
-            model, mip_solver="glpk", nlp_solver="ipopt", tee=True
+            model, mip_solver="glpk", nlp_solver="ipopt", tee=False
         )
 
         # check for all i model.nb[i].value is integer, otherwise return None

--- a/oobleck/planning/profiler.py
+++ b/oobleck/planning/profiler.py
@@ -298,7 +298,7 @@ def profile(
             arguments.microbatch_size
         )
         # In each node, the first process writes a file.
-        if "0" in os.environ["CUDA_VISIBLE_DEVICES"]:
+        if dist.get_rank() % num_workers_per_node == 0:
             with path.open(mode="w") as f:
                 json.dump(layer_execution_result, f)
                 f.flush()
@@ -309,7 +309,7 @@ def profile(
     else:
         logger.info("Profiling cross-node allreduce latency.")
         allreduce_across_nodes = profiler.profile_allreduce_across_nodes()
-        if "0" in os.environ["CUDA_VISIBLE_DEVICES"]:
+        if dist.get_rank() % num_workers_per_node == 0:
             with path.open(mode="w") as f:
                 json.dump(allreduce_across_nodes, f)
                 f.flush()
@@ -320,7 +320,7 @@ def profile(
     else:
         logger.info("Profiling in-node allreduce latency.")
         allreduce_in_node = profiler.profile_allreduce_in_node(num_workers_per_node)
-        if "0" in os.environ["CUDA_VISIBLE_DEVICES"]:
+        if dist.get_rank() % num_workers_per_node == 0:
             with path.open(mode="w") as f:
                 json.dump(allreduce_in_node, f)
                 f.flush()

--- a/oobleck/planning/profiler.py
+++ b/oobleck/planning/profiler.py
@@ -186,7 +186,9 @@ class Profiler:
             for result in results.tolist()
         ]
 
-    def profile_allreduce_in_node(self) -> list[dict[int, float]]:
+    def profile_allreduce_in_node(
+        self, num_gpus_per_node: int
+    ) -> list[dict[int, float]]:
         """Profile allreduce latency between GPUs in node,
         \# nodes = 1, 2, 4, ....
         Actual measurement is done only on global rank 0,
@@ -200,8 +202,6 @@ class Profiler:
         assert dist.is_initialized()
         logger.info(f"Profile allreduce within a node latency")
 
-        num_gpus_per_node = torch.cuda.device_count()
-        # 1, 2, 4, 8, ...
         num_gpus_list = [2**i for i in range(int(math.log2(num_gpus_per_node)) + 1)]
         ranks = list(range(num_gpus_per_node))
 
@@ -319,7 +319,7 @@ def profile(
         logger.info("Skip profiling in-node allreduce latency.")
     else:
         logger.info("Profiling in-node allreduce latency.")
-        allreduce_in_node = profiler.profile_allreduce_in_node()
+        allreduce_in_node = profiler.profile_allreduce_in_node(num_workers_per_node)
         if "0" in os.environ["CUDA_VISIBLE_DEVICES"]:
             with path.open(mode="w") as f:
                 json.dump(allreduce_in_node, f)

--- a/oobleck/planning/profiler.py
+++ b/oobleck/planning/profiler.py
@@ -268,7 +268,7 @@ def profile(
         dataset.sample,
         None,
         args.model.model_tag,
-        asdict(args.model),
+        args.model.model_args,
     )
     device = torch.device("cuda")
     for layer in model.layers:

--- a/oobleck/utils/timer.py
+++ b/oobleck/utils/timer.py
@@ -2,14 +2,14 @@ from deepspeed.utils.logging import LoggerFactory
 from deepspeed.utils.timer import SynchronizedWallClockTimer
 
 logger = LoggerFactory.create_logger(__name__)
-timer = SynchronizedWallClockTimer()
+sync_timer = SynchronizedWallClockTimer()
 
 
 def measure_time(timer_name: str):
     def inner(func: callable):
         def wrapper(s, *args, **kwargs):
-            global timer
-            timer: SynchronizedWallClockTimer.Timer = timer.timer(timer_name)
+            global sync_timer
+            timer: SynchronizedWallClockTimer.Timer = sync_timer.timer(timer_name)
             timer.start()
             # TODO: restore timer later.
             result = func(s, *args, **kwargs)

--- a/oobleck/utils/timer.py
+++ b/oobleck/utils/timer.py
@@ -9,7 +9,7 @@ def measure_time(timer_name: str):
     def inner(func: callable):
         def wrapper(s, *args, **kwargs):
             global sync_timer
-            timer: SynchronizedWallClockTimer.Timer = sync_timer.timer(timer_name)
+            timer: SynchronizedWallClockTimer.Timer = sync_timer(timer_name)
             timer.start()
             # TODO: restore timer later.
             result = func(s, *args, **kwargs)

--- a/oobleck/utils/timer.py
+++ b/oobleck/utils/timer.py
@@ -8,6 +8,7 @@ timer = SynchronizedWallClockTimer()
 def measure_time(timer_name: str):
     def inner(func: callable):
         def wrapper(s, *args, **kwargs):
+            global timer
             timer: SynchronizedWallClockTimer.Timer = timer.timer(timer_name)
             timer.start()
             # TODO: restore timer later.

--- a/oobleck/utils/timer.py
+++ b/oobleck/utils/timer.py
@@ -1,105 +1,18 @@
-from datetime import datetime
-from typing import Any, Callable, List, Tuple
-
-from deepspeed import comm as dist
-from deepspeed.monitor.config import get_monitor_config
-from deepspeed.monitor.monitor import MonitorMaster
-from deepspeed.utils.logging import logger
+from deepspeed.utils.logging import LoggerFactory
 from deepspeed.utils.timer import SynchronizedWallClockTimer
 
-from oobleck.utils.singleton import Singleton
-
-
-@Singleton
-class OobleckTimer:
-    """
-    Oobleck timer as an extension of DeepSpeed Timer.
-    It provides a decorator that simply measures time for a function execution.
-    """
-
-    def __init__(self):
-        if dist.get_rank() == 0:
-            self.monitor = MonitorMaster(
-                get_monitor_config(
-                    {
-                        "tensorboard": {
-                            "enabled": True,
-                            "output_path": "/tmp/oobleck/tensorboard/",
-                            "job_name": f"{datetime.now().astimezone().isoformat()}",
-                        }
-                    }
-                )
-            )
-            self.timer = SynchronizedWallClockTimer()
-        else:
-            self.monitor = None
-            self.timer = None
-
-    def write_events(self, event_lists: List[Tuple[Any]]):
-        if not self.monitor:
-            return
-
-        self.monitor.write_events(event_lists)
-
-    def log_throughput(
-        self, batch_size: int, world_size: int, iteration_name: str, step: int
-    ):
-        if (
-            not self.monitor
-            or not self.monitor.enabled
-            or iteration_name not in self.timer.timers
-        ):
-            return
-
-        elapsed_time = self.timer.timers[iteration_name].elapsed()
-        strings = [
-            ("throughput/batch per second", batch_size / elapsed_time * 1000, step),
-            (
-                "throughput/batch per GPU per second",
-                batch_size / elapsed_time / world_size * 1000,
-                step,
-            ),
-            (iteration_name, elapsed_time, step),
-        ]
-        logger.info(strings)
-        self.monitor.write_events(strings)
-
-    def log(
-        self,
-        names: List[str],
-        step: int,
-        normalizer: float = 1.0,
-        reset: bool = True,
-    ):
-        """Log a group of timers. Time is logged into monitor."""
-
-        if not self.monitor or not self.monitor.enabled:
-            return
-        assert normalizer > 0.0
-
-        strings = []
-        for name in names:
-            if name in self.timer.timers:
-                elapsed_time = self.timer.timers[name].elapsed(reset=reset) / normalizer
-                strings.append((name, elapsed_time, step))
-
-        logger.info(strings)
-        self.monitor.write_events(strings)
+logger = LoggerFactory.create_logger(__name__)
+timer = SynchronizedWallClockTimer()
 
 
 def measure_time(timer_name: str):
-    def inner(func: Callable):
+    def inner(func: callable):
         def wrapper(s, *args, **kwargs):
+            timer: SynchronizedWallClockTimer.Timer = timer.timer(timer_name)
+            timer.start()
             # TODO: restore timer later.
-            return func(s, *args, **kwargs)
-            assert hasattr(
-                s, "timer"
-            ), "Assign self.timer = OobleckTime() to measure time."
-            if s.training_args.should_log and s.timer.timer:
-                s.timer.timer(timer_name).start()
             result = func(s, *args, **kwargs)
-            if s.training_args.should_log and s.timer.timer:
-                s.timer.timer(timer_name).stop()
+            timer.stop()
             return result
 
         return wrapper

--- a/tests/elastic/conftest.py
+++ b/tests/elastic/conftest.py
@@ -29,6 +29,7 @@ class OobleckElasticTestCase:
                 master_port=daemon.port,
                 node_ips=["127.0.0.1", "127.0.0.2"],
                 username="test",
+                num_agents_per_node=1,
                 num_workers=4,
             ),
             job=JobArguments(),
@@ -53,7 +54,7 @@ class OobleckElasticTestCase:
     async def agent(
         self, daemon: OobleckMasterDaemon, mocker: MockerFixture
     ) -> OobleckAgent:
-        agent = OobleckAgent("127.0.0.1", daemon.port, 0)
+        agent = OobleckAgent("127.0.0.1", daemon.port, 0, 0)
 
         future = asyncio.Future()
         future.set_result(None)

--- a/tests/elastic/conftest.py
+++ b/tests/elastic/conftest.py
@@ -6,8 +6,9 @@ from pytest_mock import MockerFixture
 from oobleck.elastic.agent import OobleckAgent
 from oobleck.elastic.master import OobleckMasterDaemon
 from oobleck.elastic.training_util import (
-    DistributedJobConfiguration,
-    OobleckAgentArguments,
+    DistributedArguments,
+    JobArguments,
+    ModelArguments,
     OobleckArguments,
 )
 
@@ -22,18 +23,22 @@ class OobleckElasticTestCase:
         event_loop: asyncio.AbstractEventLoop,
     ) -> OobleckMasterDaemon:
         daemon = await OobleckMasterDaemon.create("127.0.0.1", 0)
-        daemon._job = DistributedJobConfiguration(
-            master_ip="127.0.0.1",
-            master_port=daemon.port,
-            node_ips=["127.0.0.1", "127.0.0.2"],
-            job_args=OobleckArguments(
+        daemon._job_arguments[0] = OobleckArguments(
+            dist=DistributedArguments(
+                master_ip="127.0.0.1",
+                master_port=daemon.port,
+                node_ips=["127.0.0.1", "127.0.0.2"],
+                username="test",
+            ),
+            job=JobArguments(),
+            model=ModelArguments(
                 model_name="gpt2",
                 model_tag="test",
                 dataset_path="test",
                 dataset_name=None,
             ),
-            username="test",
         )
+
         event_loop.create_task(daemon._server.serve_forever())
 
         yield daemon
@@ -47,20 +52,12 @@ class OobleckElasticTestCase:
     async def agent(
         self, daemon: OobleckMasterDaemon, mocker: MockerFixture
     ) -> OobleckAgent:
-        args = OobleckAgentArguments(
-            master_ip=daemon._job.master_ip,
-            master_port=daemon.port,
-            node_ips=daemon._job.node_ips,
-            job_args=daemon._job.job_args,
-            num_workers=self.sample_num_workers,
-        )
-
-        agent = OobleckAgent(args)
+        agent = OobleckAgent("127.0.0.1", daemon.port, 0)
 
         future = asyncio.Future()
         future.set_result(None)
         mocker.patch.object(agent, "_run_profiler", return_value=future)
-        await agent._connect_to_master(args.master_ip, args.master_port)
+        await agent._connect_to_master("127.0.0.1", daemon.port)
         yield agent
         if not agent._conn[1].is_closing():
             agent._conn[1].close()

--- a/tests/elastic/conftest.py
+++ b/tests/elastic/conftest.py
@@ -29,6 +29,7 @@ class OobleckElasticTestCase:
                 master_port=daemon.port,
                 node_ips=["127.0.0.1", "127.0.0.2"],
                 username="test",
+                num_workers=4,
             ),
             job=JobArguments(),
             model=ModelArguments(

--- a/tests/elastic/test_agent.py
+++ b/tests/elastic/test_agent.py
@@ -4,7 +4,7 @@ import multiprocessing
 import pytest
 from pytest_mock import MockerFixture
 
-from oobleck.elastic.agent import OobleckAgent, OobleckAgentArguments, Worker
+from oobleck.elastic.agent import OobleckAgent, OobleckArguments, Worker
 from oobleck.elastic.master import OobleckMasterDaemon
 from tests.elastic.conftest import OobleckElasticTestCase
 
@@ -23,22 +23,11 @@ class TestOobleckAgentClass(OobleckElasticTestCase):
         daemon: OobleckMasterDaemon,
         agent: OobleckAgent,
     ):
-        await agent._register_agent()
+        await agent._register_agent(0)
         await asyncio.sleep(1)
         assert self.sample_ip in [
             connection[0] for connection in daemon._agent_connections
         ]
-
-    @pytest.mark.asyncio
-    async def test_fail_register_agent(
-        self,
-        agent: OobleckAgent,
-        mocker: MockerFixture,
-    ):
-        mocker.patch("asyncio.StreamWriter.get_extra_info", return_value=("0.0.0.0", 0))
-
-        with pytest.raises(ConnectionError):
-            await agent._register_agent()
 
     @pytest.mark.asyncio
     async def test_launch_workers(
@@ -49,16 +38,16 @@ class TestOobleckAgentClass(OobleckElasticTestCase):
     ):
         mocker.patch("oobleck.elastic.agent.worker_main", new_callable=lambda: 0)
 
-        await agent._register_agent()
-        await agent._launch_workers(self.sample_num_workers, daemon._job.job_args)
-        assert len(agent._workers) == self.sample_num_workers
+        args_from_master = await agent._register_agent(0)
+        await agent._launch_workers(args_from_master)
+        assert len(agent._workers) == args_from_master.dist.num_workers
         for worker in agent._workers:
             worker.process.join()
 
     @staticmethod
-    async def agent_process_fn(args: OobleckAgentArguments):
+    async def agent_process_fn(args: OobleckArguments):
         agent = OobleckAgent(args)
-        await agent._connect_to_master(args.master_ip, args.master_port)
+        await agent._connect_to_master(args.dist.master_ip, args.dist.master_port)
         await agent._register_agent()
         await asyncio.sleep(1)
         agent._conn[1].close()
@@ -67,34 +56,38 @@ class TestOobleckAgentClass(OobleckElasticTestCase):
     async def test_receive_reconfiguration(
         self, daemon: OobleckMasterDaemon, agent: OobleckAgent, mocker: MockerFixture
     ):
-        num_workers = 4
+        job_id = 0
 
-        await agent._register_agent()
-        assert agent._args.node_ips == daemon._job.node_ips
+        args_from_master = await agent._register_agent(job_id)
+        assert args_from_master == daemon._job_arguments[job_id]
+        agent._args = args_from_master
+
         # Fake worker processes
         pipe = multiprocessing.Pipe()
-        for i in range(num_workers):
+        for i in range(args_from_master.dist.num_workers):
             agent._workers.append(Worker(pipe[1], None))
         pipe_spy = mocker.spy(agent._workers[0].pipe, "send")
 
         expected_lost_node = "127.0.0.2"
 
         # Create a new agent, register it, and terminate it
-        new_agent = OobleckAgent(agent._args)
+        new_agent = OobleckAgent(
+            agent._args.dist.master_ip, agent._args.dist.master_port, job_id
+        )
         await new_agent._connect_to_master(
-            agent._args.master_ip, agent._args.master_port
+            agent._args.dist.master_ip, agent._args.dist.master_port
         )
         mocker.patch(
             "asyncio.StreamWriter.get_extra_info", return_value=("127.0.0.2", "12345")
         )
-        await new_agent._register_agent()
+        await new_agent._register_agent(0)
         new_agent._conn[1].close()
         await new_agent._conn[1].wait_closed()
 
         asyncio.create_task(agent.on_receive_response())
 
         # Yield context so that agent can receive reconfiguration message
-        while "127.0.0.2" in agent._args.node_ips:
+        while "127.0.0.2" in agent._args.dist.node_ips:
             await asyncio.sleep(0.1)
 
         pipe_spy.assert_called_with(expected_lost_node)

--- a/tests/elastic/test_agent.py
+++ b/tests/elastic/test_agent.py
@@ -44,14 +44,6 @@ class TestOobleckAgentClass(OobleckElasticTestCase):
         for worker in agent._workers:
             worker.process.join()
 
-    @staticmethod
-    async def agent_process_fn(args: OobleckArguments):
-        agent = OobleckAgent(args)
-        await agent._connect_to_master(args.dist.master_ip, args.dist.master_port)
-        await agent._register_agent()
-        await asyncio.sleep(1)
-        agent._conn[1].close()
-
     @pytest.mark.asyncio
     async def test_receive_reconfiguration(
         self, daemon: OobleckMasterDaemon, agent: OobleckAgent, mocker: MockerFixture
@@ -72,7 +64,7 @@ class TestOobleckAgentClass(OobleckElasticTestCase):
 
         # Create a new agent, register it, and terminate it
         new_agent = OobleckAgent(
-            agent._args.dist.master_ip, agent._args.dist.master_port, job_id
+            agent._args.dist.master_ip, agent._args.dist.master_port, job_id, 1
         )
         await new_agent._connect_to_master(
             agent._args.dist.master_ip, agent._args.dist.master_port

--- a/tests/elastic/test_master.py
+++ b/tests/elastic/test_master.py
@@ -8,7 +8,6 @@ from pytest_mock import MockerFixture
 import oobleck.elastic.message_util as message_util
 from oobleck.elastic.agent import OobleckAgent
 from oobleck.elastic.master import OobleckMasterDaemon
-from oobleck.elastic.training_util import OobleckAgentArguments
 from tests.elastic.conftest import OobleckElasticTestCase
 
 """
@@ -38,9 +37,8 @@ class TestOobleckMasterDaemonClass(OobleckElasticTestCase):
         client_conns: tuple[asyncio.StreamReader, asyncio.StreamWriter],
         mocker: MockerFixture,
     ):
-        job = daemon._job
-        # Daemon must not have a job config
-        daemon._job = None
+        args = daemon._job_arguments[0]
+        daemon._job_arguments.clear()
 
         mock_run_agents = mocker.patch.object(
             daemon, "run_node_agent", return_value=AsyncMock(return_value=None)
@@ -49,7 +47,7 @@ class TestOobleckMasterDaemonClass(OobleckElasticTestCase):
         r, w = client_conns
         """Cehck if master launches agents."""
         await message_util.send_request_type(w, message_util.RequestType.LAUNCH_JOB)
-        await message_util.send(w, job, need_pickle=True, close=False)
+        await message_util.send(w, args)
 
         result = await message_util.recv_response(r)
         assert result == (
@@ -57,8 +55,8 @@ class TestOobleckMasterDaemonClass(OobleckElasticTestCase):
             message_util.RequestType.LAUNCH_JOB,
         )
 
-        assert mock_run_agents.call_count == len(job.node_ips)
-        assert daemon._job == job
+        assert mock_run_agents.call_count == len(args.dist.node_ips)
+        # assert args == daemon._job_arguments[0]
 
         w.close()
         await w.wait_closed()
@@ -72,25 +70,26 @@ class TestOobleckMasterDaemonClass(OobleckElasticTestCase):
         close_agent_handler_spy = mocker.spy(daemon, "close_agent")
 
         agents: list[OobleckAgent] = []
-        args = OobleckAgentArguments(
-            master_ip=daemon._job.master_ip,
-            master_port=daemon.port,
-            node_ips=daemon._job.node_ips,
-            job_args=daemon._job.job_args,
-            num_workers=self.sample_num_workers,
-        )
+        job_id = 0
+        args = daemon._job_arguments[job_id]
 
         for agent_ip in ["127.0.0.1", "127.0.0.2"]:
-            agent = OobleckAgent(args)
-            await agent._connect_to_master(args.master_ip, args.master_port)
+            agent = OobleckAgent(args.dist.master_ip, args.dist.master_port, job_id)
+            await agent._connect_to_master(args.dist.master_ip, args.dist.master_port)
+
             mocker.patch(
                 "asyncio.StreamWriter.get_extra_info", return_value=(agent_ip, 0)
             )
             await message_util.send_request_type(
                 agent._conn[1], message_util.RequestType.REGISTER_AGENT
             )
+            await message_util.send(agent._conn[1], job_id)
             result, _ = await message_util.recv_response(agent._conn[0])
             assert result == message_util.Response.SUCCESS
+
+            await message_util.recv(agent._conn[0])
+            # assert args == args_from_master
+
             agents.append(agent)
 
         # close the second agent and check if notification goes to the first agent

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -1,19 +1,34 @@
 import pytest
 
-from oobleck.elastic.training_util import OobleckArguments
+from oobleck.elastic.training_util import (
+    DistributedArguments,
+    JobArguments,
+    ModelArguments,
+    OobleckArguments,
+)
 from tests.conftest import TRAIN_BATCH_SIZE, datasets, model_args
 
 
 @pytest.fixture(scope="module")
 def sample_args(model_name_fixture: str) -> OobleckArguments:
     dataset: tuple[str, (str | None)] = datasets[model_name_fixture]
+
     return OobleckArguments(
-        model_name=model_name_fixture,
-        model_tag="test",
-        dataset_path=dataset[0],
-        dataset_name=dataset[1],
-        fault_threshold=1,
-        model_args=model_args[model_name_fixture],
-        microbatch_size=TRAIN_BATCH_SIZE,
-        global_microbatch_size=4 * TRAIN_BATCH_SIZE,
+        dist=DistributedArguments(
+            master_ip="127.0.0.1",
+            master_port=0,
+            node_ips=["127.0.0.1"],
+        ),
+        job=JobArguments(
+            fault_threshold=1,
+            microbatch_size=TRAIN_BATCH_SIZE,
+            global_microbatch_size=4 * TRAIN_BATCH_SIZE,
+        ),
+        model=ModelArguments(
+            model_name=model_name_fixture,
+            model_tag="test",
+            dataset_path=dataset[0],
+            dataset_name=dataset[1],
+            **model_args[model_name_fixture],
+        ),
     )

--- a/tests/execution/conftest.py
+++ b/tests/execution/conftest.py
@@ -29,6 +29,6 @@ def sample_args(model_name_fixture: str) -> OobleckArguments:
             model_tag="test",
             dataset_path=dataset[0],
             dataset_name=dataset[1],
-            **model_args[model_name_fixture],
+            model_args=model_args[model_name_fixture],
         ),
     )

--- a/tests/execution/test_engine.py
+++ b/tests/execution/test_engine.py
@@ -583,7 +583,7 @@ class TestOobleckEngineClass(OobleckElasticTestCase):
         )
 
         global_num_microbatch = (
-            sample_args.global_microbatch_size // sample_args.microbatch_size
+            sample_args.job.global_microbatch_size // sample_args.job.microbatch_size
         )
         engine.instantiate_pipelines(global_num_microbatch)
 
@@ -692,7 +692,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
         assert dist.get_rank() < dist.get_world_size()
         assert dist.get_world_size() == 4, "This test must run with 4 GPUs"
         global_num_microbatch = (
-            arguments.global_microbatch_size // arguments.microbatch_size
+            arguments.job.global_microbatch_size // arguments.job.microbatch_size
         )
         engine.instantiate_pipelines(global_num_microbatch)
 
@@ -756,7 +756,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
         num_nodes_per_pipeline = num_stages
         pipe = pipe[rank]
         global_num_microbatch = (
-            arguments.global_microbatch_size // arguments.microbatch_size
+            arguments.job.global_microbatch_size // arguments.job.microbatch_size
         )
 
         my_ip = agent_ips[rank]
@@ -816,7 +816,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
         num_nodes_per_pipeline = 1
         pipe = pipe[rank]
         global_num_microbatch = (
-            arguments.global_microbatch_size // arguments.microbatch_size
+            arguments.job.global_microbatch_size // arguments.job.microbatch_size
         )
 
         socket_patcher = patch("socket.gethostbyname", return_value=my_ip)
@@ -897,7 +897,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
     ):
         pipe = pipes[rank]
         global_num_microbatch = (
-            arguments.global_microbatch_size // arguments.microbatch_size
+            arguments.job.global_microbatch_size // arguments.job.microbatch_size
         )
 
         my_ip = agent_ips[rank]
@@ -1027,7 +1027,7 @@ class TestOobleckDistributedEngineClass(OobleckMultiProcessTestCase):
         # adjust global microbatch size so that batch distribution
         # works after losing 1 node.
         sample_args = copy.deepcopy(sample_args)
-        sample_args.global_microbatch_size = 24 * TRAIN_BATCH_SIZE
+        sample_args.job.global_microbatch_size = 24 * TRAIN_BATCH_SIZE
 
         num_gpus_per_node = 1
         ctx = multiprocessing.get_context("spawn")

--- a/tests/planning/test_pipeline_template.py
+++ b/tests/planning/test_pipeline_template.py
@@ -77,6 +77,17 @@ class TestOobleckPipelineTemplate(OobleckSingleProcessTestCase):
             for template in pipeline_templates
         ) == 4
 
+    def test_create_pipeline_templates_multiple_gpus_in_node_range(
+        self, profile: LayerExecutionResults
+    ):
+        generator = PipelineTemplateGenerator()
+        pipeline_templates = generator.create_pipeline_templates(profile, (1, 6), 4)
+        assert len(pipeline_templates) >= 1
+        for index, template in enumerate(pipeline_templates):
+            num_nodes = index + 1
+            assert template._num_gpus_per_node == 4
+            assert num_nodes == template._num_nodes
+
     @pytest.mark.skip(reason="Not implemented yet")
     def test_create_pipeline_templates_fsdp(self, profile: LayerExecutionResults):
         pass


### PR DESCRIPTION
This PR fixes master and agent implementation to be able to run distributed  multi-node training jobs.
Also, it adds aa feature of launching multiple agents per node to simulate single-GPU-per-node job in multi-GPU-per-node environment.