### PR TITLE
Provide CLI to gracefully terminate agent and workers

### DIFF
--- a/examples/run_gpt2.py
+++ b/examples/run_gpt2.py
@@ -16,7 +16,7 @@ from transformers import (
     get_linear_schedule_with_warmup,
 )
 
-from oobleck import ExecutionEngine, OobleckPlugin
+from oobleck.engine import ExecutionEngine, OobleckPlugin
 
 
 def tokenize_batch_for_pretrain(

--- a/examples/run_gpt2.py
+++ b/examples/run_gpt2.py
@@ -16,7 +16,8 @@ from transformers import (
     get_linear_schedule_with_warmup,
 )
 
-from oobleck.engine import ExecutionEngine, OobleckPlugin
+from oobleck.engine.execution_engine import ExecutionEngine
+from oobleck.engine.plugin import OobleckPlugin
 
 
 def tokenize_batch_for_pretrain(

--- a/oobleck/__init__.py
+++ b/oobleck/__init__.py
@@ -1,4 +1,0 @@
-from oobleck_colossalai.pipeline_template import PipelineTemplate
-
-from oobleck.engine.execution_engine import ExecutionEngine
-from oobleck.engine.plugin import OobleckPlugin

--- a/oobleck/cli.py
+++ b/oobleck/cli.py
@@ -1,0 +1,44 @@
+import click
+import grpc
+from google.protobuf.empty_pb2 import Empty
+
+from oobleck.elastic.master_service_pb2 import AgentInfo, DistInfo
+from oobleck.elastic.master_service_pb2_grpc import OobleckMasterStub
+
+
+@click.group(help="CLI tool to query and manipulate Oobleck training.")
+@click.option("--ip", type=str, default="localhost", help="Master IP address.")
+@click.option("--port", type=int, help="Master port.")
+@click.pass_context
+def main(ctx: click.core.Context, ip: str, port: int):
+    channel = grpc.insecure_channel(f"{ip}:{port}")
+    stub = OobleckMasterStub(channel)
+
+    ctx.ensure_object(dict)
+    ctx.obj["stub"] = stub
+
+
+@main.command()
+@click.pass_context
+def get_agent_list(ctx: click.core.Context):
+    stub: OobleckMasterStub = ctx.obj["stub"]
+    response: DistInfo = stub.GetDistInfo(Empty())
+
+    print("=== Agents ===")
+    for index, host in enumerate(response.hosts):
+        print(
+            f"[{index}] IP: {host.ip}:{host.port} Status: {host.status} (device indices: {host.devices})"
+        )
+    print("==============")
+
+
+@main.command()
+@click.pass_context
+@click.option("--agent_index", type=int)
+def kill_agent(ctx: click.core.Context, agent_index: int):
+    stub: OobleckMasterStub = ctx.obj["stub"]
+    stub.KillAgent(AgentInfo(agent_index=agent_index))
+
+
+if __name__ == "__main__":
+    main(obj={})

--- a/oobleck/elastic/agent.py
+++ b/oobleck/elastic/agent.py
@@ -117,6 +117,10 @@ class Agent:
             )
             worker.pipe.send(dist_info)
 
+        # If this agent is about to die, don't forward the port
+        if dist_info[self.agent_index].status == HostStatus.terminating:
+            return
+
         self.forward_master_port()
 
     def watch_reconfiguration_notification(self):
@@ -179,6 +183,7 @@ class Agent:
                     self.script,
                     self.script_args,
                 ),
+                daemon=False,
             )
             process.start()
             self.workers.append(Worker(pipe, process))

--- a/oobleck/elastic/master_service.proto
+++ b/oobleck/elastic/master_service.proto
@@ -7,12 +7,14 @@ service OobleckMaster {
     rpc SetMasterRankPort(PortInfo) returns (google.protobuf.Empty) {}
     rpc GetMasterRankPort(google.protobuf.Empty) returns (PortInfo) {}
     rpc WatchReconfigurationNotification(google.protobuf.Empty) returns (stream DistInfo) {}
+    rpc KillAgent(AgentInfo) returns (google.protobuf.Empty) {}
 }
 
 message HostInfo {
     string ip = 1;
     string devices = 2;
     uint32 port = 3;
+    string status = 4;
 }
 
 message DistInfo {
@@ -26,4 +28,8 @@ message CodeInfo {
 
 message PortInfo {
     uint32 port = 1;
+}
+
+message AgentInfo {
+    uint32 agent_index = 1;
 }

--- a/oobleck/elastic/master_service_pb2.py
+++ b/oobleck/elastic/master_service_pb2.py
@@ -15,7 +15,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14master_service.proto\x1a\x1bgoogle/protobuf/empty.proto\"5\n\x08HostInfo\x12\n\n\x02ip\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65vices\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\r\"$\n\x08\x44istInfo\x12\x18\n\x05hosts\x18\x01 \x03(\x0b\x32\t.HostInfo\"&\n\x08\x43odeInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\"\x18\n\x08PortInfo\x12\x0c\n\x04port\x18\x01 \x01(\r2\xb2\x02\n\rOobleckMaster\x12\x32\n\x0bGetDistInfo\x12\x16.google.protobuf.Empty\x1a\t.DistInfo\"\x00\x12.\n\x07GetCode\x12\x16.google.protobuf.Empty\x1a\t.CodeInfo\"\x00\x12\x38\n\x11SetMasterRankPort\x12\t.PortInfo\x1a\x16.google.protobuf.Empty\"\x00\x12\x38\n\x11GetMasterRankPort\x12\x16.google.protobuf.Empty\x1a\t.PortInfo\"\x00\x12I\n WatchReconfigurationNotification\x12\x16.google.protobuf.Empty\x1a\t.DistInfo\"\x00\x30\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x14master_service.proto\x1a\x1bgoogle/protobuf/empty.proto\"E\n\x08HostInfo\x12\n\n\x02ip\x18\x01 \x01(\t\x12\x0f\n\x07\x64\x65vices\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\r\x12\x0e\n\x06status\x18\x04 \x01(\t\"$\n\x08\x44istInfo\x12\x18\n\x05hosts\x18\x01 \x03(\x0b\x32\t.HostInfo\"&\n\x08\x43odeInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\"\x18\n\x08PortInfo\x12\x0c\n\x04port\x18\x01 \x01(\r\" \n\tAgentInfo\x12\x13\n\x0b\x61gent_index\x18\x01 \x01(\r2\xe5\x02\n\rOobleckMaster\x12\x32\n\x0bGetDistInfo\x12\x16.google.protobuf.Empty\x1a\t.DistInfo\"\x00\x12.\n\x07GetCode\x12\x16.google.protobuf.Empty\x1a\t.CodeInfo\"\x00\x12\x38\n\x11SetMasterRankPort\x12\t.PortInfo\x1a\x16.google.protobuf.Empty\"\x00\x12\x38\n\x11GetMasterRankPort\x12\x16.google.protobuf.Empty\x1a\t.PortInfo\"\x00\x12I\n WatchReconfigurationNotification\x12\x16.google.protobuf.Empty\x1a\t.DistInfo\"\x00\x30\x01\x12\x31\n\tKillAgent\x12\n.AgentInfo\x1a\x16.google.protobuf.Empty\"\x00\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -23,13 +23,15 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'master_service_pb2', _globa
 if _descriptor._USE_C_DESCRIPTORS == False:
   DESCRIPTOR._options = None
   _globals['_HOSTINFO']._serialized_start=53
-  _globals['_HOSTINFO']._serialized_end=106
-  _globals['_DISTINFO']._serialized_start=108
-  _globals['_DISTINFO']._serialized_end=144
-  _globals['_CODEINFO']._serialized_start=146
-  _globals['_CODEINFO']._serialized_end=184
-  _globals['_PORTINFO']._serialized_start=186
-  _globals['_PORTINFO']._serialized_end=210
-  _globals['_OOBLECKMASTER']._serialized_start=213
-  _globals['_OOBLECKMASTER']._serialized_end=519
+  _globals['_HOSTINFO']._serialized_end=122
+  _globals['_DISTINFO']._serialized_start=124
+  _globals['_DISTINFO']._serialized_end=160
+  _globals['_CODEINFO']._serialized_start=162
+  _globals['_CODEINFO']._serialized_end=200
+  _globals['_PORTINFO']._serialized_start=202
+  _globals['_PORTINFO']._serialized_end=226
+  _globals['_AGENTINFO']._serialized_start=228
+  _globals['_AGENTINFO']._serialized_end=260
+  _globals['_OOBLECKMASTER']._serialized_start=263
+  _globals['_OOBLECKMASTER']._serialized_end=620
 # @@protoc_insertion_point(module_scope)

--- a/oobleck/elastic/master_service_pb2.pyi
+++ b/oobleck/elastic/master_service_pb2.pyi
@@ -7,14 +7,16 @@ from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Map
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class HostInfo(_message.Message):
-    __slots__ = ("ip", "devices", "port")
+    __slots__ = ("ip", "devices", "port", "status")
     IP_FIELD_NUMBER: _ClassVar[int]
     DEVICES_FIELD_NUMBER: _ClassVar[int]
     PORT_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
     ip: str
     devices: str
     port: int
-    def __init__(self, ip: _Optional[str] = ..., devices: _Optional[str] = ..., port: _Optional[int] = ...) -> None: ...
+    status: str
+    def __init__(self, ip: _Optional[str] = ..., devices: _Optional[str] = ..., port: _Optional[int] = ..., status: _Optional[str] = ...) -> None: ...
 
 class DistInfo(_message.Message):
     __slots__ = ("hosts",)
@@ -35,3 +37,9 @@ class PortInfo(_message.Message):
     PORT_FIELD_NUMBER: _ClassVar[int]
     port: int
     def __init__(self, port: _Optional[int] = ...) -> None: ...
+
+class AgentInfo(_message.Message):
+    __slots__ = ("agent_index",)
+    AGENT_INDEX_FIELD_NUMBER: _ClassVar[int]
+    agent_index: int
+    def __init__(self, agent_index: _Optional[int] = ...) -> None: ...

--- a/oobleck/elastic/master_service_pb2_grpc.py
+++ b/oobleck/elastic/master_service_pb2_grpc.py
@@ -4,7 +4,7 @@
 import grpc
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
-from . import master_service_pb2 as master__service__pb2
+import oobleck.elastic.master_service_pb2 as master__service__pb2
 
 
 class OobleckMasterStub(object):
@@ -41,6 +41,11 @@ class OobleckMasterStub(object):
             request_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             response_deserializer=master__service__pb2.DistInfo.FromString,
         )
+        self.KillAgent = channel.unary_unary(
+            "/OobleckMaster/KillAgent",
+            request_serializer=master__service__pb2.AgentInfo.SerializeToString,
+            response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+        )
 
 
 class OobleckMasterServicer(object):
@@ -76,6 +81,12 @@ class OobleckMasterServicer(object):
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
+    def KillAgent(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("Method not implemented!")
+        raise NotImplementedError("Method not implemented!")
+
 
 def add_OobleckMasterServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -103,6 +114,11 @@ def add_OobleckMasterServicer_to_server(servicer, server):
             servicer.WatchReconfigurationNotification,
             request_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
             response_serializer=master__service__pb2.DistInfo.SerializeToString,
+        ),
+        "KillAgent": grpc.unary_unary_rpc_method_handler(
+            servicer.KillAgent,
+            request_deserializer=master__service__pb2.AgentInfo.FromString,
+            response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
         ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -250,6 +266,35 @@ class OobleckMaster(object):
             "/OobleckMaster/WatchReconfigurationNotification",
             google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             master__service__pb2.DistInfo.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+        )
+
+    @staticmethod
+    def KillAgent(
+        request,
+        target,
+        options=(),
+        channel_credentials=None,
+        call_credentials=None,
+        insecure=False,
+        compression=None,
+        wait_for_ready=None,
+        timeout=None,
+        metadata=None,
+    ):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            "/OobleckMaster/KillAgent",
+            master__service__pb2.AgentInfo.SerializeToString,
+            google_dot_protobuf_dot_empty__pb2.Empty.FromString,
             options,
             channel_credentials,
             insecure,

--- a/oobleck/engine/__init__.py
+++ b/oobleck/engine/__init__.py
@@ -1,2 +1,0 @@
-from oobleck.engine.execution_engine import ExecutionEngine
-from oobleck.engine.plugin import OobleckPlugin

--- a/oobleck/engine/__init__.py
+++ b/oobleck/engine/__init__.py
@@ -1,0 +1,2 @@
+from oobleck.engine.execution_engine import ExecutionEngine
+from oobleck.engine.plugin import OobleckPlugin

--- a/oobleck/engine/configuration_engine.py
+++ b/oobleck/engine/configuration_engine.py
@@ -131,7 +131,6 @@ class ConfigurationEngine:
             ), f"Unexpected reconfiguration message: {message}"
         except Exception:
             # Corresponding agent died. This process should also die.
-            time.sleep(60)
             os._exit(1)
 
     def send_distributed_port(self, port: int):

--- a/oobleck/engine/configuration_engine.py
+++ b/oobleck/engine/configuration_engine.py
@@ -94,8 +94,8 @@ class ConfigurationEngine:
             host.status == HostStatus.killed for host in new_dist_info
         ), "Worker should not see any killed agent status."
 
-        self.agent_index = new_dist_info.index(my_agent)
-        if new_dist_info[self.agent_index].status == HostStatus.terminating:
+        agent_index = new_dist_info.index(my_agent)
+        if new_dist_info[agent_index].status == HostStatus.terminating:
             # This process will be terminated after the iteration.
             logger.info(
                 f"Worker {self.local_rank} in agent {self.agent_index} terminating..."
@@ -107,6 +107,7 @@ class ConfigurationEngine:
             for host_info in new_dist_info
             if host_info.status == HostStatus.up
         ]
+        self.agent_index = self.dist_info.index(my_agent)
 
         self.rank_map = {
             host: list(range(i * len(gpu_indices), (i + 1) * len(gpu_indices)))

--- a/oobleck/engine/configuration_engine.py
+++ b/oobleck/engine/configuration_engine.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import torch.distributed as dist
 from loguru import logger
 
-from oobleck.elastic.run import HostInfo
+from oobleck.elastic.run import HostInfo, HostStatus
 
 
 class ConfigurationEngine:
@@ -88,11 +88,25 @@ class ConfigurationEngine:
         Get host update from the agent process.
         """
         my_agent = self.dist_info[self.agent_index]
-
         new_dist_info: list[HostInfo] = self.pipe.recv()
 
-        self.dist_info = new_dist_info
+        assert not any(
+            host.status == HostStatus.killed for host in new_dist_info
+        ), "Worker should not see any killed agent status."
+
         self.agent_index = new_dist_info.index(my_agent)
+        if new_dist_info[self.agent_index].status == HostStatus.terminating:
+            # This process will be terminated after the iteration.
+            logger.info(
+                f"Worker {self.local_rank} in agent {self.agent_index} terminating..."
+            )
+            os._exit(0)
+
+        self.dist_info = [
+            host_info
+            for host_info in new_dist_info
+            if host_info.status == HostStatus.up
+        ]
 
         self.rank_map = {
             host: list(range(i * len(gpu_indices), (i + 1) * len(gpu_indices)))
@@ -123,12 +137,22 @@ class ConfigurationEngine:
         """
         return self.agent_index == 0 and self.local_rank == 0
 
-    def recv_reconfiguration_notification(self):
+    def recv_reconfiguration_notification(self) -> bool:
+        """
+        Block this thread until the agent sends a reconfiguration message.
+
+        Returns:
+            True if training requests immediate reconfiguration.
+            False if some agents wll be terminated after the iteration.
+        """
         try:
             message = self.pipe.recv()
-            assert (
-                message == "reconfigure"
-            ), f"Unexpected reconfiguration message: {message}"
+            if message == "immediate_reconfigure":
+                return True
+            elif message == "reconfigure":
+                return False
+
+            raise ValueError(f"Unexpected reconfiguration message: {message}")
         except Exception:
             # Corresponding agent died. This process should also die.
             os._exit(1)

--- a/oobleck/engine/configuration_engine.py
+++ b/oobleck/engine/configuration_engine.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import itertools
 import os
-import time
 from multiprocessing.connection import Connection
 from pathlib import Path
 

--- a/oobleck/engine/execution_engine.py
+++ b/oobleck/engine/execution_engine.py
@@ -1,7 +1,6 @@
 import itertools
 import math
 import os
-import time
 from concurrent.futures import ThreadPoolExecutor
 from threading import Thread
 from typing import Any, Callable, Iterator
@@ -246,7 +245,6 @@ class ExecutionEngine:
             if dist.is_initialized():
                 # If torch.distributed is still initialized, this means
                 # the configuration was not immediate and should be done now.
-                dist.barrier()
                 torch.cuda.synchronize()
                 self.on_receive_reconfiguration_notifiation()
             return None
@@ -291,9 +289,6 @@ class ExecutionEngine:
     ) -> tuple[nn.Module, Optimizer, DataLoader]:
         logger.info("Waiting for failure notification watcher to finish.")
         self.notification_receiver_thread.join()
-
-        logger.info("Start reconfiguration in 5 seconds...")
-        time.sleep(5)
 
         assert not dist.is_initialized()
         model, optimizer, dataloader, _ = self.plugin.reconfigure(

--- a/oobleck/engine/execution_engine.py
+++ b/oobleck/engine/execution_engine.py
@@ -1,6 +1,7 @@
 import itertools
 import math
 import os
+import time
 from concurrent.futures import ThreadPoolExecutor
 from threading import Thread
 from typing import Any, Callable, Iterator
@@ -289,6 +290,9 @@ class ExecutionEngine:
     ) -> tuple[nn.Module, Optimizer, DataLoader]:
         logger.info("Waiting for failure notification watcher to finish.")
         self.notification_receiver_thread.join()
+
+        logger.info("Start reconfiguration in 5 seconds...")
+        time.sleep(5)
 
         assert not dist.is_initialized()
         model, optimizer, dataloader, _ = self.plugin.reconfigure(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dev = [
     "datasets",
 ]
 
+[project.scripts]
+oobleck = "oobleck.cli:main"
+
 [tool.ruff]
 # Never enforce `E501` (line length violations).
 ignore = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 dependencies = [
     "torch",
     "transformers>=4.36.0",
-    "simple_parsing",
+    "click",
     "loguru",
     "fabric",
     # "oobleck-colossalai",


### PR DESCRIPTION
Abruptly killing an agent may end up being hung somewhere, as handling NCCL error is not fully supported in Oobleck yet.
As an alternative, this PR provides CLI to provide a way of gracefully terminating an agent.
The specified agent will be terminated after the current iteration is done.