### PR TITLE
PR 2: Add plan and context foundations

### DIFF
--- a/oobleck/config.py
+++ b/oobleck/config.py
@@ -1,0 +1,128 @@
+"""Serializable Tyro command configurations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class MasterServiceConfig:
+    host: str = "127.0.0.1"
+    port: int = 0
+    heartbeat_interval_s: float = 1.0
+    lease_timeout_s: float = 5.0
+    max_frame_bytes: int = 1 << 20
+    max_nodes: int = 16
+
+    def __post_init__(self) -> None:
+        if not self.host or not 0 <= self.port <= 65535:
+            raise ValueError("master host/port is invalid")
+        if self.heartbeat_interval_s <= 0 or self.lease_timeout_s <= self.heartbeat_interval_s:
+            raise ValueError("lease timeout must exceed the positive heartbeat interval")
+        if self.max_frame_bytes < 256 or self.max_nodes < 1:
+            raise ValueError("frame limit and max_nodes must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class AgentConfig:
+    node_id: str
+    master_host: str = "127.0.0.1"
+    master_port: int = 0
+    gpu_ids: tuple[str, ...] = ("0",)
+    local_worker_socket: Path | None = None
+    worker_script: Path | None = None
+    worker_args: tuple[str, ...] = ()
+    heartbeat_interval_s: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not self.node_id or not self.master_host or not 1 <= self.master_port <= 65535:
+            raise ValueError("agent identity and master address are required")
+        if not self.gpu_ids or len(set(self.gpu_ids)) != len(self.gpu_ids):
+            raise ValueError("gpu_ids must be non-empty and unique")
+        if self.heartbeat_interval_s <= 0:
+            raise ValueError("heartbeat_interval_s must be positive")
+        if self.worker_script is not None and self.local_worker_socket is None:
+            raise ValueError("worker_script requires local_worker_socket")
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingLaunchConfig:
+    training_script: Path
+    script_args: tuple[str, ...] = ()
+    max_nodes: int = 1
+    tensor_parallel_size: int = 1
+    initial_hostfile: Path | None = None
+    agent_script: Path | None = None
+    master_host: str = "127.0.0.1"
+    master_port: int = 0
+    remote_python: str = "python"
+    ssh_command: str = "ssh"
+    socket_directory: Path = Path("/tmp")
+
+    def __post_init__(self) -> None:
+        if self.max_nodes < 1 or self.tensor_parallel_size < 1:
+            raise ValueError("max_nodes and tensor_parallel_size must be positive")
+        if self.initial_hostfile is not None and (
+            self.agent_script is None or not self.master_host or not 1 <= self.master_port <= 65535
+        ):
+            raise ValueError("SSH bootstrap requires agent_script and a reachable master host/port")
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileCommandConfig:
+    output: Path
+    model: str
+    profile: Path | None = None
+    measurement_factory: str | None = None
+    profile_output: Path | None = None
+    dtype: str = "bfloat16"
+    tensor_parallel_size: int = 1
+    microbatch_size: int = 1
+    resource_counts: tuple[int, ...] = (1,)
+    hardware: str | None = None
+    cornstarch_version: str | None = None
+    warmup_steps: int = 2
+    measurement_steps: int = 5
+
+    def __post_init__(self) -> None:
+        if not self.model or self.tensor_parallel_size < 1 or self.microbatch_size < 1:
+            raise ValueError("profile model and parallel sizes are required")
+        if not self.resource_counts or any(item < 1 for item in self.resource_counts):
+            raise ValueError("resource_counts must contain positive values")
+        if self.profile is not None and self.measurement_factory is not None:
+            raise ValueError("provide either profile or measurement_factory, not both")
+        if self.warmup_steps < 0 or self.measurement_steps < 1:
+            raise ValueError("profiling step counts are invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class DrainConfig:
+    node_id: str
+    master_host: str = "127.0.0.1"
+    master_port: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.node_id or not self.master_host or not 1 <= self.master_port <= 65535:
+            raise ValueError("drain requires a node identity and master address")
+
+
+@dataclass(frozen=True, slots=True)
+class InspectMembershipConfig:
+    master_host: str = "127.0.0.1"
+    master_port: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.master_host or not 1 <= self.master_port <= 65535:
+            raise ValueError("membership inspection requires a master address")
+
+
+@dataclass(frozen=True, slots=True)
+class ChaosConfig:
+    target_node_id: str
+    pid: int = 0
+    confirmation: str = ""
+
+    def __post_init__(self) -> None:
+        if self.pid < 1 or self.confirmation != f"FAIL:{self.target_node_id}":
+            raise ValueError("pid must be positive and confirmation must be FAIL:<node-id>")

--- a/oobleck/cornstarch.py
+++ b/oobleck/cornstarch.py
@@ -1,0 +1,171 @@
+"""Lazy boundary around Cornstarch's compile/activate partition lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from oobleck.meshes import create_heterogeneous_pipeline_meshes
+from oobleck.state import LogicalStateEntry, StateManifest
+from oobleck.types import OobleckExecutionPlan, PipelineStageSpec
+
+
+def _fallback_manifest(model: torch.nn.Module, rank: int, committed_step: int = 0) -> StateManifest:
+    entries = []
+    for kind, values in (
+        ("parameter", model.named_parameters(recurse=True)),
+        ("buffer", model.named_buffers(recurse=True)),
+    ):
+        for name, value in values:
+            entries.append(
+                LogicalStateEntry(
+                    name,
+                    tuple(value.shape),
+                    tuple(value.shape),
+                    str(value.dtype),
+                    kind,
+                    ("replicate",),
+                    0,
+                    rank,
+                    committed_step,
+                )
+            )
+    return StateManifest(rank, tuple(entries), committed_step)
+
+
+def _external_manifest(value: Any, rank: int, committed_step: int = 0) -> StateManifest:
+    entries = []
+    for item in value.entries:
+        entries.append(
+            LogicalStateEntry(
+                item.logical_key,
+                tuple(item.global_shape),
+                tuple(item.local_shape),
+                str(item.dtype),
+                item.state_kind,
+                tuple(item.placements),
+                int(item.tp_lane),
+                rank,
+                committed_step,
+                None if item.global_layer_id is None else str(item.global_layer_id),
+                item.shared_state_id,
+            )
+        )
+    return StateManifest(rank, tuple(entries), committed_step)
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledLocalPartition:
+    root_model: torch.nn.Module
+    rank: int
+    world_size: int
+    stage_spec: PipelineStageSpec
+    manifest: StateManifest
+    execution_plan: OobleckExecutionPlan
+    external_compiled: Any = None
+
+    def activate(
+        self,
+        device: str | torch.device,
+        dtype: torch.dtype | None = None,
+        *,
+        mesh: Any = None,
+    ) -> "ActivatedPartition":
+        if self.external_compiled is not None:
+            all_meshes = None
+            if mesh is None and self.world_size > 1:
+                all_meshes, mesh = create_heterogeneous_pipeline_meshes(
+                    self.execution_plan,
+                    device_type=torch.device(device).type,
+                )
+            external = self.external_compiled.activate(device=device, dtype=dtype, mesh=mesh)
+            model = getattr(external, "model", self.root_model)
+            manifest_value = getattr(external, "local_state_manifest", None)
+            manifest = (
+                self.manifest
+                if manifest_value is None
+                else _external_manifest(manifest_value, self.rank)
+            )
+            return ActivatedPartition(self, model, external, manifest, all_meshes)
+        target = torch.device(device)
+        parameters = tuple(self.root_model.parameters())
+        if parameters and any(parameter.is_meta for parameter in parameters):
+            self.root_model.to_empty(device=target)
+            initializer = getattr(self.root_model, "initialize_checkpoint", None)
+            if callable(initializer):
+                initializer()
+        else:
+            self.root_model.to(device=target, dtype=dtype)
+        return ActivatedPartition(self, self.root_model, manifest=self.manifest)
+
+
+class ActivatedPartition:
+    def __init__(
+        self,
+        compiled: CompiledLocalPartition,
+        model: torch.nn.Module,
+        external_context: Any = None,
+        manifest: StateManifest | None = None,
+        all_meshes: dict[str, Any] | None = None,
+    ) -> None:
+        self.compiled = compiled
+        self.model = model
+        self.external_context = external_context
+        self.manifest = manifest or compiled.manifest
+        self.all_meshes = all_meshes or {}
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if self.external_context is not None:
+            closer = getattr(self.external_context, "close", None)
+            if callable(closer):
+                closer()
+        self.external_context = None
+        self.all_meshes.clear()
+        self._closed = True
+
+
+def compile_local_partition(
+    model: torch.nn.Module,
+    parallel_config: object,
+    execution_plan: OobleckExecutionPlan,
+    rank: int,
+    *,
+    cornstarch_plan: object | None = None,
+) -> CompiledLocalPartition:
+    """Compile ownership without touching ``torch.distributed`` or real storage."""
+
+    stage = execution_plan.rank_local_stage(rank)
+    external = None
+    manifest = _fallback_manifest(model, rank)
+    if cornstarch_plan is not None:
+        compiler = getattr(cornstarch_plan, "compile", None)
+        if compiler is None:
+            raise RuntimeError(
+                "The installed Cornstarch does not expose compile(). Install the "
+                "pinned refactor-oobleck commit rather than a moving branch."
+            )
+        external = compiler(
+            world_size=sum(len(ranks) for _, ranks in execution_plan.rank_map),
+            rank=rank,
+            stage_overrides=(stage,),
+        )
+        if hasattr(external, "local_state_manifest"):
+            manifest = _external_manifest(external.local_state_manifest, rank)
+    return CompiledLocalPartition(
+        model,
+        rank,
+        sum(len(ranks) for _, ranks in execution_plan.rank_map),
+        stage,
+        manifest,
+        execution_plan,
+        external,
+    )

--- a/oobleck/cornstarch_base.py
+++ b/oobleck/cornstarch_base.py
@@ -1,0 +1,129 @@
+"""Lazy boundary around Cornstarch's compile/activate partition lifecycle."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from oobleck.state import LogicalStateEntry, StateManifest
+from oobleck.types import OobleckExecutionPlan, PipelineStageSpec
+
+
+def _local_manifest(model: torch.nn.Module, rank: int, committed_step: int = 0) -> StateManifest:
+    entries = []
+    for kind, values in (
+        ("parameter", model.named_parameters(recurse=True)),
+        ("buffer", model.named_buffers(recurse=True)),
+    ):
+        for name, value in values:
+            entries.append(
+                LogicalStateEntry(
+                    logical_key=name,
+                    global_shape=tuple(value.shape),
+                    local_shape=tuple(value.shape),
+                    dtype=str(value.dtype),
+                    state_kind=kind,
+                    placements=("replicate",),
+                    tp_lane=0,
+                    owner_rank=rank,
+                    version=committed_step,
+                )
+            )
+    return StateManifest(rank, tuple(entries), committed_step)
+
+
+@dataclass(frozen=True, slots=True)
+class CompiledLocalPartition:
+    """Process-group-independent rank-local ownership description."""
+
+    root_model: torch.nn.Module
+    rank: int
+    world_size: int
+    stage_spec: PipelineStageSpec
+    manifest: StateManifest
+    external_compiled: Any = None
+
+    def activate(
+        self,
+        device: str | torch.device,
+        dtype: torch.dtype | None = None,
+        *,
+        mesh: Any = None,
+    ) -> "ActivatedPartition":
+        if self.external_compiled is not None:
+            external = self.external_compiled.activate(device=device, dtype=dtype, mesh=mesh)
+            model = getattr(external, "model", self.root_model)
+            return ActivatedPartition(self, model, external)
+        target = torch.device(device)
+        parameters = tuple(self.root_model.parameters())
+        if parameters and any(parameter.is_meta for parameter in parameters):
+            self.root_model.to_empty(device=target)
+            initializer = getattr(self.root_model, "initialize_checkpoint", None)
+            if callable(initializer):
+                initializer()
+        else:
+            self.root_model.to(device=target, dtype=dtype)
+        return ActivatedPartition(self, self.root_model)
+
+
+class ActivatedPartition:
+    def __init__(
+        self,
+        compiled: CompiledLocalPartition,
+        model: torch.nn.Module,
+        external_context: Any = None,
+    ) -> None:
+        self.compiled = compiled
+        self.model = model
+        self.external_context = external_context
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if self.external_context is not None:
+            closer = getattr(self.external_context, "close", None)
+            if callable(closer):
+                closer()
+        self.external_context = None
+        self._closed = True
+
+
+def compile_local_partition(
+    model: torch.nn.Module,
+    parallel_config: object,
+    execution_plan: OobleckExecutionPlan,
+    rank: int,
+    *,
+    cornstarch_plan: object | None = None,
+) -> CompiledLocalPartition:
+    """Compile ownership without touching ``torch.distributed`` or real storage."""
+
+    stage = execution_plan.rank_local_stage(rank)
+    external = None
+    if cornstarch_plan is not None:
+        compiler = getattr(cornstarch_plan, "compile", None)
+        if compiler is None:
+            raise RuntimeError(
+                "The installed Cornstarch does not expose compile(). Install the "
+                "pinned refactor-oobleck commit rather than a moving branch."
+            )
+        external = compiler(
+            world_size=sum(len(ranks) for _, ranks in execution_plan.rank_map),
+            rank=rank,
+            stage_overrides=(stage,),
+        )
+    return CompiledLocalPartition(
+        model,
+        rank,
+        sum(len(ranks) for _, ranks in execution_plan.rank_map),
+        stage,
+        _local_manifest(model, rank),
+        external,
+    )

--- a/oobleck/data.py
+++ b/oobleck/data.py
@@ -1,0 +1,36 @@
+"""Public replayable DataLoader API with strict attachment validation."""
+
+from __future__ import annotations
+
+from torch.utils.data import DataLoader
+
+from oobleck.data_base import (
+    OobleckBatch,
+    OobleckBatchDescriptor,
+    OobleckBatchSampler,
+    PipelineBatchAssignment,
+    PreparedDataLoader,
+    logical_seed,
+)
+from oobleck.data_base import prepare_dataloader as _prepare_dataloader
+
+
+def prepare_dataloader(dataloader: DataLoader) -> PreparedDataLoader:
+    sampler = getattr(dataloader, "batch_sampler", None)
+    if isinstance(sampler, OobleckBatchSampler) and sampler.dataset is not dataloader.dataset:
+        raise ValueError(
+            "OobleckBatchSampler was created for a different dataset object than "
+            "the DataLoader; attach it to the exact stable map-style dataset"
+        )
+    return _prepare_dataloader(dataloader)
+
+
+__all__ = [
+    "OobleckBatch",
+    "OobleckBatchDescriptor",
+    "OobleckBatchSampler",
+    "PipelineBatchAssignment",
+    "PreparedDataLoader",
+    "logical_seed",
+    "prepare_dataloader",
+]

--- a/oobleck/data_base.py
+++ b/oobleck/data_base.py
@@ -1,0 +1,292 @@
+"""Replayable logical batches on top of a standard PyTorch DataLoader."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Iterator, Mapping, Sequence
+
+import torch
+from torch.utils.data import BatchSampler, DataLoader, IterableDataset
+
+from oobleck.types import PipelineInstance
+
+
+def logical_seed(seed: int, *keys: object) -> int:
+    """Derive a stable 63-bit RNG seed from logical, not physical, identity."""
+
+    digest = hashlib.sha256(
+        "\x1f".join([str(seed), *(str(key) for key in keys)]).encode("utf-8")
+    ).digest()
+    return int.from_bytes(digest[:8], "big") & ((1 << 63) - 1)
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineBatchAssignment:
+    pipeline_id: str
+    sample_indices: tuple[int, ...]
+    global_microbatch_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OobleckBatchDescriptor:
+    epoch: int
+    logical_batch_id: int
+    sample_indices: tuple[int, ...]
+    assignments: tuple[PipelineBatchAssignment, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OobleckBatch:
+    descriptor: OobleckBatchDescriptor
+    microbatches: tuple[Any, ...]
+
+    @property
+    def sample_indices(self) -> tuple[int, ...]:
+        return self.descriptor.sample_indices
+
+    @property
+    def logical_batch_id(self) -> int:
+        return self.descriptor.logical_batch_id
+
+
+class OobleckBatchSampler(BatchSampler):
+    """Deterministic sampler whose cursor advances only after step commit."""
+
+    def __init__(
+        self,
+        dataset: object,
+        *,
+        global_batch_size: int,
+        microbatch_size: int,
+        instances: Sequence[PipelineInstance],
+        seed: int,
+        shuffle: bool,
+        drop_last: bool = True,
+    ) -> None:
+        _validate_dataset(dataset)
+        if global_batch_size < 1 or microbatch_size < 1:
+            raise ValueError("batch sizes must be positive")
+        if global_batch_size % microbatch_size:
+            raise ValueError("global_batch_size must be divisible by microbatch_size")
+        if not instances:
+            raise ValueError("at least one pipeline instance is required")
+        allocated = sum(item.microbatches for item in instances)
+        if allocated != global_batch_size // microbatch_size:
+            raise ValueError(
+                f"pipeline allocation contains {allocated} microbatches; expected "
+                f"{global_batch_size // microbatch_size}"
+            )
+        self.dataset = dataset
+        self.global_batch_size = global_batch_size
+        self.microbatch_size = microbatch_size
+        self.instances = tuple(instances)
+        self.seed = seed
+        self.shuffle = shuffle
+        self.drop_last = drop_last
+        self.epoch = 0
+        self._committed_cursor = 0
+        self._issued: dict[int, OobleckBatchDescriptor] = {}
+
+    @property
+    def committed_cursor(self) -> int:
+        return self._committed_cursor
+
+    def set_epoch(self, epoch: int) -> None:
+        if epoch < 0:
+            raise ValueError("epoch must be non-negative")
+        if self._committed_cursor and epoch != self.epoch:
+            raise RuntimeError("cannot change epoch with an unconsumed committed cursor")
+        self.epoch = epoch
+        self._committed_cursor = 0
+        self._issued.clear()
+
+    def _permutation(self) -> list[int]:
+        size = len(self.dataset)  # type: ignore[arg-type]
+        if not self.shuffle:
+            return list(range(size))
+        generator = torch.Generator()
+        generator.manual_seed(logical_seed(self.seed, "sampler", self.epoch))
+        return torch.randperm(size, generator=generator).tolist()
+
+    def descriptor_at(self, batch_index: int) -> OobleckBatchDescriptor:
+        if batch_index < 0 or batch_index >= len(self):
+            raise IndexError(batch_index)
+        logical_id = batch_index
+        cached = self._issued.get(logical_id)
+        if cached is not None:
+            return cached
+        permutation = self._permutation()
+        start = batch_index * self.global_batch_size
+        indices = permutation[start : start + self.global_batch_size]
+        if len(indices) < self.global_batch_size and self.drop_last:
+            raise IndexError(batch_index)
+        assignments = []
+        sample_cursor = 0
+        microbatch_cursor = 0
+        for instance in self.instances:
+            sample_count = instance.microbatches * self.microbatch_size
+            assigned = tuple(indices[sample_cursor : sample_cursor + sample_count])
+            assignments.append(
+                PipelineBatchAssignment(
+                    instance.instance_id,
+                    assigned,
+                    tuple(
+                        range(
+                            microbatch_cursor,
+                            microbatch_cursor + instance.microbatches,
+                        )
+                    ),
+                )
+            )
+            sample_cursor += sample_count
+            microbatch_cursor += instance.microbatches
+        descriptor = OobleckBatchDescriptor(
+            self.epoch, logical_id, tuple(indices), tuple(assignments)
+        )
+        self._issued[logical_id] = descriptor
+        return descriptor
+
+    def __iter__(self) -> Iterator[list[int]]:
+        # Prefetch may advance this iterator arbitrarily far.  The committed
+        # cursor is deliberately untouched and a fresh iterator starts there.
+        for index in range(self._committed_cursor, len(self)):
+            yield list(self.descriptor_at(index).sample_indices)
+
+    def __len__(self) -> int:
+        size = len(self.dataset)  # type: ignore[arg-type]
+        if self.drop_last:
+            return size // self.global_batch_size
+        return (size + self.global_batch_size - 1) // self.global_batch_size
+
+    def commit(self, descriptor: OobleckBatchDescriptor) -> None:
+        if descriptor.epoch != self.epoch:
+            raise RuntimeError("cannot commit a batch from a stale epoch")
+        if descriptor.logical_batch_id != self._committed_cursor:
+            raise RuntimeError(
+                f"out-of-order batch commit: got {descriptor.logical_batch_id}, "
+                f"expected {self._committed_cursor}"
+            )
+        expected = self.descriptor_at(self._committed_cursor)
+        if descriptor != expected:
+            raise RuntimeError("batch descriptor does not match deterministic sampler state")
+        self._committed_cursor += 1
+        self._issued.pop(descriptor.logical_batch_id, None)
+
+    def rewind_uncommitted(self) -> None:
+        self._issued = {
+            key: value for key, value in self._issued.items() if key < self._committed_cursor
+        }
+
+    def reconfigure(self, instances: Sequence[PipelineInstance]) -> None:
+        selected = tuple(instances)
+        allocated = sum(item.microbatches for item in selected)
+        expected = self.global_batch_size // self.microbatch_size
+        if not selected or allocated != expected:
+            raise ValueError(
+                f"new pipeline allocation contains {allocated} microbatches; expected {expected}"
+            )
+        self.instances = selected
+        self.rewind_uncommitted()
+
+
+def _validate_dataset(dataset: object) -> None:
+    if isinstance(dataset, IterableDataset):
+        raise TypeError(
+            "Oobleck requires a stable map-style Dataset; streaming and other "
+            "IterableDataset instances need a durable cursor protocol"
+        )
+    if dataset.__class__.__name__ == "DatasetDict" or (
+        isinstance(dataset, Mapping)
+        and all(isinstance(key, str) for key in dataset)
+        and not hasattr(dataset, "column_names")
+    ):
+        raise TypeError(
+            "A DatasetDict is not a sample dataset. Select a split, for example "
+            "dataset['train'] or load_dataset(..., split='train')."
+        )
+    if not hasattr(dataset, "__len__") or not hasattr(dataset, "__getitem__"):
+        raise TypeError("dataset must implement stable __len__ and indexed __getitem__")
+
+
+def _slice_collated(value: Any, start: int, end: int, total: int) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _slice_collated(item, start, end, total) for key, item in value.items()}
+    if isinstance(value, tuple) and len(value) == total:
+        return value[start:end]
+    if isinstance(value, list) and len(value) == total:
+        return value[start:end]
+    if isinstance(value, torch.Tensor) and value.ndim and value.shape[0] == total:
+        return value[start:end]
+    return value
+
+
+def _normalize_microbatches(
+    collated: Any, descriptor: OobleckBatchDescriptor, microbatch_size: int
+) -> tuple[Any, ...]:
+    count = sum(len(item.global_microbatch_ids) for item in descriptor.assignments)
+    if isinstance(collated, list) and len(collated) == count:
+        return tuple(collated)
+    total = len(descriptor.sample_indices)
+    return tuple(
+        _slice_collated(
+            collated,
+            index * microbatch_size,
+            min((index + 1) * microbatch_size, total),
+            total,
+        )
+        for index in range(count)
+    )
+
+
+class PreparedDataLoader:
+    """Ordered adapter that pairs DataLoader results with logical descriptors."""
+
+    def __init__(self, dataloader: DataLoader, sampler: OobleckBatchSampler) -> None:
+        self.dataloader = dataloader
+        self.sampler = sampler
+        self._invalidated = False
+
+    def invalidate_prefetch(self) -> None:
+        self._invalidated = True
+        self.sampler.rewind_uncommitted()
+
+    def reconfigure(self, instances: Sequence[PipelineInstance]) -> None:
+        self.invalidate_prefetch()
+        self.sampler.reconfigure(instances)
+
+    def __iter__(self) -> Iterator[OobleckBatch]:
+        self._invalidated = False
+        start = self.sampler.committed_cursor
+        for offset, collated in enumerate(iter(self.dataloader)):
+            if self._invalidated:
+                return
+            descriptor = self.sampler.descriptor_at(start + offset)
+            yield OobleckBatch(
+                descriptor,
+                _normalize_microbatches(collated, descriptor, self.sampler.microbatch_size),
+            )
+
+    def __len__(self) -> int:
+        return max(0, len(self.sampler) - self.sampler.committed_cursor)
+
+
+def prepare_dataloader(dataloader: DataLoader) -> PreparedDataLoader:
+    if not isinstance(dataloader, DataLoader):
+        raise TypeError("prepare_dataloader expects torch.utils.data.DataLoader")
+    _validate_dataset(dataloader.dataset)
+    sampler = dataloader.batch_sampler
+    if not isinstance(sampler, OobleckBatchSampler):
+        raise TypeError(
+            "DataLoader must use the OobleckBatchSampler returned by "
+            "context.create_batch_sampler() via batch_sampler="
+        )
+    if dataloader.persistent_workers:
+        raise ValueError(
+            "persistent_workers must be False so failed prefetch workers can be "
+            "discarded and deterministically recreated"
+        )
+    generator = torch.Generator()
+    generator.manual_seed(logical_seed(sampler.seed, "dataloader", sampler.epoch))
+    dataloader.generator = generator
+    return PreparedDataLoader(dataloader, sampler)

--- a/oobleck/types.py
+++ b/oobleck/types.py
@@ -1,0 +1,376 @@
+"""Public, serializable value types for the refactored Oobleck runtime.
+
+This module intentionally has no Cornstarch or ``torch.distributed`` imports.  A
+generation can therefore be validated and rank-local ownership can be compiled
+before WORLD exists.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping, Sequence
+
+
+class RecoveryUnavailable(RuntimeError):
+    """The available resources cannot form a valid resilient configuration."""
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
+        "utf-8"
+    )
+
+
+def checksum(value: Any) -> str:
+    """Return a stable SHA-256 checksum for a JSON-compatible value."""
+
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class CompatibilityFingerprint:
+    model: str
+    dtype: str
+    tensor_parallel_size: int
+    hardware: str
+    cornstarch_version: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.tensor_parallel_size < 1:
+            raise ValueError("tensor_parallel_size must be >= 1")
+        if self.schema_version != 1:
+            raise ValueError(
+                f"Unsupported template schema version {self.schema_version}; expected 1"
+            )
+
+    @property
+    def digest(self) -> str:
+        return checksum(asdict(self))
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCompatibility:
+    """Exact software, model, input, and hardware contract for one job."""
+
+    oobleck_commit: str
+    cornstarch_commit: str
+    torch_version: str
+    cuda_version: str | None
+    nccl_version: str | None
+    model_fingerprint: str
+    template_schema_version: int
+    optimizer_schema_version: int
+    datasets_version: str
+    dataset_fingerprint: str
+    hardware_fingerprint: str
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        required = (
+            self.oobleck_commit,
+            self.cornstarch_commit,
+            self.torch_version,
+            self.model_fingerprint,
+            self.datasets_version,
+            self.dataset_fingerprint,
+            self.hardware_fingerprint,
+        )
+        if any(not value for value in required):
+            raise ValueError("runtime compatibility fields must not be empty")
+        if self.template_schema_version < 1 or self.optimizer_schema_version < 1:
+            raise ValueError("schema versions must be positive")
+        if self.schema_version != 1:
+            raise ValueError(f"unsupported runtime compatibility schema {self.schema_version}")
+
+    @property
+    def digest(self) -> str:
+        return checksum(asdict(self))
+
+    def assert_matches(self, other: "RuntimeCompatibility") -> None:
+        if self != other:
+            left = asdict(self)
+            right = asdict(other)
+            mismatches = [key for key in left if left[key] != right[key]]
+            raise ValueError(
+                "runtime compatibility mismatch in "
+                f"{', '.join(mismatches)} (local={self.digest}, plan={other.digest})"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineStageSpec:
+    """Global layer ownership for one pipeline stage.
+
+    ``layer_start`` is inclusive and ``layer_end`` is exclusive.  Rank order is
+    TP-lane order and remains meaningful even before process groups exist.
+    """
+
+    pipeline_id: str
+    stage_id: int
+    layer_start: int
+    layer_end: int
+    ranks: tuple[int, ...]
+    is_first: bool = False
+    is_last: bool = False
+    tied_parameter_owner: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.pipeline_id:
+            raise ValueError("pipeline_id must not be empty")
+        if self.stage_id < 0:
+            raise ValueError("stage_id must be >= 0")
+        if self.layer_start < 0 or self.layer_end <= self.layer_start:
+            raise ValueError("stage layer range must be non-empty and increasing")
+        if not self.ranks or len(set(self.ranks)) != len(self.ranks):
+            raise ValueError("ranks must be a non-empty sequence of unique ranks")
+        if any(rank < 0 for rank in self.ranks):
+            raise ValueError("ranks must be non-negative")
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineTemplate:
+    """A profiled pipeline layout independent of concrete nodes and ranks."""
+
+    template_id: str
+    layer_ranges: tuple[tuple[int, int], ...]
+    tensor_parallel_size: int
+    forward_time: float
+    backward_time: float
+    communication_time: float = 0.0
+    activation_memory: int = 0
+    persistent_memory: int = 0
+    max_microbatches: int | None = None
+    fingerprint: CompatibilityFingerprint | None = None
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if not self.template_id:
+            raise ValueError("template_id must not be empty")
+        if self.schema_version != 1:
+            raise ValueError(
+                f"Unsupported template schema version {self.schema_version}; expected 1"
+            )
+        if not self.layer_ranges:
+            raise ValueError("a pipeline template must contain at least one stage")
+        previous_end: int | None = None
+        for start, end in self.layer_ranges:
+            if start < 0 or end <= start:
+                raise ValueError("layer ranges must be non-empty and increasing")
+            if previous_end is not None and start != previous_end:
+                raise ValueError("layer ranges must be contiguous and ordered")
+            previous_end = end
+        if self.tensor_parallel_size < 1:
+            raise ValueError("tensor_parallel_size must be >= 1")
+        for name in ("forward_time", "backward_time", "communication_time"):
+            if not math.isfinite(getattr(self, name)) or getattr(self, name) < 0:
+                raise ValueError(f"{name} must be finite and non-negative")
+        if self.activation_memory < 0 or self.persistent_memory < 0:
+            raise ValueError("memory requirements must be non-negative")
+        if self.max_microbatches is not None and self.max_microbatches < 1:
+            raise ValueError("max_microbatches must be >= 1 when supplied")
+
+    @property
+    def num_stages(self) -> int:
+        return len(self.layer_ranges)
+
+    @property
+    def resource_count(self) -> int:
+        """Number of homogeneous nodes required by this template."""
+
+        return self.num_stages
+
+    def iteration_time(self, microbatches: int) -> float:
+        if microbatches < 0:
+            raise ValueError("microbatches must be non-negative")
+        if self.max_microbatches is not None and microbatches > self.max_microbatches:
+            return math.inf
+        if microbatches == 0:
+            return 0.0
+        # Flush time plus steady-state work.  This deliberately uses only the
+        # serialized profile and is deterministic across workers.
+        stage_work = self.forward_time + self.backward_time
+        bubble = max(0, self.num_stages - 1) * stage_work
+        return bubble + microbatches * stage_work + self.communication_time
+
+    def assert_compatible(self, fingerprint: CompatibilityFingerprint) -> None:
+        if self.fingerprint is None:
+            raise ValueError(f"Template {self.template_id!r} has no compatibility fingerprint")
+        if self.fingerprint != fingerprint:
+            raise ValueError(
+                "Pipeline template fingerprint mismatch: "
+                f"cached={self.fingerprint.digest}, requested={fingerprint.digest}. "
+                "Regenerate the profile/template cache."
+            )
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["layer_ranges"] = [list(item) for item in self.layer_ranges]
+        return result
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "PipelineTemplate":
+        data = dict(value)
+        data["layer_ranges"] = tuple(tuple(item) for item in data["layer_ranges"])
+        fingerprint = data.get("fingerprint")
+        if fingerprint is not None and not isinstance(fingerprint, CompatibilityFingerprint):
+            data["fingerprint"] = CompatibilityFingerprint(**fingerprint)
+        return cls(**data)
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineInstance:
+    instance_id: str
+    template: PipelineTemplate
+    node_ids: tuple[str, ...]
+    ranks: tuple[tuple[int, ...], ...] = ()
+    microbatches: int = 0
+
+    def __post_init__(self) -> None:
+        if not self.instance_id:
+            raise ValueError("instance_id must not be empty")
+        if len(self.node_ids) != self.template.num_stages:
+            raise ValueError("node count must equal the selected template's stage count")
+        if len(set(self.node_ids)) != len(self.node_ids):
+            raise ValueError("a node may appear only once in a pipeline")
+        if self.ranks and len(self.ranks) != self.template.num_stages:
+            raise ValueError("rank groups must contain one entry per stage")
+        if any(len(group) != self.template.tensor_parallel_size for group in self.ranks):
+            raise ValueError("every stage rank group must match tensor_parallel_size")
+        if self.microbatches < 0:
+            raise ValueError("microbatches must be non-negative")
+
+    @property
+    def stage_specs(self) -> tuple[PipelineStageSpec, ...]:
+        if not self.ranks:
+            return ()
+        return tuple(
+            PipelineStageSpec(
+                pipeline_id=self.instance_id,
+                stage_id=index,
+                layer_start=layer_range[0],
+                layer_end=layer_range[1],
+                ranks=self.ranks[index],
+                is_first=index == 0,
+                is_last=index == self.template.num_stages - 1,
+            )
+            for index, layer_range in enumerate(self.template.layer_ranges)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class OobleckExecutionPlan:
+    """Checksummed, immutable topology for one membership generation."""
+
+    generation: int
+    instances: tuple[PipelineInstance, ...]
+    rank_map: tuple[tuple[str, tuple[int, ...]], ...]
+    previous_generation: int | None = None
+    compatibility_digest: str | None = None
+    plan_checksum: str = field(default="", compare=False)
+
+    def __post_init__(self) -> None:
+        if self.generation < 0:
+            raise ValueError("generation must be non-negative")
+        if self.previous_generation is not None and self.previous_generation >= self.generation:
+            raise ValueError("previous_generation must be smaller than generation")
+        node_ids = [node for node, _ in self.rank_map]
+        if len(node_ids) != len(set(node_ids)):
+            raise ValueError("rank_map node IDs must be unique")
+        ranks = [rank for _, group in self.rank_map for rank in group]
+        if len(ranks) != len(set(ranks)) or any(rank < 0 for rank in ranks):
+            raise ValueError("rank_map must assign every non-negative rank once")
+        instance_nodes = [node for instance in self.instances for node in instance.node_ids]
+        if sorted(instance_nodes) != sorted(node_ids):
+            raise ValueError("pipeline instances must assign every rank-map node once")
+        expected = checksum(self._unsigned_dict())
+        if self.plan_checksum and self.plan_checksum != expected:
+            raise ValueError("execution plan checksum is invalid")
+        object.__setattr__(self, "plan_checksum", expected)
+
+    def _unsigned_dict(self) -> dict[str, Any]:
+        return {
+            "generation": self.generation,
+            "previous_generation": self.previous_generation,
+            "compatibility_digest": self.compatibility_digest,
+            "rank_map": [[node, list(ranks)] for node, ranks in self.rank_map],
+            "instances": [
+                {
+                    "instance_id": item.instance_id,
+                    "template": item.template.to_dict(),
+                    "node_ids": list(item.node_ids),
+                    "ranks": [list(group) for group in item.ranks],
+                    "microbatches": item.microbatches,
+                }
+                for item in self.instances
+            ],
+        }
+
+    def rank_local_stage(self, rank: int) -> PipelineStageSpec:
+        for instance in self.instances:
+            for spec in instance.stage_specs:
+                if rank in spec.ranks:
+                    return spec
+        raise KeyError(f"rank {rank} is not assigned to this generation")
+
+
+@dataclass(frozen=True, slots=True)
+class OobleckConfig:
+    global_batch_size: int
+    microbatch_size: int
+    fault_tolerance_threshold: int = 0
+    max_nodes: int = 1
+    seed: int = 0
+    heartbeat_interval_s: float = 1.0
+    lease_timeout_s: float = 5.0
+    max_control_frame_bytes: int = 1 << 20
+    state_transfer_chunk_bytes: int = 64 << 20
+    state_transfer_round_bytes: int = 256 << 20
+    transfer_alignment_bytes: int = 256
+
+    def __post_init__(self) -> None:
+        if self.global_batch_size < 1 or self.microbatch_size < 1:
+            raise ValueError("global_batch_size and microbatch_size must be >= 1")
+        if self.global_batch_size % self.microbatch_size:
+            raise ValueError("global_batch_size must be divisible by microbatch_size")
+        if self.fault_tolerance_threshold < 0:
+            raise ValueError("fault_tolerance_threshold must be non-negative")
+        if self.max_nodes < 1:
+            raise ValueError("max_nodes must be >= 1")
+        if self.heartbeat_interval_s <= 0:
+            raise ValueError("heartbeat_interval_s must be positive")
+        if self.lease_timeout_s <= self.heartbeat_interval_s:
+            raise ValueError("lease_timeout_s must exceed heartbeat_interval_s")
+        if self.max_control_frame_bytes < 256:
+            raise ValueError("max_control_frame_bytes must be >= 256")
+        if self.state_transfer_chunk_bytes < 1:
+            raise ValueError("state_transfer_chunk_bytes must be positive")
+        if self.state_transfer_round_bytes < self.state_transfer_chunk_bytes:
+            raise ValueError(
+                "state_transfer_round_bytes must be at least state_transfer_chunk_bytes"
+            )
+        if self.transfer_alignment_bytes < 1:
+            raise ValueError("transfer_alignment_bytes must be positive")
+
+    @property
+    def global_num_microbatches(self) -> int:
+        return self.global_batch_size // self.microbatch_size
+
+
+def stable_rank_map(
+    node_ids: Sequence[str], tensor_parallel_size: int
+) -> tuple[tuple[str, tuple[int, ...]], ...]:
+    if tensor_parallel_size < 1:
+        raise ValueError("tensor_parallel_size must be >= 1")
+    if len(set(node_ids)) != len(node_ids):
+        raise ValueError("node IDs must be unique")
+    return tuple(
+        (
+            node,
+            tuple(range(index * tensor_parallel_size, (index + 1) * tensor_parallel_size)),
+        )
+        for index, node in enumerate(sorted(node_ids))
+    )


### PR DESCRIPTION
## Summary

- adds serializable runtime, template, stage, instance, execution-plan, and compatibility types
- adds validated Oobleck and Tyro command configuration
- adds deterministic replayable batch/DataLoader primitives
- adds process-group-independent Cornstarch compile and activation adapters

## Validation

- compileall over all added modules
- public type/config/data smoke assertions
- git diff --cached --check

Targets only refactor.