### PR TITLE
PR 5: Add asyncio elastic control plane

### DIFF
--- a/oobleck/elastic/__init__.py
+++ b/oobleck/elastic/__init__.py
@@ -1,0 +1,57 @@
+from oobleck.elastic.membership import (
+    IncarnationMismatch,
+    MembershipSnapshot,
+    MembershipStateMachine,
+    NodeIdentity,
+    StaleGeneration,
+    StaleSequence,
+)
+from oobleck.elastic.hostfile import InitialHost, load_initial_hostfile, ssh_agent_command
+from oobleck.elastic.local_ipc import LocalWorkerClient, LocalWorkerRelay
+from oobleck.elastic.service import (
+    MasterControlService,
+    NodeAgentClient,
+    inspect_membership,
+    request_drain,
+)
+from oobleck.elastic.transport import (
+    AsyncioTcpControlTransport,
+    ControlConnection,
+    ControlTransport,
+    FrameTooLarge,
+    MessageEnvelope,
+    ProtocolError,
+    encode_frame,
+    read_frame,
+    write_frame,
+)
+from oobleck.elastic.workers import LocalWorkerSupervisor, run_agent_service
+
+__all__ = [
+    "AsyncioTcpControlTransport",
+    "ControlConnection",
+    "ControlTransport",
+    "FrameTooLarge",
+    "IncarnationMismatch",
+    "InitialHost",
+    "MasterControlService",
+    "LocalWorkerClient",
+    "LocalWorkerRelay",
+    "LocalWorkerSupervisor",
+    "MembershipSnapshot",
+    "MembershipStateMachine",
+    "MessageEnvelope",
+    "NodeAgentClient",
+    "NodeIdentity",
+    "ProtocolError",
+    "StaleGeneration",
+    "StaleSequence",
+    "encode_frame",
+    "read_frame",
+    "write_frame",
+    "inspect_membership",
+    "load_initial_hostfile",
+    "request_drain",
+    "run_agent_service",
+    "ssh_agent_command",
+]

--- a/oobleck/elastic/hostfile.py
+++ b/oobleck/elastic/hostfile.py
@@ -1,0 +1,85 @@
+"""Optional bootstrap-only SSH host inventory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True, slots=True)
+class InitialHost:
+    node_id: str
+    address: str
+    gpu_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.node_id or not self.address or not self.gpu_ids:
+            raise ValueError("hostfile node_id, address, and gpu_ids are required")
+        if len(self.gpu_ids) != len(set(self.gpu_ids)):
+            raise ValueError(f"hostfile node {self.node_id!r} has duplicate GPU IDs")
+
+
+def load_initial_hostfile(path: str | Path) -> tuple[InitialHost, ...]:
+    """Parse ``NODE_ID ADDRESS GPU[,GPU...]`` bootstrap records."""
+
+    target = Path(path)
+    hosts = []
+    for line_number, raw in enumerate(target.read_text().splitlines(), 1):
+        value = raw.split("#", 1)[0].strip()
+        if not value:
+            continue
+        fields = value.split()
+        if len(fields) != 3:
+            raise ValueError(f"{target}:{line_number}: expected NODE_ID ADDRESS GPU[,GPU...]")
+        hosts.append(InitialHost(fields[0], fields[1], tuple(fields[2].split(","))))
+    if not hosts:
+        raise ValueError(f"initial hostfile {target} contains no nodes")
+    node_ids = [item.node_id for item in hosts]
+    if len(node_ids) != len(set(node_ids)):
+        raise ValueError("initial hostfile contains duplicate stable node IDs")
+    widths = {len(item.gpu_ids) for item in hosts}
+    if len(widths) != 1:
+        raise ValueError("initial hostfile nodes must use one fixed per-node TP width")
+    return tuple(hosts)
+
+
+def ssh_agent_command(
+    host: InitialHost,
+    *,
+    agent_script: str | Path,
+    worker_script: str | Path,
+    master_host: str,
+    master_port: int,
+    worker_args: Sequence[str] = (),
+    remote_python: str = "python",
+    socket_directory: str | Path = "/tmp",
+    ssh_command: str = "ssh",
+) -> tuple[str, ...]:
+    """Build one explicit remote agent command without executing it."""
+
+    if not 1 <= master_port <= 65535:
+        raise ValueError("master_port must be reachable and nonzero for SSH bootstrap")
+    socket_path = Path(socket_directory) / f"oobleck-{host.node_id}.sock"
+    remote = (
+        remote_python,
+        str(agent_script),
+        "--node-id",
+        host.node_id,
+        "--master-host",
+        master_host,
+        "--master-port",
+        str(master_port),
+        "--gpu-ids",
+        *host.gpu_ids,
+        "--local-worker-socket",
+        str(socket_path),
+        "--worker-script",
+        str(worker_script),
+    )
+    if worker_args:
+        remote = (*remote, "--worker-args", *worker_args)
+    return ssh_command, host.address, *remote
+
+
+__all__ = ["InitialHost", "load_initial_hostfile", "ssh_agent_command"]

--- a/oobleck/elastic/local_ipc.py
+++ b/oobleck/elastic/local_ipc.py
@@ -1,0 +1,302 @@
+"""Unix-domain generation barrier between one CPU agent and local GPU workers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import stat
+import uuid
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from oobleck.elastic.membership import (
+    MembershipSnapshot,
+    membership_snapshot_from_payload,
+)
+from oobleck.elastic.transport import (
+    DEFAULT_MAX_FRAME_BYTES,
+    ControlConnection,
+    MessageEnvelope,
+    ProtocolError,
+)
+
+WorkerReadyCallback = Callable[[int, str], Awaitable[None]]
+
+
+class LocalWorkerRelay:
+    """Broadcast generations and aggregate readiness from local GPU workers."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        node_id: str,
+        *,
+        expected_workers: int = 1,
+        on_generation_ready: WorkerReadyCallback | None = None,
+        max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
+    ) -> None:
+        if expected_workers < 1:
+            raise ValueError("expected_workers must be positive")
+        self.path = Path(path)
+        self.node_id = node_id
+        self.expected_workers = expected_workers
+        self.on_generation_ready = on_generation_ready
+        self.max_frame_bytes = max_frame_bytes
+        self._server: asyncio.AbstractServer | None = None
+        self._workers: dict[str, ControlConnection] = {}
+        self._latest_membership: MessageEnvelope | None = None
+        self._latest_active: MessageEnvelope | None = None
+        self._acknowledged: set[str] = set()
+        self._ready_notified_generation = -1
+        self._lock = asyncio.Lock()
+
+    @property
+    def worker_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._workers))
+
+    def generation_ready(self, generation: int) -> bool:
+        latest = self._latest_membership
+        return (
+            latest is not None
+            and latest.generation == generation
+            and len(self._workers) == self.expected_workers
+            and len(self._acknowledged) == self.expected_workers
+        )
+
+    async def start(self) -> None:
+        if self._server is not None:
+            raise RuntimeError("local worker relay is already running")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            mode = self.path.stat().st_mode
+            if not stat.S_ISSOCK(mode):
+                raise ValueError(f"refusing to replace non-socket path {self.path}")
+            self.path.unlink()
+
+        async def accept(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            connection = ControlConnection(reader, writer, max_frame_bytes=self.max_frame_bytes)
+            await self._handle(connection)
+
+        self._server = await asyncio.start_unix_server(accept, path=self.path)
+
+    async def _handle(self, connection: ControlConnection) -> None:
+        worker_id: str | None = None
+        try:
+            registration = await connection.receive()
+            if registration.message_type != "worker_register":
+                raise ProtocolError("local worker must register first")
+            if registration.payload != {"node_id": self.node_id}:
+                raise ProtocolError("local worker registered for a different node")
+            worker_id = registration.agent_id
+            async with self._lock:
+                previous = self._workers.get(worker_id)
+                if previous is None and len(self._workers) >= self.expected_workers:
+                    raise ProtocolError("more local workers registered than configured GPUs")
+                self._workers[worker_id] = connection
+                latest_membership = self._latest_membership
+                latest_active = self._latest_active
+            if previous is not None:
+                await previous.close()
+            if latest_membership is not None:
+                await connection.send(latest_membership)
+            if (
+                latest_active is not None
+                and latest_membership is not None
+                and latest_active.generation == latest_membership.generation
+            ):
+                await connection.send(latest_active)
+            while True:
+                message = await connection.receive()
+                if message.message_type != "worker_ack":
+                    raise ProtocolError("local workers may only acknowledge generations")
+                if (
+                    message.agent_id != worker_id
+                    or message.incarnation_id != registration.incarnation_id
+                    or message.payload != {"phase": "ready"}
+                ):
+                    raise ProtocolError("invalid local worker readiness acknowledgement")
+                callback: WorkerReadyCallback | None = None
+                snapshot_hash = ""
+                async with self._lock:
+                    latest = self._latest_membership
+                    if latest is None or message.generation != latest.generation:
+                        continue
+                    self._acknowledged.add(worker_id)
+                    if (
+                        self.generation_ready(message.generation)
+                        and self._ready_notified_generation != message.generation
+                    ):
+                        self._ready_notified_generation = message.generation
+                        callback = self.on_generation_ready
+                        snapshot_hash = str(latest.payload["snapshot_hash"])
+                if callback is not None:
+                    await callback(message.generation, snapshot_hash)
+        except (asyncio.IncompleteReadError, ConnectionError, BrokenPipeError):
+            pass
+        finally:
+            if worker_id is not None:
+                async with self._lock:
+                    if self._workers.get(worker_id) is connection:
+                        self._workers.pop(worker_id, None)
+                        self._acknowledged.discard(worker_id)
+            with contextlib.suppress(Exception):
+                await connection.close()
+
+    async def publish(self, message: MessageEnvelope) -> None:
+        if message.message_type not in {"membership", "generation_active"}:
+            raise ValueError("local relay accepts membership and generation_active messages")
+        async with self._lock:
+            if message.message_type == "membership":
+                self._latest_membership = message
+                self._latest_active = None
+                self._acknowledged.clear()
+                self._ready_notified_generation = -1
+            else:
+                latest = self._latest_membership
+                if (
+                    latest is None
+                    or message.generation != latest.generation
+                    or message.payload != {"snapshot_hash": latest.payload["snapshot_hash"]}
+                ):
+                    raise ProtocolError("active generation does not match local membership")
+                self._latest_active = message
+            workers = tuple(self._workers.items())
+        results = await asyncio.gather(
+            *(connection.send(message) for _, connection in workers),
+            return_exceptions=True,
+        )
+        failed = [
+            worker_id
+            for (worker_id, _), result in zip(workers, results)
+            if isinstance(result, BaseException)
+        ]
+        if failed:
+            async with self._lock:
+                for worker_id in failed:
+                    self._workers.pop(worker_id, None)
+                    self._acknowledged.discard(worker_id)
+
+    async def close(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        async with self._lock:
+            workers = tuple(self._workers.values())
+            self._workers.clear()
+            self._acknowledged.clear()
+        await asyncio.gather(*(worker.close() for worker in workers), return_exceptions=True)
+        if self.path.exists() and stat.S_ISSOCK(self.path.stat().st_mode):
+            self.path.unlink()
+
+
+class LocalWorkerClient:
+    """Prepare a generation, acknowledge it, then wait for the CPU barrier."""
+
+    def __init__(self, path: str | Path, node_id: str, worker_id: str) -> None:
+        if not node_id or not worker_id:
+            raise ValueError("node_id and worker_id are required")
+        self.path = Path(path)
+        self.node_id = node_id
+        self.worker_id = worker_id
+        self.incarnation_id = str(uuid.uuid4())
+        self.connection: ControlConnection | None = None
+        self.generation = -1
+        self.active_generation = -1
+        self.sequence = 0
+
+    async def connect(self) -> None:
+        reader, writer = await asyncio.open_unix_connection(self.path)
+        self.connection = ControlConnection(reader, writer)
+        await self.connection.send(
+            MessageEnvelope(
+                1,
+                "worker_register",
+                self.worker_id,
+                self.incarnation_id,
+                0,
+                0,
+                {"node_id": self.node_id},
+            )
+        )
+
+    def _parse_membership(self, message: MessageEnvelope) -> MembershipSnapshot:
+        if message.message_type != "membership":
+            raise ProtocolError("local agent sent a non-membership message")
+        snapshot = membership_snapshot_from_payload(message.generation, message.payload)
+        if snapshot.generation <= self.generation:
+            raise ProtocolError("local agent sent a stale membership generation")
+        self.generation = snapshot.generation
+        return snapshot
+
+    async def receive(self) -> MembershipSnapshot:
+        if self.connection is None:
+            raise RuntimeError("local worker is not connected")
+        while True:
+            message = await self.connection.receive()
+            if message.message_type == "generation_active":
+                if message.generation < self.generation:
+                    continue
+                self.active_generation = message.generation
+                continue
+            return self._parse_membership(message)
+
+    async def run_context(
+        self,
+        context: Any,
+        *,
+        on_snapshot: Callable[[MembershipSnapshot], Awaitable[None]] | None = None,
+        on_active: Callable[[int], Awaitable[None]] | None = None,
+    ) -> None:
+        if self.connection is None:
+            raise RuntimeError("local worker is not connected")
+        enable_barrier = getattr(context, "enable_control_plane_barrier", None)
+        if callable(enable_barrier):
+            enable_barrier()
+        pending: MembershipSnapshot | None = None
+        while True:
+            snapshot = pending or await self.receive()
+            pending = None
+            context.apply_membership(snapshot)
+            if on_snapshot is not None:
+                await on_snapshot(snapshot)
+            self.sequence += 1
+            await self.connection.send(
+                MessageEnvelope(
+                    1,
+                    "worker_ack",
+                    self.worker_id,
+                    self.incarnation_id,
+                    self.sequence,
+                    snapshot.generation,
+                    {"phase": "ready"},
+                )
+            )
+            while True:
+                message = await self.connection.receive()
+                if message.message_type == "membership":
+                    pending = self._parse_membership(message)
+                    break
+                if message.message_type != "generation_active":
+                    raise ProtocolError("local agent sent an invalid generation phase")
+                if message.generation < snapshot.generation:
+                    continue
+                if message.generation != snapshot.generation or message.payload != {
+                    "snapshot_hash": snapshot.snapshot_hash
+                }:
+                    raise ProtocolError("active generation does not match prepared membership")
+                self.active_generation = message.generation
+                mark_active = getattr(context, "mark_generation_active", None)
+                if callable(mark_active):
+                    mark_active(message.generation)
+                if on_active is not None:
+                    await on_active(message.generation)
+                break
+
+    async def close(self) -> None:
+        if self.connection is not None:
+            await self.connection.close()
+            self.connection = None
+
+
+__all__ = ["LocalWorkerClient", "LocalWorkerRelay"]

--- a/oobleck/elastic/membership.py
+++ b/oobleck/elastic/membership.py
@@ -1,0 +1,269 @@
+"""Transport-independent, generation-based membership state machine."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Callable, Mapping
+
+
+class StaleGeneration(RuntimeError):
+    pass
+
+
+class StaleSequence(RuntimeError):
+    pass
+
+
+class IncarnationMismatch(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class NodeIdentity:
+    agent_id: str
+    incarnation_id: str
+    addresses: tuple[str, ...]
+    gpu_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.agent_id or not self.incarnation_id:
+            raise ValueError("agent_id and incarnation_id are required")
+        if not self.addresses or not self.gpu_ids:
+            raise ValueError("addresses and gpu_ids must be non-empty")
+
+
+@dataclass(slots=True)
+class _LiveNode:
+    identity: NodeIdentity
+    last_sequence: int
+    lease_deadline: float
+
+
+@dataclass(frozen=True, slots=True)
+class MembershipSnapshot:
+    generation: int
+    nodes: tuple[NodeIdentity, ...]
+    reasons: tuple[str, ...]
+    snapshot_hash: str = field(default="", compare=False)
+
+    def __post_init__(self) -> None:
+        payload = {
+            "generation": self.generation,
+            "nodes": [asdict(item) for item in self.nodes],
+            "reasons": self.reasons,
+        }
+        expected = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        if self.snapshot_hash and self.snapshot_hash != expected:
+            raise ValueError("membership snapshot hash is invalid")
+        object.__setattr__(self, "snapshot_hash", expected)
+
+
+def membership_snapshot_from_payload(
+    generation: int, payload: Mapping[str, object]
+) -> MembershipSnapshot:
+    """Strictly reconstruct a checksummed snapshot from a control payload."""
+
+    if set(payload) != {"nodes", "reasons", "snapshot_hash"}:
+        raise ValueError("membership payload fields are invalid")
+    nodes_value = payload["nodes"]
+    reasons_value = payload["reasons"]
+    if not isinstance(nodes_value, list) or not isinstance(reasons_value, list):
+        raise ValueError("membership nodes and reasons must be lists")
+    if type(payload["snapshot_hash"]) is not str:
+        raise ValueError("membership snapshot_hash must be a string")
+    nodes = []
+    for item in nodes_value:
+        if not isinstance(item, dict) or set(item) != {
+            "agent_id",
+            "incarnation_id",
+            "addresses",
+            "gpu_ids",
+        }:
+            raise ValueError("membership node fields are invalid")
+        addresses = item["addresses"]
+        gpu_ids = item["gpu_ids"]
+        if (
+            type(item["agent_id"]) is not str
+            or type(item["incarnation_id"]) is not str
+            or not isinstance(addresses, (list, tuple))
+            or not isinstance(gpu_ids, (list, tuple))
+            or not addresses
+            or not gpu_ids
+            or not all(type(value) is str for value in (*addresses, *gpu_ids))
+        ):
+            raise ValueError("membership addresses and gpu_ids must be sequences")
+        nodes.append(
+            NodeIdentity(
+                item["agent_id"],
+                item["incarnation_id"],
+                tuple(addresses),
+                tuple(gpu_ids),
+            )
+        )
+    if not all(isinstance(reason, str) for reason in reasons_value):
+        raise ValueError("membership reasons must be strings")
+    return MembershipSnapshot(
+        generation,
+        tuple(nodes),
+        tuple(reasons_value),
+        payload["snapshot_hash"],
+    )
+
+
+class MembershipStateMachine:
+    """Serializes disconnect, lease, join, replacement, and drain events."""
+
+    def __init__(
+        self,
+        *,
+        lease_timeout_s: float = 5.0,
+        max_nodes: int | None = None,
+        gpu_ids_per_node: int | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if lease_timeout_s <= 0:
+            raise ValueError("lease_timeout_s must be positive")
+        self.lease_timeout_s = lease_timeout_s
+        if max_nodes is not None and max_nodes < 1:
+            raise ValueError("max_nodes must be positive")
+        if gpu_ids_per_node is not None and gpu_ids_per_node < 1:
+            raise ValueError("gpu_ids_per_node must be positive")
+        self.max_nodes = max_nodes
+        self.gpu_ids_per_node = gpu_ids_per_node
+        self.clock = clock
+        self.generation = 0
+        self._nodes: dict[str, _LiveNode] = {}
+        self._pending_reasons: set[str] = set()
+
+    @property
+    def agent_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(self._nodes))
+
+    @property
+    def has_pending_generation(self) -> bool:
+        return bool(self._pending_reasons)
+
+    def _check_generation(self, generation: int) -> None:
+        if generation != self.generation:
+            raise StaleGeneration(
+                f"message generation {generation} does not match active {self.generation}"
+            )
+
+    def register(self, identity: NodeIdentity, sequence_number: int) -> None:
+        if sequence_number < 0:
+            raise ValueError("sequence_number must be non-negative")
+        existing = self._nodes.get(identity.agent_id)
+        if existing is None and self.max_nodes is not None and len(self._nodes) >= self.max_nodes:
+            raise ValueError(f"membership exceeds configured max_nodes={self.max_nodes}")
+        expected_gpu_ids = self.gpu_ids_per_node
+        if expected_gpu_ids is None and self._nodes:
+            expected_gpu_ids = len(next(iter(self._nodes.values())).identity.gpu_ids)
+        if expected_gpu_ids is not None and len(identity.gpu_ids) != expected_gpu_ids:
+            raise ValueError(
+                f"node {identity.agent_id!r} contributes {len(identity.gpu_ids)} GPUs; "
+                f"the fixed per-node TP width is {expected_gpu_ids}"
+            )
+        if existing and existing.identity.incarnation_id == identity.incarnation_id:
+            if sequence_number <= existing.last_sequence:
+                raise StaleSequence("duplicate or out-of-order registration")
+            existing.last_sequence = sequence_number
+            existing.lease_deadline = self.clock() + self.lease_timeout_s
+            return
+        self._nodes[identity.agent_id] = _LiveNode(
+            identity, sequence_number, self.clock() + self.lease_timeout_s
+        )
+        self._pending_reasons.add(f"{'replacement' if existing else 'join'}:{identity.agent_id}")
+
+    def acknowledge(
+        self,
+        agent_id: str,
+        incarnation_id: str,
+        sequence_number: int,
+        generation: int,
+    ) -> None:
+        """Record a preparation acknowledgement under normal ordering rules."""
+
+        self._check_generation(generation)
+        node = self._require_incarnation(agent_id, incarnation_id)
+        if sequence_number <= node.last_sequence:
+            raise StaleSequence("duplicate or out-of-order generation acknowledgement")
+        node.last_sequence = sequence_number
+        node.lease_deadline = self.clock() + self.lease_timeout_s
+
+    def heartbeat(
+        self,
+        agent_id: str,
+        incarnation_id: str,
+        sequence_number: int,
+        generation: int,
+    ) -> None:
+        self._check_generation(generation)
+        node = self._require_incarnation(agent_id, incarnation_id)
+        if sequence_number <= node.last_sequence:
+            raise StaleSequence("duplicate or out-of-order heartbeat")
+        node.last_sequence = sequence_number
+        node.lease_deadline = self.clock() + self.lease_timeout_s
+
+    def _require_incarnation(self, agent_id: str, incarnation_id: str) -> _LiveNode:
+        node = self._nodes.get(agent_id)
+        if node is None or node.identity.incarnation_id != incarnation_id:
+            raise IncarnationMismatch(f"connection does not own active incarnation for {agent_id}")
+        return node
+
+    def disconnect(self, agent_id: str, incarnation_id: str) -> bool:
+        node = self._nodes.get(agent_id)
+        if node is None or node.identity.incarnation_id != incarnation_id:
+            return False
+        del self._nodes[agent_id]
+        self._pending_reasons.add(f"disconnect:{agent_id}")
+        return True
+
+    def drain(
+        self,
+        agent_id: str,
+        incarnation_id: str,
+        sequence_number: int,
+        generation: int,
+    ) -> None:
+        self._check_generation(generation)
+        node = self._require_incarnation(agent_id, incarnation_id)
+        if sequence_number <= node.last_sequence:
+            raise StaleSequence("duplicate or out-of-order drain")
+        del self._nodes[agent_id]
+        self._pending_reasons.add(f"drain:{agent_id}")
+
+    def expire_leases(self, now: float | None = None) -> tuple[str, ...]:
+        current = self.clock() if now is None else now
+        expired = tuple(
+            sorted(
+                agent_id for agent_id, node in self._nodes.items() if node.lease_deadline <= current
+            )
+        )
+        for agent_id in expired:
+            del self._nodes[agent_id]
+            self._pending_reasons.add(f"lease-expired:{agent_id}")
+        return expired
+
+    def publish(self) -> MembershipSnapshot | None:
+        if not self._pending_reasons:
+            return None
+        self.generation += 1
+        snapshot = MembershipSnapshot(
+            self.generation,
+            tuple(self._nodes[agent_id].identity for agent_id in sorted(self._nodes)),
+            tuple(sorted(self._pending_reasons)),
+        )
+        self._pending_reasons.clear()
+        return snapshot
+
+    def snapshot(self) -> MembershipSnapshot:
+        return MembershipSnapshot(
+            self.generation,
+            tuple(self._nodes[agent_id].identity for agent_id in sorted(self._nodes)),
+            (),
+        )

--- a/oobleck/elastic/service.py
+++ b/oobleck/elastic/service.py
@@ -1,0 +1,23 @@
+"""Public membership service with bounded broadcast failure handling."""
+
+from __future__ import annotations
+
+import asyncio
+
+from oobleck.elastic.service_base import MasterControlService as _MasterControlService
+from oobleck.elastic.service_public_base import NodeAgentClient, inspect_membership, request_drain
+from oobleck.elastic.transport import MessageEnvelope
+
+
+class MasterControlService(_MasterControlService):
+    async def _broadcast_message(self, message: MessageEnvelope) -> None:
+        # A peer can close during a proposal or activation broadcast. That
+        # failed writer is a detection input, not permission to stall the
+        # membership state machine indefinitely.
+        try:
+            await asyncio.wait_for(super()._broadcast_message(message), timeout=1.0)
+        except TimeoutError:
+            return
+
+
+__all__ = ["MasterControlService", "NodeAgentClient", "inspect_membership", "request_drain"]

--- a/oobleck/elastic/service_base.py
+++ b/oobleck/elastic/service_base.py
@@ -1,0 +1,337 @@
+"""Membership master and reconnecting node client over ControlTransport."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+import uuid
+from dataclasses import asdict
+from typing import Awaitable, Callable, Sequence
+
+from oobleck.elastic.membership import MembershipSnapshot, MembershipStateMachine, NodeIdentity
+from oobleck.elastic.transport import (
+    AsyncioTcpControlTransport,
+    ControlConnection,
+    ControlTransport,
+    MessageEnvelope,
+    ProtocolError,
+)
+
+
+class MasterControlService:
+    def __init__(
+        self,
+        transport: ControlTransport | None = None,
+        *,
+        lease_timeout_s: float = 5.0,
+        lease_check_interval_s: float = 0.5,
+        max_nodes: int | None = None,
+        gpu_ids_per_node: int | None = None,
+    ) -> None:
+        self.transport = transport or AsyncioTcpControlTransport()
+        self.membership = MembershipStateMachine(
+            lease_timeout_s=lease_timeout_s,
+            max_nodes=max_nodes,
+            gpu_ids_per_node=gpu_ids_per_node,
+        )
+        self.lease_check_interval_s = lease_check_interval_s
+        self._connections: dict[str, tuple[str, ControlConnection]] = {}
+        self._lock = asyncio.Lock()
+        self._server: asyncio.AbstractServer | None = None
+        self._lease_task: asyncio.Task[None] | None = None
+        self._master_sequence = 0
+        self._proposed_snapshot: MembershipSnapshot | None = None
+        self._ready_agents: set[str] = set()
+        self.active_generation = 0
+
+    async def start(self, host: str, port: int) -> asyncio.AbstractServer:
+        if self._server is not None:
+            raise RuntimeError("master service is already running")
+        self._server = await self.transport.start_server(host, port, self._handle)
+        self._lease_task = asyncio.create_task(self._expire_leases())
+        return self._server
+
+    async def close(self) -> None:
+        if self._lease_task is not None:
+            self._lease_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._lease_task
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+        connections = [item[1] for item in self._connections.values()]
+        self._connections.clear()
+        await asyncio.gather(
+            *(connection.close() for connection in connections),
+            return_exceptions=True,
+        )
+        self._server = None
+
+    def _begin_generation(self, snapshot: MembershipSnapshot) -> None:
+        """Install a proposal and invalidate every older readiness result."""
+
+        self._proposed_snapshot = snapshot
+        self._ready_agents.clear()
+        if not snapshot.nodes:
+            self.active_generation = snapshot.generation
+
+    async def _expire_leases(self) -> None:
+        while True:
+            await asyncio.sleep(self.lease_check_interval_s)
+            async with self._lock:
+                expired = self.membership.expire_leases()
+                for agent_id in expired:
+                    self._connections.pop(agent_id, None)
+                snapshot = self.membership.publish()
+                if snapshot is not None:
+                    self._begin_generation(snapshot)
+            if snapshot is not None:
+                await self._broadcast(snapshot)
+
+    async def _handle(self, connection: ControlConnection) -> None:
+        identity: NodeIdentity | None = None
+        try:
+            first = await connection.receive()
+            if first.message_type == "inspect":
+                if first.payload:
+                    raise ProtocolError("inspect payload must be empty")
+                await connection.send(self._membership_message(self.membership.snapshot()))
+                return
+            if first.message_type == "request_drain":
+                if set(first.payload) != {"node_id"}:
+                    raise ProtocolError("request_drain payload requires node_id")
+                node_id = str(first.payload["node_id"])
+                async with self._lock:
+                    active = self._connections.get(node_id)
+                    if active is None:
+                        raise ProtocolError(f"node {node_id!r} is not active")
+                    self._master_sequence += 1
+                    command = MessageEnvelope(
+                        1,
+                        "drain_command",
+                        "master",
+                        "master",
+                        self._master_sequence,
+                        self.membership.generation,
+                        {"node_id": node_id},
+                    )
+                    await active[1].send(command)
+                await connection.send(
+                    MessageEnvelope(
+                        1,
+                        "drain_accepted",
+                        "master",
+                        "master",
+                        self._master_sequence,
+                        self.membership.generation,
+                        {"node_id": node_id},
+                    )
+                )
+                return
+            if first.message_type != "register":
+                raise ProtocolError("the first message on an agent stream must be register")
+            payload = first.payload
+            if set(payload) != {"addresses", "gpu_ids"}:
+                raise ProtocolError("register payload requires addresses and gpu_ids")
+            identity = NodeIdentity(
+                first.agent_id,
+                first.incarnation_id,
+                tuple(payload["addresses"]),
+                tuple(payload["gpu_ids"]),
+            )
+            async with self._lock:
+                self.membership.register(identity, first.sequence_number)
+                self._connections[identity.agent_id] = (
+                    identity.incarnation_id,
+                    connection,
+                )
+                snapshot = self.membership.publish()
+                if snapshot is not None:
+                    self._begin_generation(snapshot)
+            if snapshot is not None:
+                await self._broadcast(snapshot)
+
+            while True:
+                message = await connection.receive()
+                snapshot = None
+                active_message = None
+                async with self._lock:
+                    if message.message_type == "heartbeat":
+                        self.membership.heartbeat(
+                            message.agent_id,
+                            message.incarnation_id,
+                            message.sequence_number,
+                            message.generation,
+                        )
+                    elif message.message_type == "generation_ready":
+                        proposed = self._proposed_snapshot
+                        if (
+                            proposed is None
+                            or message.generation != proposed.generation
+                            or message.payload != {"snapshot_hash": proposed.snapshot_hash}
+                        ):
+                            continue
+                        self.membership.acknowledge(
+                            message.agent_id,
+                            message.incarnation_id,
+                            message.sequence_number,
+                            message.generation,
+                        )
+                        self._ready_agents.add(message.agent_id)
+                        if self._ready_agents == set(self.membership.agent_ids):
+                            self.active_generation = proposed.generation
+                            active_message = self._generation_active_message(proposed)
+                    elif message.message_type == "drain":
+                        self.membership.drain(
+                            message.agent_id,
+                            message.incarnation_id,
+                            message.sequence_number,
+                            message.generation,
+                        )
+                        snapshot = self.membership.publish()
+                        if snapshot is not None:
+                            self._begin_generation(snapshot)
+                    else:
+                        raise ProtocolError(f"unsupported agent message {message.message_type!r}")
+                if active_message is not None:
+                    await self._broadcast_message(active_message)
+                if message.message_type == "drain":
+                    if snapshot is not None:
+                        await self._broadcast(snapshot)
+                    return
+        except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError):
+            pass
+        finally:
+            if identity is not None:
+                async with self._lock:
+                    active = self._connections.get(identity.agent_id)
+                    if active and active[0] == identity.incarnation_id:
+                        self._connections.pop(identity.agent_id, None)
+                        self.membership.disconnect(identity.agent_id, identity.incarnation_id)
+                        snapshot = self.membership.publish()
+                        if snapshot is not None:
+                            self._begin_generation(snapshot)
+                    else:
+                        snapshot = None
+                if snapshot is not None:
+                    await self._broadcast(snapshot)
+
+    async def _broadcast(self, snapshot: MembershipSnapshot) -> None:
+        message = self._membership_message(snapshot)
+        await self._broadcast_message(message)
+
+    async def _broadcast_message(self, message: MessageEnvelope) -> None:
+        connections = [item[1] for item in self._connections.values()]
+        results = await asyncio.gather(
+            *(connection.send(message) for connection in connections),
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+
+    def _membership_message(self, snapshot: MembershipSnapshot) -> MessageEnvelope:
+        self._master_sequence += 1
+        return MessageEnvelope(
+            1,
+            "membership",
+            "master",
+            "master",
+            self._master_sequence,
+            snapshot.generation,
+            {
+                "nodes": [asdict(node) for node in snapshot.nodes],
+                "reasons": list(snapshot.reasons),
+                "snapshot_hash": snapshot.snapshot_hash,
+            },
+        )
+
+    def _generation_active_message(self, snapshot: MembershipSnapshot) -> MessageEnvelope:
+        self._master_sequence += 1
+        return MessageEnvelope(
+            1,
+            "generation_active",
+            "master",
+            "master",
+            self._master_sequence,
+            snapshot.generation,
+            {"snapshot_hash": snapshot.snapshot_hash},
+        )
+
+
+class NodeAgentClient:
+    def __init__(
+        self,
+        node_id: str,
+        gpu_ids: Sequence[str],
+        *,
+        transport: ControlTransport | None = None,
+        heartbeat_interval_s: float = 1.0,
+        on_membership: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
+    ) -> None:
+        if not node_id or not gpu_ids:
+            raise ValueError("node_id and gpu_ids are required")
+        self.node_id = node_id
+        self.gpu_ids = tuple(gpu_ids)
+        self.transport = transport or AsyncioTcpControlTransport()
+        self.heartbeat_interval_s = heartbeat_interval_s
+        self.on_membership = on_membership
+        self.incarnation_id = str(uuid.uuid4())
+        self.generation = 0
+        self.sequence = 0
+        self.connection: ControlConnection | None = None
+
+    async def connect(self, host: str, port: int) -> MessageEnvelope:
+        self.connection = await self.transport.connect(host, port)
+        await self.connection.send(
+            MessageEnvelope(
+                1,
+                "register",
+                self.node_id,
+                self.incarnation_id,
+                self.sequence,
+                self.generation,
+                {
+                    "addresses": [socket.gethostbyname(socket.gethostname())],
+                    "gpu_ids": list(self.gpu_ids),
+                },
+            )
+        )
+        membership = await self.connection.receive()
+        self.generation = membership.generation
+        return membership
+
+    async def run(self) -> None:
+        if self.connection is None:
+            raise RuntimeError("connect() must be called before run()")
+        while True:
+            await asyncio.sleep(self.heartbeat_interval_s)
+            self.sequence += 1
+            await self.connection.send(
+                MessageEnvelope(
+                    1,
+                    "heartbeat",
+                    self.node_id,
+                    self.incarnation_id,
+                    self.sequence,
+                    self.generation,
+                    {},
+                )
+            )
+            with contextlib.suppress(asyncio.TimeoutError):
+                message = await asyncio.wait_for(self.connection.receive(), timeout=0.01)
+                if message.message_type == "membership" and message.generation > self.generation:
+                    self.generation = message.generation
+                    if self.on_membership is not None:
+                        await self.on_membership(message)
+
+    async def drain(self) -> None:
+        if self.connection is None:
+            raise RuntimeError("agent is not connected")
+        self.sequence += 1
+        await self.connection.send(
+            MessageEnvelope(
+                1, "drain", self.node_id, self.incarnation_id, self.sequence, self.generation, {}
+            )
+        )

--- a/oobleck/elastic/service_public_base.py
+++ b/oobleck/elastic/service_public_base.py
@@ -1,0 +1,326 @@
+"""Public membership service and concurrently reading node client."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import socket
+import uuid
+from pathlib import Path
+from typing import Awaitable, Callable, Mapping, Sequence
+
+from oobleck.elastic.membership import (
+    MembershipSnapshot,
+    StaleSequence,
+    membership_snapshot_from_payload,
+)
+from oobleck.elastic.local_ipc import LocalWorkerRelay
+from oobleck.elastic.service_base import MasterControlService
+from oobleck.elastic.transport import (
+    AsyncioTcpControlTransport,
+    ControlConnection,
+    ControlTransport,
+    MessageEnvelope,
+)
+
+
+class NodeAgentClient:
+    def __init__(
+        self,
+        node_id: str,
+        gpu_ids: Sequence[str],
+        *,
+        transport: ControlTransport | None = None,
+        heartbeat_interval_s: float = 1.0,
+        on_membership: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
+        on_generation_active: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
+        local_worker_socket: str | Path | None = None,
+    ) -> None:
+        if not node_id or not gpu_ids or heartbeat_interval_s <= 0:
+            raise ValueError("node_id, gpu_ids, and a positive heartbeat interval are required")
+        self.node_id = node_id
+        self.gpu_ids = tuple(gpu_ids)
+        self.transport = transport or AsyncioTcpControlTransport()
+        self.heartbeat_interval_s = heartbeat_interval_s
+        self.on_membership = on_membership
+        self.on_generation_active = on_generation_active
+        self.incarnation_id = str(uuid.uuid4())
+        self.generation = 0
+        self.active_generation = 0
+        self.sequence = 0
+        self.connection: ControlConnection | None = None
+        self.snapshot: MembershipSnapshot | None = None
+        self._host: str | None = None
+        self._port: int | None = None
+        self._last_master_sequence = -1
+        self._prepared_generation = -1
+        self._ready_sent_generation = -1
+        self._send_lock = asyncio.Lock()
+        self._ready_lock = asyncio.Lock()
+        self._stopping = False
+        self.local_worker_relay = (
+            LocalWorkerRelay(
+                local_worker_socket,
+                node_id,
+                expected_workers=len(self.gpu_ids),
+                on_generation_ready=self._local_workers_ready,
+            )
+            if local_worker_socket is not None
+            else None
+        )
+
+    async def _send_agent_message(
+        self,
+        message_type: str,
+        generation: int,
+        payload: Mapping[str, object],
+    ) -> None:
+        if self.connection is None:
+            raise RuntimeError("agent is not connected")
+        async with self._send_lock:
+            self.sequence += 1
+            await self.connection.send(
+                MessageEnvelope(
+                    1,
+                    message_type,
+                    self.node_id,
+                    self.incarnation_id,
+                    self.sequence,
+                    generation,
+                    payload,
+                )
+            )
+
+    async def _local_workers_ready(self, generation: int, snapshot_hash: str) -> None:
+        snapshot = self.snapshot
+        if (
+            snapshot is not None
+            and generation == snapshot.generation
+            and snapshot_hash == snapshot.snapshot_hash
+        ):
+            await self._send_ready_if_possible(generation)
+
+    async def _send_ready_if_possible(self, generation: int) -> None:
+        async with self._ready_lock:
+            snapshot = self.snapshot
+            if (
+                self.connection is None
+                or snapshot is None
+                or generation != snapshot.generation
+                or self._prepared_generation != generation
+                or self._ready_sent_generation >= generation
+            ):
+                return
+            if self.local_worker_relay is not None and not self.local_worker_relay.generation_ready(
+                generation
+            ):
+                return
+            self._ready_sent_generation = generation
+            try:
+                await self._send_agent_message(
+                    "generation_ready",
+                    generation,
+                    {"snapshot_hash": snapshot.snapshot_hash},
+                )
+            except BaseException:
+                self._ready_sent_generation = -1
+                raise
+
+    def _validate_master_sequence(self, message: MessageEnvelope) -> None:
+        if message.agent_id != "master":
+            raise ValueError("expected a control message from the master")
+        if message.sequence_number <= self._last_master_sequence:
+            raise StaleSequence("duplicate or out-of-order master message")
+        self._last_master_sequence = message.sequence_number
+
+    async def _consume_membership(self, message: MessageEnvelope) -> MembershipSnapshot:
+        if message.message_type != "membership":
+            raise ValueError("expected a membership message from the master")
+        self._validate_master_sequence(message)
+        snapshot = membership_snapshot_from_payload(message.generation, message.payload)
+        if snapshot.generation < self.generation:
+            raise ValueError("master sent a stale membership generation")
+        self.generation = snapshot.generation
+        self.snapshot = snapshot
+        self._prepared_generation = -1
+        self._ready_sent_generation = -1
+        if self.local_worker_relay is not None:
+            await self.local_worker_relay.publish(message)
+        if self.on_membership is not None:
+            await self.on_membership(message)
+        self._prepared_generation = snapshot.generation
+        await self._send_ready_if_possible(snapshot.generation)
+        return snapshot
+
+    async def _consume_active(self, message: MessageEnvelope) -> None:
+        if message.message_type != "generation_active":
+            raise ValueError("expected a generation_active message")
+        self._validate_master_sequence(message)
+        if message.generation < self.generation:
+            return
+        snapshot = self.snapshot
+        if (
+            snapshot is None
+            or message.generation != snapshot.generation
+            or message.payload != {"snapshot_hash": snapshot.snapshot_hash}
+        ):
+            raise ValueError("master activated an unprepared generation")
+        self.active_generation = message.generation
+        if self.local_worker_relay is not None:
+            await self.local_worker_relay.publish(message)
+        if self.on_generation_active is not None:
+            await self.on_generation_active(message)
+
+    async def connect(self, host: str, port: int) -> MessageEnvelope:
+        self._host, self._port = host, port
+        if self.local_worker_relay is not None and self.local_worker_relay._server is None:
+            await self.local_worker_relay.start()
+        self.connection = await self.transport.connect(host, port)
+        await self.connection.send(
+            MessageEnvelope(
+                1,
+                "register",
+                self.node_id,
+                self.incarnation_id,
+                self.sequence,
+                self.generation,
+                {
+                    "addresses": [socket.gethostbyname(socket.gethostname())],
+                    "gpu_ids": list(self.gpu_ids),
+                },
+            )
+        )
+        membership = await self.connection.receive()
+        await self._consume_membership(membership)
+        return membership
+
+    async def _heartbeat_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self.heartbeat_interval_s)
+            await self._send_agent_message("heartbeat", self.generation, {})
+
+    async def _receive_loop(self) -> None:
+        assert self.connection is not None
+        while True:
+            message = await self.connection.receive()
+            if message.message_type == "drain_command":
+                if message.payload != {"node_id": self.node_id}:
+                    raise ValueError("drain command targets a different node")
+                await self.drain()
+                return
+            if message.message_type == "membership":
+                await self._consume_membership(message)
+            elif message.message_type == "generation_active":
+                await self._consume_active(message)
+            else:
+                raise ValueError(f"unsupported master message {message.message_type!r}")
+
+    async def run(self) -> None:
+        if self.connection is None:
+            raise RuntimeError("connect() must be called before run()")
+        tasks = {
+            asyncio.create_task(self._heartbeat_loop()),
+            asyncio.create_task(self._receive_loop()),
+        }
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_EXCEPTION)
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        for task in done:
+            task.result()
+
+    async def run_reconnecting(self, *, retry_delay_s: float = 0.1) -> None:
+        """Maintain one incarnation at a time and reconnect after stream loss."""
+
+        if self._host is None or self._port is None:
+            raise RuntimeError("connect() must be called before run_reconnecting()")
+        if retry_delay_s <= 0:
+            raise ValueError("retry_delay_s must be positive")
+        while not self._stopping:
+            try:
+                await self.run()
+            except (OSError, ConnectionError, asyncio.IncompleteReadError):
+                if self._stopping:
+                    break
+                if self.connection is not None:
+                    with contextlib.suppress(Exception):
+                        await self.connection.close()
+                self.connection = None
+                self.incarnation_id = str(uuid.uuid4())
+                self.sequence = 0
+                await asyncio.sleep(retry_delay_s)
+                await self.connect(self._host, self._port)
+
+    async def drain(self) -> None:
+        if self.connection is None:
+            raise RuntimeError("agent is not connected")
+        self._stopping = True
+        await self._send_agent_message("drain", self.generation, {})
+
+    async def close(self, *, graceful: bool = False) -> None:
+        self._stopping = True
+        if self.connection is not None:
+            if graceful:
+                await self.drain()
+            await self.connection.close()
+            self.connection = None
+        if self.local_worker_relay is not None:
+            await self.local_worker_relay.close()
+
+
+async def inspect_membership(
+    host: str,
+    port: int,
+    *,
+    transport: ControlTransport | None = None,
+) -> MembershipSnapshot:
+    selected = transport or AsyncioTcpControlTransport()
+    connection = await selected.connect(host, port)
+    try:
+        identity = str(uuid.uuid4())
+        await connection.send(MessageEnvelope(1, "inspect", "operator", identity, 0, 0, {}))
+        message = await connection.receive()
+        client = NodeAgentClient("operator", ("inspection",), transport=selected)
+        return await client._consume_membership(message)
+    finally:
+        await connection.close()
+
+
+async def request_drain(
+    host: str,
+    port: int,
+    node_id: str,
+    *,
+    transport: ControlTransport | None = None,
+) -> int:
+    """Ask the active node incarnation to submit its own graceful drain."""
+
+    selected = transport or AsyncioTcpControlTransport()
+    connection = await selected.connect(host, port)
+    try:
+        identity = str(uuid.uuid4())
+        await connection.send(
+            MessageEnvelope(
+                1,
+                "request_drain",
+                "operator",
+                identity,
+                0,
+                0,
+                {"node_id": node_id},
+            )
+        )
+        reply = await connection.receive()
+        if reply.message_type != "drain_accepted" or reply.payload != {"node_id": node_id}:
+            raise ValueError("master rejected or malformed the drain request")
+        return reply.generation
+    finally:
+        await connection.close()
+
+
+__all__ = [
+    "MasterControlService",
+    "NodeAgentClient",
+    "inspect_membership",
+    "request_drain",
+]

--- a/oobleck/elastic/transport.py
+++ b/oobleck/elastic/transport.py
@@ -1,0 +1,296 @@
+"""Length-prefixed asyncio control transport with strict JSON envelopes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+from dataclasses import asdict, dataclass
+from typing import Awaitable, Callable, Mapping, Protocol
+
+
+PROTOCOL_VERSION = 1
+DEFAULT_MAX_FRAME_BYTES = 1 << 20
+_FIELDS = {
+    "protocol_version",
+    "message_type",
+    "agent_id",
+    "incarnation_id",
+    "sequence_number",
+    "generation",
+    "payload",
+}
+_PAYLOAD_FIELDS = {
+    "register": {"addresses", "gpu_ids"},
+    "heartbeat": set(),
+    "generation_ready": {"snapshot_hash"},
+    "drain": set(),
+    "membership": {"nodes", "reasons", "snapshot_hash"},
+    "generation_active": {"snapshot_hash"},
+    "inspect": set(),
+    "request_drain": {"node_id"},
+    "drain_command": {"node_id"},
+    "drain_accepted": {"node_id"},
+    "worker_register": {"node_id"},
+    "worker_ack": {"phase"},
+}
+
+
+class ProtocolError(ValueError):
+    pass
+
+
+class FrameTooLarge(ProtocolError):
+    pass
+
+
+def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
+    expected = _PAYLOAD_FIELDS.get(message_type)
+    if expected is None:
+        raise ProtocolError(f"unsupported message_type {message_type!r}")
+    if set(payload) != expected:
+        raise ProtocolError(f"invalid {message_type} payload fields; expected={sorted(expected)}")
+    if message_type == "register":
+        for field in ("addresses", "gpu_ids"):
+            values = payload[field]
+            if (
+                type(values) is not list
+                or not values
+                or not all(type(item) is str for item in values)
+            ):
+                raise ProtocolError(f"register {field} must be a non-empty list of strings")
+    elif message_type == "membership":
+        if type(payload["nodes"]) is not list or type(payload["reasons"]) is not list:
+            raise ProtocolError("membership nodes and reasons must be lists")
+        if type(payload["snapshot_hash"]) is not str:
+            raise ProtocolError("membership snapshot_hash must be a string")
+    elif message_type in {"generation_ready", "generation_active"}:
+        if type(payload["snapshot_hash"]) is not str or not payload["snapshot_hash"]:
+            raise ProtocolError(f"{message_type} snapshot_hash must be a non-empty string")
+    elif message_type in {
+        "request_drain",
+        "drain_command",
+        "drain_accepted",
+        "worker_register",
+    }:
+        if type(payload["node_id"]) is not str or not payload["node_id"]:
+            raise ProtocolError(f"{message_type} node_id must be a non-empty string")
+    elif message_type == "worker_ack" and payload["phase"] != "ready":
+        raise ProtocolError("worker_ack phase must be 'ready'")
+
+
+@dataclass(frozen=True, slots=True)
+class MessageEnvelope:
+    protocol_version: int
+    message_type: str
+    agent_id: str
+    incarnation_id: str
+    sequence_number: int
+    generation: int
+    payload: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        if self.protocol_version != PROTOCOL_VERSION:
+            raise ProtocolError(
+                f"unsupported protocol version {self.protocol_version}; expected {PROTOCOL_VERSION}"
+            )
+        if not self.message_type or not self.agent_id or not self.incarnation_id:
+            raise ProtocolError("message_type, agent_id, and incarnation_id are required")
+        if self.sequence_number < 0 or self.generation < 0:
+            raise ProtocolError("sequence_number and generation must be non-negative")
+        if not isinstance(self.payload, Mapping):
+            raise ProtocolError("payload must be a JSON object")
+        _validate_payload(self.message_type, self.payload)
+
+    @classmethod
+    def from_dict(cls, value: object) -> "MessageEnvelope":
+        if not isinstance(value, dict):
+            raise ProtocolError("control envelope must be a JSON object")
+        if set(value) != _FIELDS:
+            missing = sorted(_FIELDS - set(value))
+            extra = sorted(set(value) - _FIELDS)
+            raise ProtocolError(f"invalid envelope fields; missing={missing}, extra={extra}")
+        expected_types = {
+            "protocol_version": int,
+            "message_type": str,
+            "agent_id": str,
+            "incarnation_id": str,
+            "sequence_number": int,
+            "generation": int,
+            "payload": dict,
+        }
+        for name, expected in expected_types.items():
+            if type(value[name]) is not expected:
+                raise ProtocolError(f"{name} must be {expected.__name__}")
+        return cls(**value)
+
+
+def encode_frame(message: MessageEnvelope, max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES) -> bytes:
+    body = json.dumps(
+        asdict(message), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    if len(body) > max_frame_bytes:
+        raise FrameTooLarge(f"control frame is {len(body)} bytes; limit is {max_frame_bytes}")
+    return struct.pack(">I", len(body)) + body
+
+
+async def read_frame(
+    reader: asyncio.StreamReader, max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES
+) -> MessageEnvelope:
+    header = await reader.readexactly(4)
+    size = struct.unpack(">I", header)[0]
+    if size == 0:
+        raise ProtocolError("empty control frames are not allowed")
+    if size > max_frame_bytes:
+        raise FrameTooLarge(f"control frame declares {size} bytes; limit is {max_frame_bytes}")
+    body = await reader.readexactly(size)
+    try:
+        value = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProtocolError("control frame is not valid UTF-8 JSON") from exc
+    return MessageEnvelope.from_dict(value)
+
+
+async def write_frame(
+    writer: asyncio.StreamWriter,
+    message: MessageEnvelope,
+    max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
+) -> None:
+    writer.write(encode_frame(message, max_frame_bytes))
+    await writer.drain()
+
+
+class SerializedWriter:
+    """One bounded writer queue per connection, providing real backpressure."""
+
+    def __init__(
+        self,
+        writer: asyncio.StreamWriter,
+        *,
+        max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
+        queue_size: int = 64,
+    ) -> None:
+        self._writer = writer
+        self._max_frame_bytes = max_frame_bytes
+        self._queue: asyncio.Queue[tuple[MessageEnvelope | None, asyncio.Future[None]]] = (
+            asyncio.Queue(queue_size)
+        )
+        self._task = asyncio.create_task(self._run())
+
+    async def send(self, message: MessageEnvelope) -> None:
+        if self._task.done():
+            await self._task
+        future = asyncio.get_running_loop().create_future()
+        await self._queue.put((message, future))
+        await future
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                message, completion = await self._queue.get()
+                if message is None:
+                    completion.set_result(None)
+                    return
+                try:
+                    await write_frame(self._writer, message, self._max_frame_bytes)
+                except BaseException as exc:
+                    if not completion.done():
+                        completion.set_exception(exc)
+                    raise
+                else:
+                    completion.set_result(None)
+        except BaseException as exc:
+            while not self._queue.empty():
+                _, completion = self._queue.get_nowait()
+                if not completion.done():
+                    completion.set_exception(exc)
+            raise
+
+    async def close(self) -> None:
+        if not self._task.done():
+            completion = asyncio.get_running_loop().create_future()
+            await self._queue.put((None, completion))
+            await completion
+            await self._task
+        self._writer.close()
+        await self._writer.wait_closed()
+
+
+class ControlConnection:
+    def __init__(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        *,
+        max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
+        writer_queue_size: int = 64,
+    ) -> None:
+        self.reader = reader
+        self.writer = SerializedWriter(
+            writer,
+            max_frame_bytes=max_frame_bytes,
+            queue_size=writer_queue_size,
+        )
+        self.max_frame_bytes = max_frame_bytes
+
+    async def receive(self) -> MessageEnvelope:
+        return await read_frame(self.reader, self.max_frame_bytes)
+
+    async def send(self, message: MessageEnvelope) -> None:
+        await self.writer.send(message)
+
+    async def close(self) -> None:
+        await self.writer.close()
+
+
+class ControlTransport(Protocol):
+    async def connect(self, host: str, port: int) -> ControlConnection: ...
+
+    async def start_server(
+        self,
+        host: str,
+        port: int,
+        handler: Callable[[ControlConnection], Awaitable[None]],
+    ) -> asyncio.AbstractServer: ...
+
+
+class AsyncioTcpControlTransport:
+    def __init__(
+        self,
+        *,
+        max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
+        writer_queue_size: int = 64,
+    ) -> None:
+        if max_frame_bytes < 256 or writer_queue_size < 1:
+            raise ValueError("invalid control transport limits")
+        self.max_frame_bytes = max_frame_bytes
+        self.writer_queue_size = writer_queue_size
+
+    def _connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> ControlConnection:
+        return ControlConnection(
+            reader,
+            writer,
+            max_frame_bytes=self.max_frame_bytes,
+            writer_queue_size=self.writer_queue_size,
+        )
+
+    async def connect(self, host: str, port: int) -> ControlConnection:
+        reader, writer = await asyncio.open_connection(host, port)
+        return self._connection(reader, writer)
+
+    async def start_server(
+        self,
+        host: str,
+        port: int,
+        handler: Callable[[ControlConnection], Awaitable[None]],
+    ) -> asyncio.AbstractServer:
+        async def accept(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            connection = self._connection(reader, writer)
+            try:
+                await handler(connection)
+            finally:
+                await connection.close()
+
+        return await asyncio.start_server(accept, host, port)

--- a/oobleck/elastic/workers.py
+++ b/oobleck/elastic/workers.py
@@ -1,0 +1,137 @@
+"""Agent-owned local GPU worker process lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import sys
+from pathlib import Path
+from typing import Awaitable, Callable, Sequence
+
+from oobleck.config import AgentConfig
+from oobleck.elastic.service_public_base import NodeAgentClient
+from oobleck.elastic.transport import MessageEnvelope
+
+
+class LocalWorkerSupervisor:
+    """Launch and retire one training process for each configured local GPU."""
+
+    def __init__(
+        self,
+        script: str | Path,
+        script_args: Sequence[str],
+        *,
+        node_id: str,
+        gpu_ids: Sequence[str],
+        socket_path: str | Path,
+    ) -> None:
+        self.script = Path(script)
+        self.script_args = tuple(script_args)
+        self.node_id = node_id
+        self.gpu_ids = tuple(gpu_ids)
+        self.socket_path = Path(socket_path)
+        self.processes: list[asyncio.subprocess.Process] = []
+
+    async def start(self) -> None:
+        if self.processes:
+            raise RuntimeError("local workers are already running")
+        if not self.script.is_file():
+            raise FileNotFoundError(f"worker script does not exist: {self.script}")
+        for local_rank, gpu_id in enumerate(self.gpu_ids):
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "CUDA_VISIBLE_DEVICES": gpu_id,
+                    "LOCAL_RANK": "0",
+                    "OOBLECK_GPU_ID": gpu_id,
+                    "OOBLECK_LOCAL_RANK": str(local_rank),
+                    "OOBLECK_LOCAL_WORKER_SOCKET": str(self.socket_path),
+                    "OOBLECK_NODE_ID": self.node_id,
+                    "OOBLECK_WORKER_ID": f"{self.node_id}:gpu-{gpu_id}",
+                    "PYTHONUNBUFFERED": "1",
+                }
+            )
+            process = await asyncio.create_subprocess_exec(
+                sys.executable,
+                str(self.script),
+                *self.script_args,
+                env=environment,
+            )
+            self.processes.append(process)
+
+    async def wait(self) -> tuple[int, ...]:
+        if not self.processes:
+            raise RuntimeError("local workers have not been started")
+        codes = tuple(await asyncio.gather(*(item.wait() for item in self.processes)))
+        failed = [code for code in codes if code != 0]
+        if failed:
+            raise RuntimeError(f"local GPU workers exited unsuccessfully: {codes}")
+        return codes
+
+    async def close(self) -> None:
+        running = [item for item in self.processes if item.returncode is None]
+        for process in running:
+            process.terminate()
+        if running:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*(item.wait() for item in running)), timeout=5.0
+                )
+            except TimeoutError:
+                for process in running:
+                    if process.returncode is None:
+                        process.kill()
+                await asyncio.gather(*(item.wait() for item in running))
+        self.processes.clear()
+
+
+async def run_agent_service(
+    config: AgentConfig,
+    *,
+    on_membership: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
+    on_generation_active: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
+) -> None:
+    """Run an agent lease and, when configured, its local training workers."""
+
+    client = NodeAgentClient(
+        config.node_id,
+        config.gpu_ids,
+        heartbeat_interval_s=config.heartbeat_interval_s,
+        on_membership=on_membership,
+        on_generation_active=on_generation_active,
+        local_worker_socket=config.local_worker_socket,
+    )
+    supervisor = (
+        LocalWorkerSupervisor(
+            config.worker_script,
+            config.worker_args,
+            node_id=config.node_id,
+            gpu_ids=config.gpu_ids,
+            socket_path=config.local_worker_socket,
+        )
+        if config.worker_script is not None and config.local_worker_socket is not None
+        else None
+    )
+    agent_task: asyncio.Task[None] | None = None
+    workers_completed = False
+    await client.connect(config.master_host, config.master_port)
+    try:
+        if supervisor is None:
+            await client.run_reconnecting()
+            return
+        await supervisor.start()
+        agent_task = asyncio.create_task(client.run_reconnecting())
+        await supervisor.wait()
+        workers_completed = True
+    finally:
+        if supervisor is not None:
+            await supervisor.close()
+        with contextlib.suppress(Exception):
+            await client.close(graceful=workers_completed and not client._stopping)
+        if agent_task is not None:
+            agent_task.cancel()
+            await asyncio.gather(agent_task, return_exceptions=True)
+
+
+__all__ = ["LocalWorkerSupervisor", "run_agent_service"]

--- a/tests/refactor/test_control.py
+++ b/tests/refactor/test_control.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+
+import pytest
+
+from oobleck.elastic import (
+    FrameTooLarge,
+    MembershipStateMachine,
+    MessageEnvelope,
+    NodeIdentity,
+    StaleGeneration,
+    StaleSequence,
+    encode_frame,
+    read_frame,
+)
+from oobleck.elastic.transport import ProtocolError, SerializedWriter
+
+
+def test_frames_support_fragmentation_and_coalescing():
+    async def check():
+        first = MessageEnvelope(1, "heartbeat", "a", "i", 1, 0, {})
+        second = MessageEnvelope(1, "heartbeat", "a", "i", 2, 0, {})
+        payload = encode_frame(first) + encode_frame(second)
+        reader = asyncio.StreamReader()
+        for byte in payload[:7]:
+            reader.feed_data(bytes([byte]))
+        reader.feed_data(payload[7:])
+        reader.feed_eof()
+        assert await read_frame(reader) == first
+        assert await read_frame(reader) == second
+
+    asyncio.run(check())
+
+
+def test_oversized_frame_is_rejected():
+    message = MessageEnvelope(
+        1,
+        "register",
+        "a",
+        "i",
+        0,
+        0,
+        {"addresses": ["x" * 100], "gpu_ids": ["0"]},
+    )
+    with pytest.raises(FrameTooLarge):
+        encode_frame(message, max_frame_bytes=32)
+    with pytest.raises(ProtocolError, match="non-empty list of strings"):
+        MessageEnvelope(1, "register", "a", "i", 0, 0, {"addresses": "host", "gpu_ids": [0]})
+
+
+def test_malformed_frame_and_strict_field_types_are_rejected():
+    async def check():
+        reader = asyncio.StreamReader()
+        body = json.dumps({"protocol_version": True}).encode()
+        reader.feed_data(struct.pack(">I", len(body)) + body)
+        with pytest.raises(ProtocolError):
+            await read_frame(reader)
+
+    asyncio.run(check())
+
+
+def test_serialized_writer_applies_drain_backpressure():
+    class Writer:
+        def __init__(self):
+            self.release = asyncio.Event()
+            self.closed = False
+
+        def write(self, value):
+            self.value = value
+
+        async def drain(self):
+            await self.release.wait()
+
+        def close(self):
+            self.closed = True
+
+        async def wait_closed(self):
+            pass
+
+    async def check():
+        raw = Writer()
+        writer = SerializedWriter(raw, queue_size=1)
+        message = MessageEnvelope(1, "heartbeat", "a", "i", 1, 0, {})
+        pending = asyncio.create_task(writer.send(message))
+        await asyncio.sleep(0)
+        assert not pending.done()
+        raw.release.set()
+        await pending
+        await writer.close()
+        assert raw.closed
+
+    asyncio.run(check())
+
+
+def test_membership_coalesces_failures_and_rejects_stale_messages():
+    state = MembershipStateMachine(lease_timeout_s=5, clock=lambda: 0.0)
+    a = NodeIdentity("a", "a1", ("10.0.0.1",), ("0",))
+    b = NodeIdentity("b", "b1", ("10.0.0.2",), ("0",))
+    state.register(a, 0)
+    state.register(b, 0)
+    initial = state.publish()
+    assert initial is not None and initial.generation == 1
+    with pytest.raises(StaleGeneration):
+        state.heartbeat("a", "a1", 1, 0)
+    state.heartbeat("a", "a1", 1, 1)
+    with pytest.raises(StaleSequence):
+        state.heartbeat("a", "a1", 1, 1)
+    state.disconnect("a", "a1")
+    state.disconnect("b", "b1")
+    failed = state.publish()
+    assert failed is not None and failed.generation == 2
+    assert failed.nodes == ()
+    assert len(failed.reasons) == 2
+
+
+def test_incomplete_frame_and_lease_expiry_use_failure_path():
+    async def incomplete():
+        reader = asyncio.StreamReader()
+        reader.feed_data(struct.pack(">I", 8) + b"{}")
+        reader.feed_eof()
+        with pytest.raises(asyncio.IncompleteReadError):
+            await read_frame(reader)
+
+    asyncio.run(incomplete())
+
+    now = [0.0]
+    state = MembershipStateMachine(lease_timeout_s=5, clock=lambda: now[0])
+    state.register(NodeIdentity("a", "a1", ("10.0.0.1",), ("0",)), 0)
+    assert state.publish().generation == 1
+    now[0] = 5.0
+    assert state.expire_leases() == ("a",)
+    expired = state.publish()
+    assert expired is not None and expired.generation == 2
+    assert expired.nodes == ()
+    assert expired.reasons == ("lease-expired:a",)

--- a/tests/refactor/test_control_service.py
+++ b/tests/refactor/test_control_service.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+
+from oobleck.elastic import (
+    LocalWorkerClient,
+    MasterControlService,
+    NodeAgentClient,
+    inspect_membership,
+    request_drain,
+)
+
+
+def test_agents_join_and_concurrent_disconnects_publish_complete_snapshots():
+    async def check():
+        service = MasterControlService(lease_timeout_s=2, lease_check_interval_s=0.05)
+        server = await service.start("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        first = NodeAgentClient("node-a", ("0",), heartbeat_interval_s=0.02)
+        second = NodeAgentClient("node-b", ("0",), heartbeat_interval_s=0.02)
+        assert (await first.connect("127.0.0.1", port)).generation == 1
+        first_task = asyncio.create_task(first.run())
+        assert (await second.connect("127.0.0.1", port)).generation == 2
+        second_task = asyncio.create_task(second.run())
+        for _ in range(100):
+            if first.generation == second.generation == 2:
+                break
+            await asyncio.sleep(0.01)
+        assert first.generation == second.generation == 2
+        for _ in range(100):
+            if service.active_generation == 2:
+                break
+            await asyncio.sleep(0.01)
+        assert service.active_generation == 2
+        await asyncio.gather(first.connection.close(), second.connection.close())
+        await asyncio.sleep(0.05)
+        first_task.cancel()
+        second_task.cancel()
+        await asyncio.gather(first_task, second_task, return_exceptions=True)
+        assert service.membership.agent_ids == ()
+        assert service.membership.generation >= 3
+        await service.close()
+
+    asyncio.run(check())
+
+
+def test_inspection_reconnect_and_graceful_drain_use_complete_snapshots():
+    async def check():
+        service = MasterControlService(lease_timeout_s=2, lease_check_interval_s=0.02)
+        server = await service.start("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        client = NodeAgentClient("node-a", ("0",), heartbeat_interval_s=0.01)
+        await client.connect("127.0.0.1", port)
+        first_incarnation = client.incarnation_id
+        task = asyncio.create_task(client.run_reconnecting(retry_delay_s=0.01))
+
+        inspected = await inspect_membership("127.0.0.1", port)
+        assert [node.agent_id for node in inspected.nodes] == ["node-a"]
+        await client.connection.close()
+        for _ in range(200):
+            if client.incarnation_id != first_incarnation and client.connection is not None:
+                break
+            await asyncio.sleep(0.01)
+        assert client.incarnation_id != first_incarnation
+        assert service.membership.agent_ids == ("node-a",)
+
+        accepted_generation = await request_drain("127.0.0.1", port, "node-a")
+        assert accepted_generation == client.generation
+        for _ in range(200):
+            if service.membership.agent_ids == ():
+                break
+            await asyncio.sleep(0.01)
+        assert service.membership.agent_ids == ()
+        await client.close()
+        await asyncio.gather(task, return_exceptions=True)
+        await service.close()
+
+    asyncio.run(check())
+
+
+def test_agent_relays_latest_membership_to_local_gpu_workers(tmp_path):
+    async def check():
+        service = MasterControlService(lease_timeout_s=2, lease_check_interval_s=0.02)
+        server = await service.start("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        socket_path = tmp_path / "agent.sock"
+        first = NodeAgentClient(
+            "node-a",
+            ("0",),
+            heartbeat_interval_s=0.01,
+            local_worker_socket=socket_path,
+        )
+        await first.connect("127.0.0.1", port)
+        first_task = asyncio.create_task(first.run())
+
+        # A worker that starts after registration still receives generation 1.
+        worker = LocalWorkerClient(socket_path, "node-a", "gpu-0")
+        await worker.connect()
+        assert (await worker.receive()).generation == 1
+
+        second = NodeAgentClient("node-b", ("0",), heartbeat_interval_s=0.01)
+        await second.connect("127.0.0.1", port)
+        assert (await worker.receive()).generation == 2
+
+        class Context:
+            def __init__(self):
+                self.generations = []
+                self.active_generations = []
+
+            def apply_membership(self, snapshot):
+                self.generations.append(snapshot.generation)
+                return True
+
+            def mark_generation_active(self, generation):
+                self.active_generations.append(generation)
+
+        context = Context()
+        worker_task = asyncio.create_task(worker.run_context(context))
+        await second.close()
+        for _ in range(200):
+            if context.active_generations:
+                break
+            await asyncio.sleep(0.01)
+        assert context.generations == [3]
+        assert context.active_generations == [3]
+        assert service.active_generation == 3
+
+        await worker.close()
+        await first.close()
+        first_task.cancel()
+        worker_task.cancel()
+        await asyncio.gather(first_task, worker_task, return_exceptions=True)
+        await service.close()
+        assert not socket_path.exists()
+
+    asyncio.run(check())

--- a/tests/refactor/test_hostfile.py
+++ b/tests/refactor/test_hostfile.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from oobleck.config import TrainingLaunchConfig
+from oobleck.elastic import load_initial_hostfile, ssh_agent_command
+
+
+def test_initial_hostfile_is_strict_and_builds_agent_commands(tmp_path):
+    path = tmp_path / "hosts.txt"
+    path.write_text("# stable node inventory\nnode-a 10.0.0.1 0,1\nnode-b 10.0.0.2 0,1\n")
+    hosts = load_initial_hostfile(path)
+    assert [item.node_id for item in hosts] == ["node-a", "node-b"]
+    command = ssh_agent_command(
+        hosts[0],
+        agent_script="run_agent.py",
+        worker_script="pretrain.py",
+        master_host="10.0.0.9",
+        master_port=29600,
+        worker_args=("--split", "train"),
+    )
+    assert command[:3] == ("ssh", "10.0.0.1", "python")
+    assert "--node-id" in command and "node-a" in command
+    assert command[-3:] == ("--worker-args", "--split", "train")
+
+
+def test_initial_hostfile_rejects_duplicate_ids_and_mixed_tp_width(tmp_path):
+    duplicate = tmp_path / "duplicate.txt"
+    duplicate.write_text("node-a host-a 0\nnode-a host-b 0\n")
+    with pytest.raises(ValueError, match="duplicate stable node"):
+        load_initial_hostfile(duplicate)
+
+    mixed = tmp_path / "mixed.txt"
+    mixed.write_text("node-a host-a 0\nnode-b host-b 0,1\n")
+    with pytest.raises(ValueError, match="fixed per-node TP width"):
+        load_initial_hostfile(mixed)
+
+
+def test_ssh_launch_configuration_requires_master_and_agent_script(tmp_path):
+    hostfile = tmp_path / "hosts.txt"
+    hostfile.write_text("node-a host-a 0\n")
+    with pytest.raises(ValueError, match="SSH bootstrap"):
+        TrainingLaunchConfig(
+            training_script=tmp_path / "train.py",
+            initial_hostfile=hostfile,
+        )


### PR DESCRIPTION
## Summary

- adds strict length-prefixed asyncio TCP framing and payload validation
- adds complete checksummed membership generations, leases, reconnect ordering, and coalesced failure handling
- adds local Unix-socket worker preparation/activation barriers
- adds graceful drain, inspection, hostfile bootstrap, and agent-owned worker supervision

## Validation

- pytest -q tests/refactor/test_control.py tests/refactor/test_control_service.py tests/refactor/test_hostfile.py (12 passed)
- git diff --cached --check

Targets only refactor.