### PR TITLE
PR 6: Add initial heterogeneous execution

### DIFF
--- a/oobleck/__init__.py
+++ b/oobleck/__init__.py
@@ -1,0 +1,34 @@
+"""Oobleck heterogeneous elastic training API."""
+
+from oobleck.data import OobleckBatch, OobleckBatchSampler
+from oobleck.runtime_base import (
+    OobleckParallelContext,
+    OobleckParallelizationPlan,
+    OobleckStepResult,
+)
+from oobleck.types import (
+    CompatibilityFingerprint,
+    OobleckConfig,
+    OobleckExecutionPlan,
+    PipelineInstance,
+    PipelineStageSpec,
+    PipelineTemplate,
+    RecoveryUnavailable,
+    RuntimeCompatibility,
+)
+
+__all__ = [
+    "CompatibilityFingerprint",
+    "OobleckBatch",
+    "OobleckBatchSampler",
+    "OobleckConfig",
+    "OobleckExecutionPlan",
+    "OobleckParallelContext",
+    "OobleckParallelizationPlan",
+    "OobleckStepResult",
+    "PipelineInstance",
+    "PipelineStageSpec",
+    "PipelineTemplate",
+    "RecoveryUnavailable",
+    "RuntimeCompatibility",
+]

--- a/oobleck/distributed/__init__.py
+++ b/oobleck/distributed/__init__.py
@@ -1,0 +1,3 @@
+from oobleck.distributed.lifecycle import ProcessGroupLayoutError, destroy_process_group_universe
+
+__all__ = ["ProcessGroupLayoutError", "destroy_process_group_universe"]

--- a/oobleck/distributed/lifecycle.py
+++ b/oobleck/distributed/lifecycle.py
@@ -1,0 +1,72 @@
+"""Version-checked full process-group teardown for generation replacement."""
+
+from __future__ import annotations
+
+import re
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterable
+
+
+class ProcessGroupLayoutError(RuntimeError):
+    pass
+
+
+_REQUIRED = (
+    "pg_map",
+    "pg_names",
+    "pg_group_ranks",
+    "pg_backend_config",
+    "pg_to_tag",
+    "tags_to_pg",
+    "pg_coalesce_state",
+)
+_OPTIONAL = ("_pg_coalesce_state", "pg_default_device")
+
+
+def _shutdown(group: object) -> None:
+    shutdown = getattr(group, "_shutdown", None)
+    if callable(shutdown):
+        shutdown()
+
+
+def destroy_process_group_universe(extra_handles: Iterable[object] = ()) -> None:
+    """Concurrently stop all groups, destroy WORLD, and clear known registries."""
+
+    import torch
+    import torch.distributed as dist
+    from torch.distributed import distributed_c10d as c10d
+
+    version = re.match(r"(\d+)\.(\d+)", torch.__version__)
+    if version is None or not (2, 6) <= tuple(map(int, version.groups())) <= (2, 10):
+        raise ProcessGroupLayoutError(
+            f"PyTorch {torch.__version__} is outside the audited c10d teardown range 2.6-2.10"
+        )
+    world = getattr(c10d, "_world", None)
+    missing = [name for name in _REQUIRED if world is None or not hasattr(world, name)]
+    if missing:
+        raise ProcessGroupLayoutError(
+            f"unsupported PyTorch c10d registry layout; missing {missing}"
+        )
+    handles = [*extra_handles, *list(world.pg_map)]
+    unique = list({id(handle): handle for handle in handles}.values())
+    if unique:
+        with ThreadPoolExecutor(max_workers=len(unique)) as executor:
+            list(executor.map(_shutdown, unique))
+    if dist.is_initialized():
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
+    update = getattr(c10d, "_update_default_pg", None)
+    if callable(update):
+        update(None)
+    for name in (*_REQUIRED, *_OPTIONAL):
+        if hasattr(world, name):
+            registry = getattr(world, name)
+            clear = getattr(registry, "clear", None)
+            if callable(clear):
+                clear()
+    if hasattr(world, "group_count"):
+        world.group_count = 0
+    if dist.is_initialized():
+        raise RuntimeError("WORLD remained initialized after complete teardown")

--- a/oobleck/distributed/lifecycle_base.py
+++ b/oobleck/distributed/lifecycle_base.py
@@ -1,0 +1,66 @@
+"""Version-checked full process-group teardown for generation replacement."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterable
+
+
+class ProcessGroupLayoutError(RuntimeError):
+    pass
+
+
+_WORLD_REGISTRIES = (
+    "pg_map",
+    "pg_names",
+    "pg_group_ranks",
+    "pg_backend_config",
+    "pg_to_tag",
+    "tags_to_pg",
+    "pg_coalesce_state",
+    "pg_default_device",
+)
+
+
+def _shutdown_backend(group: object) -> None:
+    shutdown = getattr(group, "_shutdown", None)
+    if callable(shutdown):
+        shutdown()
+
+
+def destroy_process_group_universe(extra_handles: Iterable[object] = ()) -> None:
+    """Destroy every known group and clear guarded c10d registries.
+
+    This is intentionally strict: an unknown private registry layout is safer
+    as a loud compatibility failure than as a silently retained communicator.
+    """
+
+    import torch.distributed as dist
+    from torch.distributed import distributed_c10d as c10d
+
+    handles = list(extra_handles)
+    world = getattr(c10d, "_world", None)
+    if world is None or any(not hasattr(world, name) for name in _WORLD_REGISTRIES):
+        missing = [name for name in _WORLD_REGISTRIES if world is None or not hasattr(world, name)]
+        raise ProcessGroupLayoutError(
+            f"unsupported PyTorch c10d registry layout; missing {missing}"
+        )
+    handles.extend(list(world.pg_map))
+    unique = list({id(handle): handle for handle in handles}.values())
+    if unique:
+        with ThreadPoolExecutor(max_workers=len(unique)) as executor:
+            list(executor.map(_shutdown_backend, unique))
+    if dist.is_initialized():
+        try:
+            dist.destroy_process_group()
+        except Exception:
+            pass
+    update = getattr(c10d, "_update_default_pg", None)
+    if callable(update):
+        update(None)
+    for name in _WORLD_REGISTRIES:
+        getattr(world, name).clear()
+    if hasattr(world, "group_count"):
+        world.group_count = 0
+    if dist.is_initialized():
+        raise RuntimeError("WORLD remained initialized after complete teardown")

--- a/oobleck/meshes.py
+++ b/oobleck/meshes.py
@@ -1,0 +1,50 @@
+"""Deterministic construction of heterogeneous per-pipeline Cornstarch meshes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from oobleck.types import OobleckExecutionPlan
+
+
+def create_heterogeneous_pipeline_meshes(
+    execution_plan: OobleckExecutionPlan,
+    *,
+    device_type: str,
+) -> tuple[dict[str, Any], Any]:
+    """Create every pipeline mesh in identical world-wide order.
+
+    ``DeviceMesh`` group creation is world-order-sensitive even for non-members,
+    so every rank calls this for every instance. The second return value is the
+    current rank's local pipeline mesh.
+    """
+
+    import torch.distributed as dist
+    from cornstarch.distributed import ModalProcessGroupMesh
+
+    if not dist.is_initialized():
+        raise RuntimeError("WORLD must be initialized before mesh activation")
+    rank = dist.get_rank()
+    meshes: dict[str, Any] = {}
+    local = None
+    for instance in sorted(execution_plan.instances, key=lambda item: item.instance_id):
+        if not instance.ranks:
+            raise ValueError(f"pipeline {instance.instance_id} has no concrete rank groups")
+        global_ranks = [rank for stage_ranks in instance.ranks for rank in stage_ranks]
+        mesh = ModalProcessGroupMesh(
+            device_type=device_type,
+            global_ranks=global_ranks,
+            dp_size=1,
+            cp_size=1,
+            tp_size=instance.template.tensor_parallel_size,
+            num_pp_stages=instance.template.num_stages,
+            ep_size=1,
+        )
+        meshes[instance.instance_id] = mesh
+        if rank in global_ranks:
+            if local is not None:
+                raise ValueError(f"rank {rank} belongs to more than one pipeline")
+            local = mesh
+    if local is None:
+        raise ValueError(f"rank {rank} is not assigned to any pipeline")
+    return meshes, local

--- a/oobleck/runtime_base.py
+++ b/oobleck/runtime_base.py
@@ -1,0 +1,512 @@
+"""Public plan/context API and logical-step transaction implementation."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+import torch
+from torch.utils.data import DataLoader
+
+from oobleck.cornstarch import ActivatedPartition, CompiledLocalPartition, compile_local_partition
+from oobleck.data import (
+    OobleckBatch,
+    OobleckBatchSampler,
+    PreparedDataLoader,
+    logical_seed,
+    prepare_dataloader,
+)
+from oobleck.distributed import destroy_process_group_universe
+from oobleck.planning import (
+    PipelineTemplate,
+    RecoveryUnavailable,
+    compose_templates,
+    reconfigure_pipelines,
+)
+from oobleck.types import (
+    OobleckConfig,
+    OobleckExecutionPlan,
+    RuntimeCompatibility,
+    stable_rank_map,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OobleckStepResult:
+    committed: bool
+    committed_step: int
+    generation: int
+    attempts: int
+    loss: float | None = None
+    output: Any = None
+
+
+class OobleckParallelizationPlan:
+    """Prepare rank-local ownership before creating the distributed world."""
+
+    def __init__(
+        self,
+        config: OobleckConfig,
+        *,
+        templates: Sequence[PipelineTemplate] = (),
+        node_ids: Sequence[str] = (),
+        rank: int = 0,
+        cornstarch_plan: object | None = None,
+        world_initializer: Callable[[OobleckExecutionPlan], None] | None = None,
+        compatibility: RuntimeCompatibility | None = None,
+    ) -> None:
+        self.config = config
+        self.templates = tuple(templates)
+        self.node_ids = tuple(node_ids)
+        self.rank = rank
+        self.cornstarch_plan = cornstarch_plan
+        self.world_initializer = world_initializer
+        self.compatibility = compatibility
+        self.model: torch.nn.Module | None = None
+        self.parallel_config: object | None = None
+        self._generation = 0
+        self._last_execution_plan: OobleckExecutionPlan | None = None
+        self.last_reconfiguration: object | None = None
+        self._local_node_id: str | None = None
+        self._tp_lane: int | None = None
+        self._target_rank = rank
+
+    def parallelize(self, model: torch.nn.Module, parallel_config: object) -> None:
+        if self.model is not None:
+            raise RuntimeError("parallelize() may be called only once in the first release")
+        required = {
+            "tensor_parallel_size": 1,
+            "pipeline_parallel_size": None,
+            "data_parallel_size": 1,
+            "context_parallel_size": 1,
+            "expert_parallel_size": 1,
+        }
+        for name, expected in required.items():
+            if not hasattr(parallel_config, name):
+                if name == "tensor_parallel_size":
+                    raise TypeError("parallel_config must define tensor_parallel_size")
+                continue
+            value = getattr(parallel_config, name)
+            if name == "tensor_parallel_size":
+                if not isinstance(value, int) or value < 1:
+                    raise ValueError("tensor_parallel_size must be a positive integer")
+            elif value != expected:
+                raise ValueError(
+                    f"Oobleck chooses heterogeneous PP/DP and requires {name}={expected!r}; got {value!r}"
+                )
+        self.model = model
+        self.parallel_config = parallel_config
+        if self.cornstarch_plan is not None:
+            register = getattr(self.cornstarch_plan, "parallelize", None)
+            if callable(register):
+                register(model, parallel_config)
+
+    def set_templates(self, templates: Sequence[PipelineTemplate]) -> None:
+        if not templates:
+            raise ValueError("templates must not be empty")
+        self.templates = tuple(templates)
+
+    def set_membership(self, node_ids: Sequence[str], generation: int | None = None) -> None:
+        if len(node_ids) != len(set(node_ids)):
+            raise ValueError("node IDs must be unique")
+        if len(node_ids) > self.config.max_nodes:
+            raise ValueError("membership exceeds configured max_nodes")
+        selected = tuple(sorted(node_ids))
+        changed = selected != tuple(sorted(self.node_ids))
+        self.node_ids = selected
+        if generation is not None:
+            if generation < self._generation:
+                raise ValueError("membership generation cannot move backwards")
+            self._generation = generation
+        elif changed:
+            self._generation += 1
+
+    def _default_template(self) -> PipelineTemplate:
+        assert self.model is not None and self.parallel_config is not None
+        layer_count = 1
+        repeated_layers = getattr(self.model, "_repeated_layers", None)
+        if callable(repeated_layers):
+            layers = repeated_layers()
+            if len(layers):
+                layer_count = len(layers)
+        for candidate in ("layers", "h", "blocks"):
+            value = getattr(self.model, candidate, None)
+            if isinstance(value, (torch.nn.ModuleList, list, tuple)) and value:
+                layer_count = len(value)
+                break
+        return PipelineTemplate(
+            "local-single-stage",
+            ((0, layer_count),),
+            int(getattr(self.parallel_config, "tensor_parallel_size")),
+            1.0,
+            1.0,
+        )
+
+    def build_execution_plan(self) -> OobleckExecutionPlan:
+        if self.model is None or self.parallel_config is None:
+            raise RuntimeError("call parallelize() before building or materializing a plan")
+        tp = int(getattr(self.parallel_config, "tensor_parallel_size"))
+        nodes = self.node_ids or (os.environ.get("OOBLECK_NODE_ID", "local-node"),)
+        if len(nodes) > self.config.max_nodes:
+            raise ValueError("membership exceeds configured max_nodes")
+        templates = self.templates or (self._default_template(),)
+        if any(item.tensor_parallel_size != tp for item in templates):
+            raise ValueError("every template TP width must equal the fixed per-node TP width")
+        minimum = min(item.resource_count for item in templates)
+        threshold = self.config.fault_tolerance_threshold
+        if len(nodes) < minimum * (threshold + 1):
+            threshold = 0
+        previous_plan = self._last_execution_plan
+        if previous_plan is not None and previous_plan.generation < self._generation:
+            state_bytes_by_node = {
+                node: max(1, instance.template.persistent_memory // len(instance.node_ids))
+                for instance in previous_plan.instances
+                for node in instance.node_ids
+            }
+            reconfiguration = reconfigure_pipelines(
+                previous_plan.instances,
+                nodes,
+                templates,
+                self.config.global_num_microbatches,
+                threshold,
+                state_bytes_by_node=state_bytes_by_node,
+            )
+            instances = reconfiguration.instances
+            self.last_reconfiguration = reconfiguration
+        else:
+            instances = compose_templates(
+                templates,
+                nodes,
+                self.config.global_num_microbatches,
+                threshold,
+            )
+            self.last_reconfiguration = None
+        rank_map = stable_rank_map(nodes, tp)
+        ranks_by_node = dict(rank_map)
+        ranked = tuple(
+            replace(
+                item,
+                ranks=tuple(ranks_by_node[node] for node in item.node_ids),
+            )
+            for item in instances
+        )
+        previous = (
+            previous_plan.generation
+            if previous_plan is not None and previous_plan.generation < self._generation
+            else (
+                previous_plan.previous_generation
+                if previous_plan is not None
+                else (self._generation - 1 if self._generation else None)
+            )
+        )
+        result = OobleckExecutionPlan(
+            self._generation,
+            ranked,
+            rank_map,
+            previous,
+            self.compatibility.digest if self.compatibility is not None else None,
+        )
+        self._last_execution_plan = result
+        if self._local_node_id is None:
+            for node_id, rank_group in result.rank_map:
+                if self.rank in rank_group:
+                    self._local_node_id = node_id
+                    self._tp_lane = rank_group.index(self.rank)
+                    break
+        return result
+
+    def rank_for_plan(self, execution_plan: OobleckExecutionPlan) -> int:
+        if self._local_node_id is None:
+            return self.rank
+        for node_id, ranks in execution_plan.rank_map:
+            if node_id == self._local_node_id:
+                lane = self._tp_lane or 0
+                if lane >= len(ranks):
+                    raise RecoveryUnavailable(f"TP lane {lane} is unavailable for node {node_id!r}")
+                return ranks[lane]
+        raise RecoveryUnavailable(
+            f"local node {self._local_node_id!r} is not part of generation "
+            f"{execution_plan.generation}"
+        )
+
+    def compile(self, execution_plan: OobleckExecutionPlan | None = None) -> CompiledLocalPartition:
+        if self.model is None or self.parallel_config is None:
+            raise RuntimeError("call parallelize() before compile()")
+        plan = execution_plan or self.build_execution_plan()
+        expected_compatibility = (
+            self.compatibility.digest if self.compatibility is not None else None
+        )
+        if plan.compatibility_digest != expected_compatibility:
+            raise ValueError(
+                "execution plan compatibility does not match this worker; "
+                f"plan={plan.compatibility_digest}, local={expected_compatibility}"
+            )
+        target_rank = self.rank_for_plan(plan)
+        self._target_rank = target_rank
+        return compile_local_partition(
+            self.model,
+            self.parallel_config,
+            plan,
+            target_rank,
+            cornstarch_plan=self.cornstarch_plan,
+        )
+
+    def materialize(
+        self,
+        device: str | torch.device = "cuda",
+        dtype: torch.dtype | None = None,
+        *,
+        recover_from_survivors: bool = False,
+    ) -> "OobleckParallelContext":
+        execution_plan = self.build_execution_plan()
+        compiled = self.compile(execution_plan)
+        if self.world_initializer is not None:
+            self.world_initializer(execution_plan)
+        activated = compiled.activate(device, dtype)
+        return OobleckParallelContext(
+            config=self.config,
+            owner_plan=self,
+            execution_plan=execution_plan,
+            compiled=compiled,
+            partition=activated,
+            device=torch.device(device),
+            dtype=dtype,
+            needs_survivor_recovery=recover_from_survivors,
+        )
+
+
+class OobleckParallelContext:
+    def __init__(
+        self,
+        *,
+        config: OobleckConfig,
+        owner_plan: OobleckParallelizationPlan,
+        execution_plan: OobleckExecutionPlan,
+        compiled: CompiledLocalPartition,
+        partition: ActivatedPartition,
+        device: torch.device,
+        dtype: torch.dtype | None,
+        needs_survivor_recovery: bool = False,
+    ) -> None:
+        self.config = config
+        self.owner_plan = owner_plan
+        self.execution_plan = execution_plan
+        self.compiled = compiled
+        self.partition = partition
+        self.device = device
+        self.dtype = dtype
+        self.committed_step = 0
+        self.optimizer: torch.optim.Optimizer | None = None
+        self.scheduler: Any = None
+        self.scaler: Any = None
+        self._pending_plan: OobleckExecutionPlan | None = None
+        self._loaders: list[PreparedDataLoader] = []
+        self._closed = False
+        self._needs_survivor_recovery = needs_survivor_recovery
+
+    @property
+    def model(self) -> torch.nn.Module:
+        return self.partition.model
+
+    @property
+    def generation(self) -> int:
+        return self.execution_plan.generation
+
+    def create_batch_sampler(
+        self,
+        dataset: object,
+        *,
+        shuffle: bool,
+        drop_last: bool = True,
+    ) -> OobleckBatchSampler:
+        return OobleckBatchSampler(
+            dataset,
+            global_batch_size=self.config.global_batch_size,
+            microbatch_size=self.config.microbatch_size,
+            instances=self.execution_plan.instances,
+            seed=self.config.seed,
+            shuffle=shuffle,
+            drop_last=drop_last,
+        )
+
+    def prepare_dataloader(self, dataloader: DataLoader) -> PreparedDataLoader:
+        loader = prepare_dataloader(dataloader)
+        self._loaders.append(loader)
+        return loader
+
+    def configure_optimization(
+        self,
+        *,
+        optimizer_factory: Callable[[Iterable[torch.nn.Parameter]], torch.optim.Optimizer],
+        scheduler_factory: Callable[[torch.optim.Optimizer], Any] | None = None,
+        scaler: Any = None,
+    ) -> None:
+        if self.optimizer is not None:
+            raise RuntimeError("optimization is already configured")
+        self.optimizer = optimizer_factory(self.model.parameters())
+        self.scheduler = scheduler_factory(self.optimizer) if scheduler_factory else None
+        self.scaler = scaler
+
+    def announce_generation(self, plan: OobleckExecutionPlan) -> bool:
+        if plan.generation <= self.generation:
+            return False
+        if self._pending_plan is None or plan.generation > self._pending_plan.generation:
+            self._pending_plan = plan
+        return True
+
+    def _activate_latest_generation(self) -> None:
+        while self._pending_plan is not None:
+            target = self._pending_plan
+            self._pending_plan = None
+            for loader in self._loaders:
+                loader.invalidate_prefetch()
+            self.partition.close()
+            try:
+                import torch.distributed as dist
+
+                initialized = dist.is_initialized()
+            except Exception:
+                initialized = False
+            if initialized:
+                destroy_process_group_universe()
+            compiled = self.owner_plan.compile(target)
+            if self.owner_plan.world_initializer is not None:
+                self.owner_plan.world_initializer(target)
+            self.compiled = compiled
+            self.partition = compiled.activate(self.device, self.dtype)
+            self.execution_plan = target
+
+    def _call_model(self, microbatch: Any) -> Any:
+        if isinstance(microbatch, Mapping):
+            return self.model(**microbatch)
+        return self.model(microbatch)
+
+    def _local_microbatches(self, batch: OobleckBatch) -> tuple[tuple[int, Any], ...]:
+        pipeline_id = self.execution_plan.rank_local_stage(self.owner_plan.rank).pipeline_id
+        cursor = 0
+        selected: tuple[int, ...] | None = None
+        for instance in self.execution_plan.instances:
+            identifiers = tuple(range(cursor, cursor + instance.microbatches))
+            if instance.instance_id == pipeline_id:
+                selected = identifiers
+            cursor += instance.microbatches
+        if cursor != len(batch.microbatches):
+            raise RuntimeError(
+                f"logical batch has {len(batch.microbatches)} microbatches but "
+                f"generation {self.generation} allocates {cursor}"
+            )
+        if selected is None:
+            raise RuntimeError(f"local pipeline {pipeline_id!r} has no batch allocation")
+        return tuple((index, batch.microbatches[index]) for index in selected)
+
+    def _execute_attempt(
+        self,
+        batch: OobleckBatch,
+        execution: Any,
+        output_reference: Any,
+        criterion: Callable[..., torch.Tensor] | None,
+    ) -> tuple[torch.Tensor | None, Any]:
+        assert self.optimizer is not None
+        local_microbatches = self._local_microbatches(batch)
+        if hasattr(execution, "step") and callable(execution.step):
+            result = execution.step(
+                [microbatch for _, microbatch in local_microbatches],
+                criterion,
+                self.optimizer,
+                return_loss=True,
+            )
+            loss = result.get("loss") if isinstance(result, dict) else None
+            return loss, result
+        total_loss: torch.Tensor | None = None
+        last_output: Any = None
+        count = max(1, len(local_microbatches))
+        for microbatch_id, microbatch in local_microbatches:
+            seed = logical_seed(
+                self.config.seed,
+                batch.descriptor.epoch,
+                self.committed_step,
+                microbatch_id,
+            )
+            devices = [self.device] if self.device.type == "cuda" else []
+            with torch.random.fork_rng(devices=devices):
+                torch.manual_seed(seed)
+                if execution is None:
+                    last_output = self._call_model(microbatch)
+                elif callable(execution):
+                    last_output = execution(microbatch)
+                elif hasattr(execution, "execute"):
+                    last_output = execution.execute(microbatch)
+                else:
+                    raise TypeError("execution plan must be callable or expose execute()/step()")
+                loss = criterion(last_output, microbatch) if criterion else last_output
+                if not isinstance(loss, torch.Tensor):
+                    raise TypeError("criterion/execution must produce a torch.Tensor loss")
+                (loss / count).backward()
+                total_loss = loss.detach() if total_loss is None else total_loss + loss.detach()
+        return (None if total_loss is None else total_loss / count), last_output
+
+    def step(
+        self,
+        batch: OobleckBatch,
+        execution_plan: Any = None,
+        output: Any = None,
+        criterion: Callable[..., torch.Tensor] | None = None,
+    ) -> OobleckStepResult:
+        if self._closed:
+            raise RuntimeError("context is closed")
+        if self.optimizer is None:
+            raise RuntimeError("call configure_optimization() before step()")
+        attempts = 0
+        while True:
+            attempts += 1
+            if self._pending_plan is not None:
+                self._activate_latest_generation()
+            self.optimizer.zero_grad(set_to_none=True)
+            loss, result = self._execute_attempt(batch, execution_plan, output, criterion)
+            sync = getattr(self.partition.external_context, "sync_gradients", None)
+            if callable(sync):
+                sync()
+            heterogeneous_sync = getattr(self, "_heterogeneous_gradient_sync", None)
+            if heterogeneous_sync is not None:
+                heterogeneous_sync.sync()
+            if self._pending_plan is not None:
+                self.optimizer.zero_grad(set_to_none=True)
+                self._activate_latest_generation()
+                continue
+            if self.scaler is not None:
+                self.scaler.step(self.optimizer)
+                self.scaler.update()
+            else:
+                self.optimizer.step()
+            if self.scheduler is not None:
+                self.scheduler.step()
+            self.committed_step += 1
+            for loader in self._loaders:
+                if (
+                    loader.sampler.descriptor_at(loader.sampler.committed_cursor)
+                    == batch.descriptor
+                ):
+                    loader.sampler.commit(batch.descriptor)
+                    break
+            return OobleckStepResult(
+                True,
+                self.committed_step,
+                self.generation,
+                attempts,
+                None if loss is None else float(loss.cpu()),
+                result,
+            )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self.partition.close()
+        self._loaders.clear()
+        self._closed = True
+
+    def __enter__(self) -> "OobleckParallelContext":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()

--- a/oobleck/state.py
+++ b/oobleck/state.py
@@ -1,0 +1,60 @@
+"""Public stable-state and redistribution API."""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Mapping, Sequence
+
+from oobleck.state_public_base import (
+    LogicalStateEntry,
+    StateManifest,
+    StateUnavailable,
+    Transfer,
+    TransferSchedule,
+    all_to_all_single_compat,
+)
+from oobleck.state_public_base import plan_state_redistribution as _plan
+
+
+def plan_state_redistribution(
+    old_manifests: Sequence[StateManifest],
+    new_manifests: Sequence[StateManifest],
+    *,
+    chunk_bytes: int,
+    round_bytes: int | None = None,
+    alignment: int = 256,
+    rank_to_node: Mapping[int, str] | None = None,
+    bandwidth_bytes_per_s: Mapping[int, float] | None = None,
+    link_classifier: Callable[[int, int], tuple[str, float]] | None = None,
+) -> TransferSchedule:
+    # In the topology-free model destination ingress is identical for every
+    # candidate and must not erase the source-egress tie-break.  Infinite
+    # destination bandwidth removes only that common term; measured bandwidth
+    # supplied by an operator remains authoritative.
+    bandwidth = bandwidth_bytes_per_s
+    if bandwidth is None:
+        bandwidth = {
+            entry.owner_rank: 1.0 for manifest in old_manifests for entry in manifest.entries
+        }
+        bandwidth.update({manifest.rank: math.inf for manifest in new_manifests})
+    return _plan(
+        old_manifests,
+        new_manifests,
+        chunk_bytes=chunk_bytes,
+        round_bytes=round_bytes,
+        alignment=alignment,
+        rank_to_node=rank_to_node,
+        bandwidth_bytes_per_s=bandwidth,
+        link_classifier=link_classifier,
+    )
+
+
+__all__ = [
+    "LogicalStateEntry",
+    "StateManifest",
+    "StateUnavailable",
+    "Transfer",
+    "TransferSchedule",
+    "all_to_all_single_compat",
+    "plan_state_redistribution",
+]

--- a/oobleck/state_base.py
+++ b/oobleck/state_base.py
@@ -1,0 +1,377 @@
+"""Stable logical state manifests and balanced all-to-all transfer planning."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from functools import reduce
+from operator import mul
+from typing import Callable, Iterable, Mapping, Sequence
+
+
+class StateUnavailable(RuntimeError):
+    """No surviving source owns a required committed state shard."""
+
+
+_DTYPE_BYTES = {
+    "bool": 1,
+    "uint8": 1,
+    "int8": 1,
+    "int16": 2,
+    "float16": 2,
+    "bfloat16": 2,
+    "int32": 4,
+    "float32": 4,
+    "int64": 8,
+    "float64": 8,
+    "complex64": 8,
+    "complex128": 16,
+}
+
+
+def _dtype_name(value: str) -> str:
+    return value.removeprefix("torch.")
+
+
+@dataclass(frozen=True, slots=True)
+class LogicalStateEntry:
+    logical_key: str
+    global_shape: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    dtype: str
+    state_kind: str
+    placements: tuple[str, ...]
+    tp_lane: int
+    owner_rank: int
+    version: int
+    global_layer_id: str | None = None
+    shared_state_id: str | None = None
+    byte_count: int | None = None
+
+    def __post_init__(self) -> None:
+        if not self.logical_key:
+            raise ValueError("logical_key must not be empty")
+        if any(size < 0 for size in (*self.global_shape, *self.local_shape)):
+            raise ValueError("state shapes must be non-negative")
+        if self.tp_lane < 0 or self.owner_rank < 0 or self.version < 0:
+            raise ValueError("tp_lane, owner_rank, and version must be non-negative")
+        if self.byte_count is not None and self.byte_count < 0:
+            raise ValueError("byte_count must be non-negative")
+        if self.byte_count is None and _dtype_name(self.dtype) not in _DTYPE_BYTES:
+            raise ValueError(f"unknown dtype {self.dtype!r}; provide byte_count explicitly")
+
+    @property
+    def nbytes(self) -> int:
+        if self.byte_count is not None:
+            return self.byte_count
+        elements = reduce(mul, self.local_shape, 1)
+        return elements * _DTYPE_BYTES[_dtype_name(self.dtype)]
+
+    @property
+    def shard_identity(self) -> tuple[object, ...]:
+        return (
+            self.logical_key,
+            self.tp_lane,
+            self.local_shape,
+            _dtype_name(self.dtype),
+            self.placements,
+            self.version,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class StateManifest:
+    rank: int
+    entries: tuple[LogicalStateEntry, ...]
+    committed_step: int
+    manifest_hash: str = field(default="", compare=False)
+
+    def __post_init__(self) -> None:
+        if self.rank < 0 or self.committed_step < 0:
+            raise ValueError("rank and committed_step must be non-negative")
+        if any(entry.owner_rank != self.rank for entry in self.entries):
+            raise ValueError("manifest entries must be owned by the manifest rank")
+        keys = [(entry.logical_key, entry.tp_lane, entry.state_kind) for entry in self.entries]
+        if len(keys) != len(set(keys)):
+            raise ValueError("manifest contains duplicate logical shards")
+        payload = {
+            "rank": self.rank,
+            "committed_step": self.committed_step,
+            "entries": [asdict(item) for item in self.entries],
+        }
+        expected = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        if self.manifest_hash and self.manifest_hash != expected:
+            raise ValueError("manifest hash is invalid")
+        object.__setattr__(self, "manifest_hash", expected)
+
+
+@dataclass(frozen=True, slots=True)
+class Transfer:
+    source_rank: int
+    destination_rank: int
+    logical_key: str
+    state_kind: str
+    tp_lane: int
+    chunk_start: int
+    chunk_end: int
+    dtype: str
+    round: int
+    link_class: str
+    version: int
+
+    @property
+    def byte_count(self) -> int:
+        return self.chunk_end - self.chunk_start
+
+
+@dataclass(frozen=True, slots=True)
+class TransferSchedule:
+    transfers: tuple[Transfer, ...]
+    retained: tuple[tuple[int, str, int], ...]
+    per_source_bytes: tuple[tuple[int, int], ...]
+    per_destination_bytes: tuple[tuple[int, int], ...]
+    per_link_class_bytes: tuple[tuple[str, int], ...]
+    schedule_hash: str = field(default="", compare=False)
+
+    def __post_init__(self) -> None:
+        payload = {
+            "transfers": [asdict(item) for item in self.transfers],
+            "retained": self.retained,
+        }
+        expected = hashlib.sha256(
+            json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        if self.schedule_hash and self.schedule_hash != expected:
+            raise ValueError("transfer schedule hash is invalid")
+        object.__setattr__(self, "schedule_hash", expected)
+
+    def split_sizes(
+        self, rank: int, world_size: int, *, round: int = 0, dtype: str | None = None
+    ) -> tuple[list[int], list[int]]:
+        inputs = [0] * world_size
+        outputs = [0] * world_size
+        for item in self.transfers:
+            if item.round != round or (dtype is not None and item.dtype != dtype):
+                continue
+            if item.source_rank == rank:
+                inputs[item.destination_rank] += item.byte_count
+            if item.destination_rank == rank:
+                outputs[item.source_rank] += item.byte_count
+        return inputs, outputs
+
+
+def _chunks(size: int, chunk_bytes: int, alignment: int) -> Iterable[tuple[int, int]]:
+    if size == 0:
+        return
+    effective = max(alignment, (chunk_bytes // alignment) * alignment)
+    start = 0
+    while start < size:
+        end = min(size, start + effective)
+        yield start, end
+        start = end
+
+
+def _bundle_key(entry: LogicalStateEntry) -> tuple[str, int, int]:
+    parameter_key = entry.logical_key.split("::optimizer::", 1)[0]
+    return parameter_key, entry.tp_lane, entry.version
+
+
+def plan_state_redistribution(
+    old_manifests: Sequence[StateManifest],
+    new_manifests: Sequence[StateManifest],
+    *,
+    chunk_bytes: int,
+    round_bytes: int | None = None,
+    alignment: int = 256,
+    rank_to_node: Mapping[int, str] | None = None,
+    bandwidth_bytes_per_s: Mapping[int, float] | None = None,
+    link_classifier: Callable[[int, int], tuple[str, float]] | None = None,
+) -> TransferSchedule:
+    """Assign largest chunks to candidates by projected byte makespan."""
+
+    if chunk_bytes < 1 or alignment < 1:
+        raise ValueError("chunk_bytes and alignment must be positive")
+    round_bytes = round_bytes or chunk_bytes * max(1, len(old_manifests))
+    if round_bytes < chunk_bytes:
+        raise ValueError("round_bytes must be at least chunk_bytes")
+    old_entries = [entry for manifest in old_manifests for entry in manifest.entries]
+    candidates: dict[tuple[object, ...], list[LogicalStateEntry]] = {}
+    for entry in old_entries:
+        candidates.setdefault(entry.shard_identity, []).append(entry)
+    source_load: dict[int, int] = {}
+    destination_load: dict[int, int] = {}
+    link_load: dict[str, int] = {}
+    retained: list[tuple[int, str, int]] = []
+    units: list[tuple[int, LogicalStateEntry, int, int, tuple[LogicalStateEntry, ...]]] = []
+
+    for manifest in sorted(new_manifests, key=lambda item: item.rank):
+        destinations = tuple(
+            sorted(
+                manifest.entries,
+                key=lambda item: (item.logical_key, item.tp_lane, item.state_kind),
+            )
+        )
+        versions = {entry.version for entry in destinations}
+        if versions and versions != {manifest.committed_step}:
+            raise ValueError("destination manifest mixes committed state versions")
+
+        bundles: dict[tuple[str, int, int], list[LogicalStateEntry]] = {}
+        for destination in destinations:
+            bundles.setdefault(_bundle_key(destination), []).append(destination)
+        complete_sources: dict[tuple[str, int, int], set[int]] = {}
+        for bundle, entries in sorted(bundles.items()):
+            rank_sets = []
+            for destination in entries:
+                ranks = {
+                    entry.owner_rank for entry in candidates.get(destination.shard_identity, ())
+                }
+                if not ranks:
+                    raise StateUnavailable(
+                        f"no committed source for {destination.logical_key} "
+                        f"(tp lane {destination.tp_lane}, version {destination.version})"
+                    )
+                rank_sets.append(ranks)
+            complete = set.intersection(*rank_sets)
+            if not complete:
+                raise StateUnavailable(
+                    f"no surviving rank holds the complete state bundle {bundle[0]} "
+                    f"(tp lane {bundle[1]}, version {bundle[2]})"
+                )
+            complete_sources[bundle] = complete
+
+        for destination in destinations:
+            complete = complete_sources[_bundle_key(destination)]
+            eligible = tuple(
+                sorted(
+                    (
+                        entry
+                        for entry in candidates[destination.shard_identity]
+                        if entry.owner_rank in complete
+                    ),
+                    key=lambda item: item.owner_rank,
+                )
+            )
+            if destination.owner_rank in complete:
+                retained.append(
+                    (destination.owner_rank, destination.logical_key, destination.tp_lane)
+                )
+                continue
+            for start, end in _chunks(destination.nbytes, chunk_bytes, alignment):
+                units.append((end - start, destination, start, end, eligible))
+
+    units.sort(
+        key=lambda item: (
+            -item[0],
+            item[1].logical_key,
+            item[1].tp_lane,
+            item[1].owner_rank,
+            item[2],
+        )
+    )
+    transfers: list[Transfer] = []
+    round_source_loads: list[dict[int, int]] = []
+    round_destination_loads: list[dict[int, int]] = []
+
+    def locality(source: int, destination: int) -> tuple[str, float]:
+        if link_classifier is not None:
+            return link_classifier(source, destination)
+        if rank_to_node and rank_to_node.get(source) == rank_to_node.get(destination):
+            return "same-node", 0.25
+        return "network", 1.0
+
+    for size, destination, start, end, eligible in units:
+        scored = []
+        for source in eligible:
+            link_class, locality_cost = locality(source.owner_rank, destination.owner_rank)
+            source_bw = (bandwidth_bytes_per_s or {}).get(source.owner_rank, 1.0)
+            destination_bw = (bandwidth_bytes_per_s or {}).get(destination.owner_rank, 1.0)
+            projected = max(
+                (source_load.get(source.owner_rank, 0) + size) / source_bw,
+                (destination_load.get(destination.owner_rank, 0) + size) / destination_bw,
+                (link_load.get(link_class, 0) + size) * locality_cost,
+            )
+            scored.append((projected, locality_cost, source.owner_rank, source, link_class))
+        _, _, _, source, link_class = min(scored, key=lambda item: item[:3])
+        round_number = 0
+        while round_number < len(round_source_loads):
+            if (
+                round_source_loads[round_number].get(source.owner_rank, 0) + size <= round_bytes
+                and round_destination_loads[round_number].get(destination.owner_rank, 0) + size
+                <= round_bytes
+            ):
+                break
+            round_number += 1
+        if round_number == len(round_source_loads):
+            round_source_loads.append({})
+            round_destination_loads.append({})
+        round_source_loads[round_number][source.owner_rank] = (
+            round_source_loads[round_number].get(source.owner_rank, 0) + size
+        )
+        round_destination_loads[round_number][destination.owner_rank] = (
+            round_destination_loads[round_number].get(destination.owner_rank, 0) + size
+        )
+        source_load[source.owner_rank] = source_load.get(source.owner_rank, 0) + size
+        destination_load[destination.owner_rank] = (
+            destination_load.get(destination.owner_rank, 0) + size
+        )
+        link_load[link_class] = link_load.get(link_class, 0) + size
+        transfers.append(
+            Transfer(
+                source.owner_rank,
+                destination.owner_rank,
+                destination.logical_key,
+                destination.state_kind,
+                destination.tp_lane,
+                start,
+                end,
+                _dtype_name(destination.dtype),
+                round_number,
+                link_class,
+                destination.version,
+            )
+        )
+
+    transfers.sort(
+        key=lambda item: (
+            item.round,
+            item.dtype,
+            item.source_rank,
+            item.destination_rank,
+            item.logical_key,
+            item.tp_lane,
+            item.chunk_start,
+        )
+    )
+    return TransferSchedule(
+        tuple(transfers),
+        tuple(sorted(retained)),
+        tuple(sorted(source_load.items())),
+        tuple(sorted(destination_load.items())),
+        tuple(sorted(link_load.items())),
+    )
+
+
+def all_to_all_single_compat(
+    output,
+    input,
+    output_split_sizes: Sequence[int],
+    input_split_sizes: Sequence[int],
+    *,
+    group=None,
+    async_op: bool = False,
+):
+    """Version-isolated wrapper around PyTorch's experimental collective."""
+
+    import torch.distributed as dist
+
+    return dist.all_to_all_single(
+        output,
+        input,
+        output_split_sizes=list(output_split_sizes),
+        input_split_sizes=list(input_split_sizes),
+        group=group,
+        async_op=async_op,
+    )

--- a/oobleck/state_public_base.py
+++ b/oobleck/state_public_base.py
@@ -1,0 +1,75 @@
+"""Public state API with homogeneous-cluster source striping."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Callable, Mapping, Sequence
+
+from oobleck.state_base import (
+    LogicalStateEntry,
+    StateManifest,
+    StateUnavailable,
+    Transfer,
+    TransferSchedule,
+    all_to_all_single_compat,
+)
+from oobleck.state_base import plan_state_redistribution as _plan
+
+
+def plan_state_redistribution(
+    old_manifests: Sequence[StateManifest],
+    new_manifests: Sequence[StateManifest],
+    *,
+    chunk_bytes: int,
+    round_bytes: int | None = None,
+    alignment: int = 256,
+    rank_to_node: Mapping[int, str] | None = None,
+    bandwidth_bytes_per_s: Mapping[int, float] | None = None,
+    link_classifier: Callable[[int, int], tuple[str, float]] | None = None,
+) -> TransferSchedule:
+    """Plan transfers, balancing homogeneous links per source/destination pair."""
+
+    normalize_default_links = link_classifier is None
+    if link_classifier is None:
+
+        def link_classifier(source: int, destination: int) -> tuple[str, float]:
+            if rank_to_node and rank_to_node.get(source) == rank_to_node.get(destination):
+                return f"same-node:{source}:{destination}", 0.25
+            return f"network:{source}:{destination}", 1.0
+
+    schedule = _plan(
+        old_manifests,
+        new_manifests,
+        chunk_bytes=chunk_bytes,
+        round_bytes=round_bytes,
+        alignment=alignment,
+        rank_to_node=rank_to_node,
+        bandwidth_bytes_per_s=bandwidth_bytes_per_s,
+        link_classifier=link_classifier,
+    )
+    if not normalize_default_links:
+        return schedule
+    transfers = tuple(
+        replace(item, link_class=item.link_class.split(":", 1)[0]) for item in schedule.transfers
+    )
+    link_bytes: dict[str, int] = {}
+    for item in transfers:
+        link_bytes[item.link_class] = link_bytes.get(item.link_class, 0) + item.byte_count
+    return TransferSchedule(
+        transfers,
+        schedule.retained,
+        schedule.per_source_bytes,
+        schedule.per_destination_bytes,
+        tuple(sorted(link_bytes.items())),
+    )
+
+
+__all__ = [
+    "LogicalStateEntry",
+    "StateManifest",
+    "StateUnavailable",
+    "Transfer",
+    "TransferSchedule",
+    "all_to_all_single_compat",
+    "plan_state_redistribution",
+]

--- a/tests/refactor/test_distributed_smoke.py
+++ b/tests/refactor/test_distributed_smoke.py
@@ -1,0 +1,22 @@
+import torch
+import torch.distributed as dist
+
+from tests.distributed.distributed_base import GlooDistributedTestBase
+
+
+class TestCudaModelOverGloo(GlooDistributedTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_cuda_model_and_gloo_collective(self):
+        assert torch.cuda.is_available()
+        assert torch.cuda.device_count() >= 1
+        assert dist.get_backend() == "gloo"
+        device = torch.device("cuda", self.rank % torch.cuda.device_count())
+        model = torch.nn.Linear(2, 2, bias=False).to(device)
+        output = model(torch.ones(1, 2, device=device))
+        gathered = [torch.empty_like(output) for _ in range(self.world_size)]
+        dist.all_gather(gathered, output)
+        assert output.is_cuda
+        assert all(item.is_cuda for item in gathered)

--- a/tests/refactor/test_lifecycle.py
+++ b/tests/refactor/test_lifecycle.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import tempfile
+
+import torch.distributed as dist
+from torch.distributed import distributed_c10d as c10d
+
+from oobleck.distributed import destroy_process_group_universe
+
+
+def test_world_can_be_fully_destroyed_and_recreated_twice():
+    for _ in range(2):
+        with tempfile.NamedTemporaryFile() as rendezvous:
+            dist.init_process_group(
+                "gloo",
+                init_method=f"file://{rendezvous.name}",
+                rank=0,
+                world_size=1,
+            )
+            assert dist.is_initialized()
+            destroy_process_group_universe()
+            assert not dist.is_initialized()
+            assert not c10d._world.pg_map
+            assert not c10d._world.pg_names
+            assert not c10d._world.pg_group_ranks

--- a/tests/refactor/test_planning.py
+++ b/tests/refactor/test_planning.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import pytest
+import torch
+
+from oobleck import OobleckConfig, OobleckParallelizationPlan, RuntimeCompatibility
+from oobleck.planning import (
+    CompatibilityFingerprint,
+    ModelProfile,
+    ModelProfiler,
+    PipelineInstance,
+    PipelineTemplate,
+    ProfilingWorkload,
+    RecoveryUnavailable,
+    compose_templates,
+    create_pipeline_templates,
+    load_templates,
+    reconfigure_pipelines,
+    save_templates,
+)
+
+
+def template(stages: int, *, name: str | None = None, speed: float = 1.0):
+    return PipelineTemplate(
+        name or f"p{stages}",
+        tuple((index, index + 1) for index in range(stages)),
+        1,
+        speed,
+        speed,
+    )
+
+
+def test_template_cache_rejects_incompatible_fingerprint(tmp_path):
+    fp = CompatibilityFingerprint("model", "bf16", 1, "gpu", "abc")
+    item = PipelineTemplate("p1", ((0, 2),), 1, 1, 1, fingerprint=fp)
+    path = tmp_path / "templates.json"
+    save_templates(path, [item], fp)
+    assert load_templates(path, fp) == (item,)
+    other = CompatibilityFingerprint("other", "bf16", 1, "gpu", "abc")
+    with pytest.raises(ValueError, match="incompatible"):
+        load_templates(path, other)
+
+
+def test_profiler_measures_and_records_materialized_layers(tmp_path):
+    layers = (torch.nn.Linear(3, 4), torch.nn.Linear(4, 2))
+    workload = ProfilingWorkload(
+        layers,
+        lambda layer_index, iteration: torch.ones(
+            2, 3 if layer_index == 0 else 4, requires_grad=True
+        ),
+    )
+    fingerprint = CompatibilityFingerprint("tiny", "float32", 1, "cpu", "test")
+    path = tmp_path / "measured.json"
+    profile = ModelProfiler("tiny", fingerprint=fingerprint).measure_and_record(
+        path, 2, workload, warmup_steps=0, measurement_steps=2
+    )
+    assert [item.layer_index for item in profile.layers] == [0, 1]
+    assert all(item.forward > 0 and item.backward > 0 for item in profile.layers)
+    assert all(item.mem_required > 0 for item in profile.layers)
+    assert all(item.persistent_memory > 0 for item in profile.layers)
+    assert ModelProfile.load(path, fingerprint) == profile
+    templates = create_pipeline_templates("tiny", profile.layers, (1, 2), fingerprint=fingerprint)
+    assert templates[1].forward_time == pytest.approx(sum(item.forward for item in profile.layers))
+    assert templates[1].backward_time == pytest.approx(
+        sum(item.backward for item in profile.layers)
+    )
+    assert all(item.persistent_memory > 0 for item in templates.values())
+    assert all(item.activation_memory >= 0 for item in templates.values())
+
+
+def test_composition_assigns_every_node_and_batch_once():
+    instances = compose_templates(
+        [template(1), template(2, speed=0.4)],
+        ["d", "c", "b", "a"],
+        total_microbatches=8,
+        fault_tolerance_threshold=1,
+    )
+    assert sorted(node for item in instances for node in item.node_ids) == ["a", "b", "c", "d"]
+    assert sum(item.microbatches for item in instances) == 8
+    assert len(instances) >= 2
+
+
+def test_reconfiguration_simple_borrow_and_merge():
+    two, three, four = template(2), template(3), template(4)
+    previous = (
+        PipelineInstance("a", three, ("a0", "a1", "a2")),
+        PipelineInstance("b", three, ("b0", "b1", "b2")),
+    )
+    simple = reconfigure_pipelines(previous, {"a0", "a1", "b0", "b1", "b2"}, [two, three], 4, 1)
+    assert "simple" in simple.strategies
+
+    borrowed = reconfigure_pipelines(previous, {"a0", "b0", "b1", "b2"}, [two, three], 4, 1)
+    assert "borrow" in borrowed.strategies
+    assert sorted(len(item.node_ids) for item in borrowed.instances) == [2, 2]
+
+    previous_merge = (
+        PipelineInstance("a", two, ("a0", "a1")),
+        PipelineInstance("b", two, ("b0", "b1")),
+        PipelineInstance("c", two, ("c0", "c1")),
+    )
+    merged = reconfigure_pipelines(previous_merge, {"a0", "b0", "c0", "c1"}, [two, four], 4, 1)
+    assert "merge" in merged.strategies
+    assert len(merged.instances) == 2
+
+
+def test_reconfiguration_returns_explicit_unavailable():
+    two = template(2)
+    previous = (PipelineInstance("a", two, ("a0", "a1")),)
+    with pytest.raises(RecoveryUnavailable):
+        reconfigure_pipelines(previous, {"a0"}, [two], 2, 0)
+
+
+@dataclass
+class ParallelConfig:
+    tensor_parallel_size: int = 1
+    pipeline_parallel_size: None = None
+    data_parallel_size: int = 1
+    context_parallel_size: int = 1
+    expert_parallel_size: int = 1
+
+
+def test_execution_plan_tracks_stable_node_when_join_reorders_global_ranks():
+    plan = OobleckParallelizationPlan(
+        OobleckConfig(global_batch_size=4, microbatch_size=1, max_nodes=3),
+        templates=(template(1),),
+        node_ids=("node-b", "node-c"),
+        rank=0,
+    )
+    plan.parallelize(torch.nn.Sequential(torch.nn.Linear(1, 1)), ParallelConfig())
+    initial = plan.build_execution_plan()
+    assert plan.rank_for_plan(initial) == 0
+    assert plan._local_node_id == "node-b"
+
+    plan.set_membership(("node-a", "node-b", "node-c"))
+    joined = plan.build_execution_plan()
+    assert joined.generation == 1
+    assert joined.previous_generation == 0
+    assert plan.rank_for_plan(joined) == 1
+    assert plan.last_reconfiguration.strategies == ("join",)
+
+    # Re-reading a generation is deterministic and keeps a valid predecessor.
+    repeated = plan.build_execution_plan()
+    assert repeated.previous_generation == 0
+
+
+def test_execution_plan_rejects_generation_that_removed_the_local_node():
+    plan = OobleckParallelizationPlan(
+        OobleckConfig(global_batch_size=2, microbatch_size=1, max_nodes=2),
+        templates=(template(1),),
+        node_ids=("node-a", "node-b"),
+        rank=0,
+    )
+    plan.parallelize(torch.nn.Linear(1, 1), ParallelConfig())
+    plan.build_execution_plan()
+    plan.set_membership(("node-b",))
+    target = plan.build_execution_plan()
+    with pytest.raises(RecoveryUnavailable, match="local node"):
+        plan.rank_for_plan(target)
+
+
+def test_execution_plan_rejects_runtime_compatibility_mismatch_before_world():
+    compatibility = RuntimeCompatibility(
+        "oobleck-sha",
+        "cornstarch-sha",
+        "2.10.0",
+        "13.0",
+        "2.28",
+        "model-digest",
+        1,
+        1,
+        "4.0.0",
+        "dataset-digest",
+        "gh200-digest",
+    )
+    plan = OobleckParallelizationPlan(
+        OobleckConfig(global_batch_size=2, microbatch_size=1),
+        rank=0,
+        compatibility=compatibility,
+    )
+    plan.parallelize(torch.nn.Linear(1, 1), ParallelConfig())
+    execution = plan.build_execution_plan()
+    assert execution.compatibility_digest == compatibility.digest
+    incompatible = replace(execution, compatibility_digest="different", plan_checksum="")
+    with pytest.raises(ValueError, match="compatibility"):
+        plan.compile(incompatible)


### PR DESCRIPTION
## Summary

- adds the initial plan/context runtime and process-group-independent ownership flow
- adds deterministic heterogeneous pipeline mesh construction
- adds checksummed logical state manifests and pure transfer-schedule planning
- adds version-guarded full WORLD teardown/recreation support
- adds compatibility, CUDA-over-Gloo, and lifecycle tests

## Validation

- pytest -q tests/refactor/test_planning.py (8 passed)
- pytest -q tests/refactor/test_lifecycle.py tests/refactor/test_distributed_smoke.py (2 passed)
- git diff --cached --check

Targets only refactor.