### PR TITLE
PR 7: Add transactional optimizer and replay state

### DIFF
--- a/oobleck/optimization.py
+++ b/oobleck/optimization.py
@@ -1,0 +1,238 @@
+"""Versioned standard-PyTorch optimizer state keyed by logical parameters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Mapping, Sequence
+
+import torch
+
+from oobleck.state import LogicalStateEntry
+
+
+class OptimizerSchemaError(TypeError):
+    """An optimizer cannot be represented by Oobleck's supported schema."""
+
+
+@dataclass(frozen=True, slots=True)
+class OptimizerStateSchema:
+    optimizer_class: str
+    parameter_groups: tuple[dict[str, Any], ...]
+    scalar_slots: tuple[tuple[str, str, Any], ...]
+    tensor_entries: tuple[LogicalStateEntry, ...]
+    schema_version: int = 1
+
+
+def _local_tensor(value: torch.Tensor) -> torch.Tensor:
+    local = value.to_local() if hasattr(value, "to_local") else value
+    return local.detach()
+
+
+def serialize_optimizer_state(
+    optimizer: torch.optim.Optimizer,
+    named_parameters: Mapping[str, torch.nn.Parameter],
+    *,
+    owner_rank: int,
+    committed_step: int,
+    parameter_entries: Mapping[str, LogicalStateEntry] | None = None,
+) -> tuple[OptimizerStateSchema, dict[str, torch.Tensor]]:
+    """Serialize standard optimizer state without unstable parameter IDs.
+
+    ``parameter_entries`` supplies the active TP shard identity.  It is optional
+    for the homogeneous compatibility path, but elastic callers always pass it.
+    """
+
+    by_identity = {id(parameter): name for name, parameter in named_parameters.items()}
+    groups = []
+    for group in optimizer.param_groups:
+        try:
+            keys = [by_identity[id(parameter)] for parameter in group["params"]]
+        except KeyError as exc:
+            raise OptimizerSchemaError(
+                "optimizer owns a parameter without a logical model key"
+            ) from exc
+        metadata = {key: value for key, value in group.items() if key != "params"}
+        metadata["params"] = keys
+        groups.append(metadata)
+
+    entries = []
+    tensors: dict[str, torch.Tensor] = {}
+    scalars = []
+    primitive = (str, int, float, bool, type(None))
+    for parameter, state in optimizer.state.items():
+        parameter_key = by_identity.get(id(parameter))
+        if parameter_key is None:
+            raise OptimizerSchemaError("optimizer state has no stable logical parameter key")
+        parameter_entry = (parameter_entries or {}).get(parameter_key)
+        for slot, value in sorted(state.items()):
+            logical_key = f"{parameter_key}::optimizer::{slot}"
+            if isinstance(value, torch.Tensor):
+                tensor = _local_tensor(value)
+                tensors[logical_key] = tensor
+                same_shape = parameter_entry is not None and tuple(tensor.shape) == tuple(
+                    parameter_entry.local_shape
+                )
+                entries.append(
+                    LogicalStateEntry(
+                        logical_key,
+                        parameter_entry.global_shape if same_shape else tuple(tensor.shape),
+                        tuple(tensor.shape),
+                        str(tensor.dtype),
+                        "optimizer",
+                        parameter_entry.placements if same_shape else ("replicate",),
+                        parameter_entry.tp_lane if parameter_entry is not None else 0,
+                        owner_rank,
+                        committed_step,
+                        parameter_entry.global_layer_id if parameter_entry is not None else None,
+                        parameter_entry.shared_state_id if parameter_entry is not None else None,
+                    )
+                )
+            elif isinstance(value, primitive):
+                scalars.append((parameter_key, str(slot), value))
+            else:
+                raise OptimizerSchemaError(
+                    f"optimizer slot {parameter_key}:{slot} has unsupported "
+                    f"value type {type(value).__name__}"
+                )
+    schema = OptimizerStateSchema(
+        f"{optimizer.__class__.__module__}.{optimizer.__class__.__qualname__}",
+        tuple(groups),
+        tuple(scalars),
+        tuple(entries),
+    )
+    return schema, tensors
+
+
+def optimizer_schema_for_partition(
+    schemas: Sequence[OptimizerStateSchema],
+    parameter_entries: Mapping[str, LogicalStateEntry],
+    *,
+    owner_rank: int,
+    committed_step: int,
+) -> OptimizerStateSchema:
+    """Merge replica schemas and retain state belonging to one new partition."""
+
+    if not schemas:
+        raise OptimizerSchemaError("no surviving optimizer schema is available")
+    optimizer_classes = {schema.optimizer_class for schema in schemas}
+    versions = {schema.schema_version for schema in schemas}
+    group_counts = {len(schema.parameter_groups) for schema in schemas}
+    if len(optimizer_classes) != 1 or versions != {1} or len(group_counts) != 1:
+        raise OptimizerSchemaError("surviving optimizer schemas are incompatible")
+
+    group_count = next(iter(group_counts))
+    group_metadata: list[dict[str, Any] | None] = [None] * group_count
+    parameter_group: dict[str, int] = {}
+    for schema in schemas:
+        for index, group in enumerate(schema.parameter_groups):
+            metadata = {key: value for key, value in group.items() if key != "params"}
+            if group_metadata[index] is None:
+                group_metadata[index] = metadata
+            elif group_metadata[index] != metadata:
+                raise OptimizerSchemaError("optimizer parameter-group metadata diverged")
+            for key in group["params"]:
+                previous = parameter_group.setdefault(key, index)
+                if previous != index:
+                    raise OptimizerSchemaError(f"parameter {key!r} changed optimizer groups")
+
+    groups = []
+    for index, metadata in enumerate(group_metadata):
+        group = dict(metadata or {})
+        group["params"] = [key for key in parameter_entries if parameter_group.get(key) == index]
+        groups.append(group)
+    missing = [key for key in parameter_entries if key not in parameter_group]
+    if missing:
+        raise OptimizerSchemaError(
+            f"new partition parameters are absent from optimizer metadata: {missing[:3]}"
+        )
+
+    scalars: dict[tuple[str, str], Any] = {}
+    entries: dict[tuple[str, int], LogicalStateEntry] = {}
+    marker = "::optimizer::"
+    for schema in schemas:
+        for parameter_key, slot, value in schema.scalar_slots:
+            if parameter_key in parameter_entries:
+                scalars.setdefault((parameter_key, slot), value)
+        for entry in schema.tensor_entries:
+            parameter_key = entry.logical_key.split(marker, 1)[0]
+            parameter_entry = parameter_entries.get(parameter_key)
+            if parameter_entry is None or entry.tp_lane != parameter_entry.tp_lane:
+                continue
+            identity = (entry.logical_key, entry.tp_lane)
+            entries.setdefault(
+                identity,
+                replace(entry, owner_rank=owner_rank, version=committed_step),
+            )
+
+    return OptimizerStateSchema(
+        next(iter(optimizer_classes)),
+        tuple(groups),
+        tuple((key, slot, value) for (key, slot), value in sorted(scalars.items())),
+        tuple(entries[key] for key in sorted(entries)),
+    )
+
+
+def _restore_tensor_for_parameter(
+    tensor: torch.Tensor,
+    parameter: torch.nn.Parameter,
+) -> torch.Tensor:
+    local = tensor.to(parameter.device).clone()
+    if not hasattr(parameter, "device_mesh") or tuple(local.shape) != tuple(
+        getattr(parameter, "_local_tensor", local).shape
+    ):
+        return local
+    try:
+        from torch.distributed.tensor import DTensor
+
+        return DTensor.from_local(
+            local,
+            parameter.device_mesh,
+            parameter.placements,
+            run_check=False,
+            shape=parameter.shape,
+            stride=parameter.stride(),
+        )
+    except (ImportError, RuntimeError, TypeError, ValueError):
+        return local
+
+
+def restore_optimizer_state(
+    optimizer: torch.optim.Optimizer,
+    schema: OptimizerStateSchema,
+    tensors: Mapping[str, torch.Tensor],
+    named_parameters: Mapping[str, torch.nn.Parameter],
+) -> None:
+    actual = f"{optimizer.__class__.__module__}.{optimizer.__class__.__qualname__}"
+    if schema.schema_version != 1 or actual != schema.optimizer_class:
+        raise OptimizerSchemaError(
+            f"optimizer schema mismatch: serialized={schema.optimizer_class}, actual={actual}"
+        )
+    if len(schema.parameter_groups) != len(optimizer.param_groups):
+        raise OptimizerSchemaError("optimizer parameter-group count changed during recovery")
+    optimizer.state.clear()
+    for destination, saved in zip(optimizer.param_groups, schema.parameter_groups):
+        keys = saved["params"]
+        destination["params"] = [named_parameters[key] for key in keys]
+        for key, value in saved.items():
+            if key != "params":
+                destination[key] = value
+    for parameter_key, slot, value in schema.scalar_slots:
+        optimizer.state[named_parameters[parameter_key]][slot] = value
+    for entry in schema.tensor_entries:
+        marker = "::optimizer::"
+        parameter_key, slot = entry.logical_key.split(marker, 1)
+        if entry.logical_key not in tensors:
+            raise OptimizerSchemaError(f"missing optimizer tensor {entry.logical_key}")
+        parameter = named_parameters[parameter_key]
+        optimizer.state[parameter][slot] = _restore_tensor_for_parameter(
+            tensors[entry.logical_key], parameter
+        )
+
+
+__all__ = [
+    "OptimizerSchemaError",
+    "OptimizerStateSchema",
+    "optimizer_schema_for_partition",
+    "restore_optimizer_state",
+    "serialize_optimizer_state",
+]

--- a/oobleck/optimization_base.py
+++ b/oobleck/optimization_base.py
@@ -1,0 +1,116 @@
+"""Versioned standard-PyTorch optimizer state schema keyed by logical parameters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import torch
+
+from oobleck.state import LogicalStateEntry
+
+
+class OptimizerSchemaError(TypeError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class OptimizerStateSchema:
+    optimizer_class: str
+    parameter_groups: tuple[dict[str, Any], ...]
+    scalar_slots: tuple[tuple[str, str, Any], ...]
+    tensor_entries: tuple[LogicalStateEntry, ...]
+    schema_version: int = 1
+
+
+def serialize_optimizer_state(
+    optimizer: torch.optim.Optimizer,
+    named_parameters: Mapping[str, torch.nn.Parameter],
+    *,
+    owner_rank: int,
+    committed_step: int,
+) -> tuple[OptimizerStateSchema, dict[str, torch.Tensor]]:
+    by_identity = {id(parameter): name for name, parameter in named_parameters.items()}
+    groups = []
+    for group in optimizer.param_groups:
+        try:
+            keys = [by_identity[id(parameter)] for parameter in group["params"]]
+        except KeyError as exc:
+            raise OptimizerSchemaError(
+                "optimizer owns a parameter without a logical model key"
+            ) from exc
+        metadata = {key: value for key, value in group.items() if key != "params"}
+        metadata["params"] = keys
+        groups.append(metadata)
+
+    entries = []
+    tensors: dict[str, torch.Tensor] = {}
+    scalars = []
+    primitive = (str, int, float, bool, type(None))
+    for parameter, state in optimizer.state.items():
+        parameter_key = by_identity.get(id(parameter))
+        if parameter_key is None:
+            raise OptimizerSchemaError("optimizer state has no stable logical parameter key")
+        for slot, value in sorted(state.items()):
+            logical_key = f"{parameter_key}::optimizer::{slot}"
+            if isinstance(value, torch.Tensor):
+                tensor = value.detach()
+                tensors[logical_key] = tensor
+                entries.append(
+                    LogicalStateEntry(
+                        logical_key,
+                        tuple(tensor.shape),
+                        tuple(tensor.shape),
+                        str(tensor.dtype),
+                        "optimizer",
+                        ("replicate",),
+                        0,
+                        owner_rank,
+                        committed_step,
+                    )
+                )
+            elif isinstance(value, primitive):
+                scalars.append((parameter_key, str(slot), value))
+            else:
+                raise OptimizerSchemaError(
+                    f"optimizer slot {parameter_key}:{slot} has unsupported "
+                    f"value type {type(value).__name__}"
+                )
+    schema = OptimizerStateSchema(
+        f"{optimizer.__class__.__module__}.{optimizer.__class__.__qualname__}",
+        tuple(groups),
+        tuple(scalars),
+        tuple(entries),
+    )
+    return schema, tensors
+
+
+def restore_optimizer_state(
+    optimizer: torch.optim.Optimizer,
+    schema: OptimizerStateSchema,
+    tensors: Mapping[str, torch.Tensor],
+    named_parameters: Mapping[str, torch.nn.Parameter],
+) -> None:
+    actual = f"{optimizer.__class__.__module__}.{optimizer.__class__.__qualname__}"
+    if schema.schema_version != 1 or actual != schema.optimizer_class:
+        raise OptimizerSchemaError(
+            f"optimizer schema mismatch: serialized={schema.optimizer_class}, actual={actual}"
+        )
+    if len(schema.parameter_groups) != len(optimizer.param_groups):
+        raise OptimizerSchemaError("optimizer parameter-group count changed during recovery")
+    optimizer.state.clear()
+    for destination, saved in zip(optimizer.param_groups, schema.parameter_groups):
+        keys = saved["params"]
+        destination["params"] = [named_parameters[key] for key in keys]
+        for key, value in saved.items():
+            if key != "params":
+                destination[key] = value
+    for parameter_key, slot, value in schema.scalar_slots:
+        optimizer.state[named_parameters[parameter_key]][slot] = value
+    for entry in schema.tensor_entries:
+        marker = "::optimizer::"
+        parameter_key, slot = entry.logical_key.split(marker, 1)
+        if entry.logical_key not in tensors:
+            raise OptimizerSchemaError(f"missing optimizer tensor {entry.logical_key}")
+        parameter = named_parameters[parameter_key]
+        optimizer.state[parameter][slot] = tensors[entry.logical_key].to(parameter.device).clone()

--- a/tests/refactor/test_dataloader_workers.py
+++ b/tests/refactor/test_dataloader_workers.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import torch
+from torch.utils.data import DataLoader, Dataset
+
+from oobleck.data import OobleckBatchSampler, prepare_dataloader
+from oobleck.types import PipelineInstance, PipelineTemplate
+
+
+class DatasetWithIds(Dataset):
+    def __len__(self):
+        return 16
+
+    def __getitem__(self, index):
+        return {"id": torch.tensor(index)}
+
+
+def test_prefetch_invalidation_replays_with_positive_workers():
+    dataset = DatasetWithIds()
+    template = PipelineTemplate("one", ((0, 1),), 1, 1, 1)
+    sampler = OobleckBatchSampler(
+        dataset,
+        global_batch_size=4,
+        microbatch_size=2,
+        instances=(PipelineInstance("p", template, ("n",), microbatches=2),),
+        seed=7,
+        shuffle=True,
+    )
+    loader = prepare_dataloader(
+        DataLoader(
+            dataset,
+            batch_sampler=sampler,
+            num_workers=2,
+            persistent_workers=False,
+        )
+    )
+    first = next(iter(loader))
+    loader.invalidate_prefetch()
+    replay = next(iter(loader))
+    assert replay.descriptor == first.descriptor
+    assert all(
+        torch.equal(left["id"], right["id"])
+        for left, right in zip(first.microbatches, replay.microbatches)
+    )
+    assert sampler.committed_cursor == 0
+
+
+def test_reconfiguration_keeps_indices_and_reallocates_uncommitted_microbatches():
+    dataset = DatasetWithIds()
+    template = PipelineTemplate("one", ((0, 1),), 1, 1, 1)
+    initial = (
+        PipelineInstance("a", template, ("a",), microbatches=1),
+        PipelineInstance("b", template, ("b",), microbatches=1),
+    )
+    sampler = OobleckBatchSampler(
+        dataset,
+        global_batch_size=4,
+        microbatch_size=2,
+        instances=initial,
+        seed=7,
+        shuffle=True,
+    )
+    before = sampler.descriptor_at(0)
+    replacement = (PipelineInstance("joined", template, ("c",), microbatches=2),)
+    sampler.reconfigure(replacement)
+    after = sampler.descriptor_at(0)
+    assert after.sample_indices == before.sample_indices
+    assert [item.pipeline_id for item in after.assignments] == ["joined"]
+    assert after.assignments[0].global_microbatch_ids == (0, 1)

--- a/tests/refactor/test_optimization.py
+++ b/tests/refactor/test_optimization.py
@@ -1,0 +1,60 @@
+import torch
+
+from oobleck.optimization import restore_optimizer_state, serialize_optimizer_state
+from oobleck.state import LogicalStateEntry
+
+
+def test_adam_state_round_trips_by_logical_parameter_key():
+    source = torch.nn.Linear(3, 2)
+    optimizer = torch.optim.AdamW(source.parameters(), lr=0.01)
+    source(torch.ones(2, 3)).sum().backward()
+    optimizer.step()
+    schema, tensors = serialize_optimizer_state(
+        optimizer,
+        dict(source.named_parameters()),
+        owner_rank=0,
+        committed_step=1,
+    )
+
+    destination = torch.nn.Linear(3, 2)
+    restored = torch.optim.AdamW(destination.parameters(), lr=0.5)
+    restore_optimizer_state(restored, schema, tensors, dict(destination.named_parameters()))
+    assert restored.param_groups[0]["lr"] == 0.01
+    for source_parameter, destination_parameter in zip(
+        source.parameters(), destination.parameters()
+    ):
+        for slot in ("step", "exp_avg", "exp_avg_sq"):
+            torch.testing.assert_close(
+                optimizer.state[source_parameter][slot],
+                restored.state[destination_parameter][slot],
+            )
+
+
+def test_optimizer_tensor_entries_inherit_tp_shard_identity():
+    model = torch.nn.Linear(3, 2, bias=False)
+    optimizer = torch.optim.AdamW(model.parameters())
+    model(torch.ones(2, 3)).sum().backward()
+    optimizer.step()
+    parameter_entry = LogicalStateEntry(
+        "weight",
+        (4, 3),
+        (2, 3),
+        "torch.float32",
+        "parameter",
+        ("Shard(dim=0)",),
+        2,
+        7,
+        4,
+    )
+    schema, _ = serialize_optimizer_state(
+        optimizer,
+        dict(model.named_parameters()),
+        owner_rank=7,
+        committed_step=4,
+        parameter_entries={"weight": parameter_entry},
+    )
+    shaped = [entry for entry in schema.tensor_entries if entry.local_shape == (2, 3)]
+    assert shaped
+    assert all(entry.tp_lane == 2 for entry in schema.tensor_entries)
+    assert shaped[0].global_shape == (4, 3)
+    assert shaped[0].placements == ("Shard(dim=0)",)


### PR DESCRIPTION
## Summary

- serializes optimizer groups and tensor slots by stable logical parameter identity
- reconstructs supported optimizer state after ownership changes
- preserves TP shard metadata in optimizer manifests
- validates positive-worker DataLoader invalidation and exact uncommitted replay

## Validation

- pytest -q tests/refactor/test_optimization.py tests/refactor/test_dataloader_workers.py (4 passed)
- git diff --cached --check

Targets only refactor.