### PR TITLE
PR 8: Add balanced all-to-all recovery

### DIFF
--- a/oobleck/__init__.py
+++ b/oobleck/__init__.py
@@ -1,11 +1,20 @@
 """Oobleck heterogeneous elastic training API."""
 
 from oobleck.data import OobleckBatch, OobleckBatchSampler
-from oobleck.runtime_base import (
+from oobleck.runtime import (
+    GenerationTransitionMetrics,
     OobleckParallelContext,
     OobleckParallelizationPlan,
     OobleckStepResult,
 )
+from oobleck.state import (
+    LogicalStateEntry,
+    StateManifest,
+    StateUnavailable,
+    TransferSchedule,
+    plan_state_redistribution,
+)
+from oobleck.state_transfer import execute_transfer_schedule
 from oobleck.types import (
     CompatibilityFingerprint,
     OobleckConfig,
@@ -19,6 +28,8 @@ from oobleck.types import (
 
 __all__ = [
     "CompatibilityFingerprint",
+    "GenerationTransitionMetrics",
+    "LogicalStateEntry",
     "OobleckBatch",
     "OobleckBatchSampler",
     "OobleckConfig",
@@ -31,4 +42,9 @@ __all__ = [
     "PipelineTemplate",
     "RecoveryUnavailable",
     "RuntimeCompatibility",
+    "StateManifest",
+    "StateUnavailable",
+    "TransferSchedule",
+    "execute_transfer_schedule",
+    "plan_state_redistribution",
 ]

--- a/oobleck/recovery.py
+++ b/oobleck/recovery.py
@@ -1,0 +1,182 @@
+"""Public recovery coordinator with all-rank destination planning."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from oobleck.recovery_base import *  # noqa: F403
+from oobleck.recovery_base import __all__ as _base_all
+from oobleck.recovery_base import (
+    RecoveryReport,
+    RecoverySnapshot,
+    _combined_manifest,
+    _copy_retained,
+    _distributed_identity,
+    _dtype,
+    _gather_metadata,
+    _reown_manifest,
+    logical_state_bindings,
+    version_manifest,
+)
+from oobleck.optimization import optimizer_schema_for_partition, restore_optimizer_state
+from oobleck.state import StateManifest, plan_state_redistribution
+from oobleck.state_transfer import execute_transfer_schedule
+
+import copy
+import time
+import torch
+
+
+def _gather_new_manifests(
+    manifest: StateManifest, *, dist: Any, world_size: int
+) -> tuple[StateManifest, ...]:
+    if dist is None:
+        return (manifest,)
+    gathered: list[StateManifest | None] = [None] * world_size
+    dist.all_gather_object(gathered, manifest)
+    if any(item is None for item in gathered):
+        raise RuntimeError("destination manifest exchange was incomplete")
+    return tuple(item for item in gathered if item is not None)
+
+
+def restore_context_state(context: Any, snapshot: RecoverySnapshot | None) -> RecoveryReport:
+    """Redistribute a committed snapshot into every rank of the active generation."""
+
+    started = time.perf_counter()
+    dist, rank, world_size = _distributed_identity(context.owner_plan.rank)
+    if context.compiled.world_size != world_size:
+        raise RuntimeError(
+            f"activated plan expects world_size={context.compiled.world_size}, "
+            f"but the new WORLD has {world_size} ranks"
+        )
+    metadata = _gather_metadata(snapshot, rank=rank, dist=dist, world_size=world_size)
+    if not metadata:
+        raise RuntimeError("no surviving committed state source joined recovery")
+    metadata_finished = time.perf_counter()
+    steps = {item.committed_step for item in metadata}
+    if len(steps) != 1:
+        raise RuntimeError(f"surviving ranks disagree on committed step: {sorted(steps)}")
+    committed_step = next(iter(steps))
+
+    model_manifest = version_manifest(context.partition.manifest, committed_step)
+    if model_manifest.rank != rank:
+        model_manifest = _reown_manifest(model_manifest, rank)
+    named_parameters, model_destinations = logical_state_bindings(context.model, model_manifest)
+    parameter_entries = {
+        entry.logical_key: entry
+        for entry in model_manifest.entries
+        if entry.state_kind == "parameter"
+    }
+
+    optimizer_schema = None
+    optimizer_destinations = {}
+    schemas = tuple(item.optimizer_schema for item in metadata if item.optimizer_schema is not None)
+    if schemas:
+        if not schemas or context._optimizer_factory is None:
+            raise RuntimeError("optimizer recovery metadata/factory is unavailable")
+        optimizer_schema = optimizer_schema_for_partition(
+            schemas,
+            parameter_entries,
+            owner_rank=rank,
+            committed_step=committed_step,
+        )
+        for entry in optimizer_schema.tensor_entries:
+            optimizer_destinations[(entry.logical_key, "optimizer", entry.tp_lane)] = torch.empty(
+                entry.local_shape, dtype=_dtype(entry.dtype), device=context.device
+            )
+
+    new_manifest = _combined_manifest(model_manifest, optimizer_schema)
+    new_manifests = _gather_new_manifests(new_manifest, dist=dist, world_size=world_size)
+    schedule = plan_state_redistribution(
+        tuple(item.manifest for item in metadata),
+        new_manifests,
+        chunk_bytes=context.config.state_transfer_chunk_bytes,
+        round_bytes=getattr(
+            context.config,
+            "state_transfer_round_bytes",
+            context.config.state_transfer_chunk_bytes * world_size,
+        ),
+        alignment=context.config.transfer_alignment_bytes,
+    )
+    if dist is not None:
+        hashes: list[str | None] = [None] * world_size
+        dist.all_gather_object(hashes, schedule.schedule_hash)
+        if set(hashes) != {schedule.schedule_hash}:
+            raise RuntimeError("ranks derived different state-transfer schedules")
+    planning_finished = time.perf_counter()
+
+    destinations = dict(model_destinations)
+    destinations.update(optimizer_destinations)
+    source_tensors = snapshot.tensors if snapshot is not None else {}
+    local_old_manifest = next(
+        (item.manifest for item in metadata if item.manifest.rank == rank), None
+    )
+    with torch.no_grad():
+        copied = (
+            _copy_retained(local_old_manifest, new_manifest, source_tensors, destinations)
+            if local_old_manifest is not None
+            else set()
+        )
+        transfer_metrics = execute_transfer_schedule(
+            schedule,
+            rank=rank,
+            world_size=world_size,
+            sources=source_tensors,
+            destinations=destinations,
+            device=context.device,
+        )
+    transfer_finished = time.perf_counter()
+    incoming = {
+        (item.logical_key, item.state_kind, item.tp_lane)
+        for item in schedule.transfers
+        if item.destination_rank == rank
+    }
+    missing = set(destinations) - copied - incoming
+    if missing:
+        raise RuntimeError(f"recovery left state uninitialized: {sorted(missing)[:3]}")
+
+    if optimizer_schema is not None:
+        context.optimizer = context._optimizer_factory(context.model.parameters())
+        restore_optimizer_state(
+            context.optimizer,
+            optimizer_schema,
+            {
+                entry.logical_key: optimizer_destinations[
+                    (entry.logical_key, "optimizer", entry.tp_lane)
+                ]
+                for entry in optimizer_schema.tensor_entries
+            },
+            named_parameters,
+        )
+        context.scheduler = (
+            context._scheduler_factory(context.optimizer)
+            if context._scheduler_factory is not None
+            else None
+        )
+        canonical = metadata[0]
+        if context.scheduler is not None and canonical.scheduler_state is not None:
+            context.scheduler.load_state_dict(copy.deepcopy(canonical.scheduler_state))
+        if context.scaler is not None and canonical.scaler_state is not None:
+            context.scaler.load_state_dict(copy.deepcopy(canonical.scaler_state))
+    context.committed_step = committed_step
+    if dist is not None:
+        dist.barrier()
+    finished = time.perf_counter()
+    return RecoveryReport(
+        schedule=schedule,
+        source_bytes=schedule.per_source_bytes,
+        destination_bytes=schedule.per_destination_bytes,
+        link_class_bytes=schedule.per_link_class_bytes,
+        actual_source_bytes=transfer_metrics.actual_source_bytes,
+        actual_destination_bytes=transfer_metrics.actual_destination_bytes,
+        actual_link_class_bytes=transfer_metrics.actual_link_class_bytes,
+        round_durations=transfer_metrics.round_durations,
+        metadata_exchange_seconds=metadata_finished - started,
+        planning_seconds=planning_finished - metadata_finished,
+        transfer_seconds=transfer_finished - planning_finished,
+        restoration_seconds=finished - transfer_finished,
+        total_seconds=finished - started,
+    )
+
+
+__all__ = [*_base_all, "restore_context_state"]

--- a/oobleck/recovery_base.py
+++ b/oobleck/recovery_base.py
@@ -1,0 +1,403 @@
+"""Committed training-state capture and deterministic generation recovery."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, replace
+from typing import Any, Mapping, MutableMapping
+
+import torch
+
+from oobleck.optimization import (
+    OptimizerStateSchema,
+    optimizer_schema_for_partition,
+    restore_optimizer_state,
+    serialize_optimizer_state,
+)
+from oobleck.state import StateManifest, TransferSchedule, plan_state_redistribution
+from oobleck.state_transfer import StateTensorKey, execute_transfer_schedule
+
+
+@dataclass(slots=True)
+class RecoverySnapshot:
+    manifest: StateManifest
+    tensors: dict[StateTensorKey, torch.Tensor]
+    optimizer_schema: OptimizerStateSchema | None
+    scheduler_state: Mapping[str, Any] | None
+    scaler_state: Mapping[str, Any] | None
+    committed_step: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryMetadata:
+    manifest: StateManifest
+    optimizer_schema: OptimizerStateSchema | None
+    scheduler_state: Mapping[str, Any] | None
+    scaler_state: Mapping[str, Any] | None
+    committed_step: int
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryReport:
+    schedule: TransferSchedule
+    source_bytes: tuple[tuple[int, int], ...]
+    destination_bytes: tuple[tuple[int, int], ...]
+    link_class_bytes: tuple[tuple[str, int], ...]
+    actual_source_bytes: tuple[tuple[int, int], ...] = ()
+    actual_destination_bytes: tuple[tuple[int, int], ...] = ()
+    actual_link_class_bytes: tuple[tuple[str, int], ...] = ()
+    round_durations: tuple[tuple[int, str, float], ...] = ()
+    metadata_exchange_seconds: float = 0.0
+    planning_seconds: float = 0.0
+    transfer_seconds: float = 0.0
+    restoration_seconds: float = 0.0
+    total_seconds: float = 0.0
+
+    @property
+    def maximum_source_bytes(self) -> int:
+        return max((value for _, value in self.source_bytes), default=0)
+
+    @property
+    def maximum_destination_bytes(self) -> int:
+        return max((value for _, value in self.destination_bytes), default=0)
+
+
+def version_manifest(manifest: StateManifest, committed_step: int) -> StateManifest:
+    return StateManifest(
+        manifest.rank,
+        tuple(replace(entry, version=committed_step) for entry in manifest.entries),
+        committed_step,
+    )
+
+
+def _local_tensor(value: torch.Tensor) -> torch.Tensor:
+    return value.to_local() if hasattr(value, "to_local") else value
+
+
+def _logical_candidates(root: torch.nn.Module, local_name: str) -> tuple[str, ...]:
+    candidates = [local_name]
+    modules = sorted(root.named_modules(), key=lambda item: len(item[0]), reverse=True)
+    for prefix, module in modules:
+        converter = getattr(module, "_global_cornstarch_key", None)
+        if not callable(converter):
+            continue
+        if prefix and not local_name.startswith(f"{prefix}."):
+            continue
+        relative = local_name[len(prefix) + 1 :] if prefix else local_name
+        try:
+            global_name = converter(relative)
+        except (KeyError, ValueError, AttributeError):
+            continue
+        candidates.append(str(global_name))
+        if prefix:
+            candidates.append(f"{prefix}.{global_name}")
+    return tuple(dict.fromkeys(candidates))
+
+
+def logical_state_bindings(
+    model: torch.nn.Module,
+    manifest: StateManifest,
+) -> tuple[dict[str, torch.nn.Parameter], dict[StateTensorKey, torch.Tensor]]:
+    """Bind stable manifest identities to the active partition's local tensors."""
+
+    parameters: dict[str, torch.nn.Parameter] = {}
+    states: dict[StateTensorKey, torch.Tensor] = {}
+    expected = {(entry.logical_key, entry.state_kind): entry for entry in manifest.entries}
+    for kind, values in (
+        ("parameter", model.named_parameters(recurse=True, remove_duplicate=False)),
+        ("buffer", model.named_buffers(recurse=True, remove_duplicate=False)),
+    ):
+        for local_name, value in values:
+            entry = None
+            for candidate in _logical_candidates(model, local_name):
+                entry = expected.get((candidate, kind))
+                if entry is not None:
+                    break
+            if entry is None:
+                continue
+            local = _local_tensor(value)
+            if tuple(local.shape) != entry.local_shape or str(local.dtype) != entry.dtype:
+                raise RuntimeError(
+                    f"active tensor {entry.logical_key!r} does not match its manifest"
+                )
+            key = (entry.logical_key, kind, entry.tp_lane)
+            states[key] = local
+            if kind == "parameter":
+                parameters[entry.logical_key] = value
+
+    missing = [
+        (entry.logical_key, entry.state_kind, entry.tp_lane)
+        for entry in manifest.entries
+        if (entry.logical_key, entry.state_kind, entry.tp_lane) not in states
+    ]
+    if missing:
+        raise RuntimeError(f"manifest entries are not bound to active tensors: {missing[:3]}")
+    return parameters, states
+
+
+def _combined_manifest(
+    model_manifest: StateManifest,
+    optimizer_schema: OptimizerStateSchema | None,
+) -> StateManifest:
+    entries = list(model_manifest.entries)
+    if optimizer_schema is not None:
+        entries.extend(optimizer_schema.tensor_entries)
+    return StateManifest(model_manifest.rank, tuple(entries), model_manifest.committed_step)
+
+
+def capture_context_state(context: Any) -> RecoverySnapshot:
+    """Clone the last committed rank-local state before retiring a generation."""
+
+    model_manifest = version_manifest(context.partition.manifest, context.committed_step)
+    named_parameters, model_tensors = logical_state_bindings(context.model, model_manifest)
+    tensors = {key: value.detach().contiguous().clone() for key, value in model_tensors.items()}
+    parameter_entries = {
+        entry.logical_key: entry
+        for entry in model_manifest.entries
+        if entry.state_kind == "parameter"
+    }
+    optimizer_schema = None
+    if context.optimizer is not None:
+        optimizer_schema, optimizer_tensors = serialize_optimizer_state(
+            context.optimizer,
+            named_parameters,
+            owner_rank=model_manifest.rank,
+            committed_step=context.committed_step,
+            parameter_entries=parameter_entries,
+        )
+        lanes = {entry.logical_key: entry.tp_lane for entry in optimizer_schema.tensor_entries}
+        tensors.update(
+            {
+                (key, "optimizer", lanes[key]): value.detach().contiguous().clone()
+                for key, value in optimizer_tensors.items()
+            }
+        )
+    manifest = _combined_manifest(model_manifest, optimizer_schema)
+    scheduler_state = (
+        copy.deepcopy(context.scheduler.state_dict())
+        if context.scheduler is not None and hasattr(context.scheduler, "state_dict")
+        else None
+    )
+    scaler_state = (
+        copy.deepcopy(context.scaler.state_dict())
+        if context.scaler is not None and hasattr(context.scaler, "state_dict")
+        else None
+    )
+    return RecoverySnapshot(
+        manifest,
+        tensors,
+        optimizer_schema,
+        scheduler_state,
+        scaler_state,
+        context.committed_step,
+    )
+
+
+def _distributed_identity(fallback_rank: int) -> tuple[Any, int, int]:
+    try:
+        import torch.distributed as dist
+
+        if dist.is_initialized():
+            return dist, dist.get_rank(), dist.get_world_size()
+    except (ImportError, RuntimeError):
+        pass
+    return None, fallback_rank, 1
+
+
+def _reown_manifest(manifest: StateManifest, rank: int) -> StateManifest:
+    return StateManifest(
+        rank,
+        tuple(replace(entry, owner_rank=rank) for entry in manifest.entries),
+        manifest.committed_step,
+    )
+
+
+def _reown_schema(schema: OptimizerStateSchema | None, rank: int) -> OptimizerStateSchema | None:
+    if schema is None:
+        return None
+    return replace(
+        schema,
+        tensor_entries=tuple(replace(entry, owner_rank=rank) for entry in schema.tensor_entries),
+    )
+
+
+def _gather_metadata(
+    snapshot: RecoverySnapshot | None,
+    *,
+    rank: int,
+    dist: Any,
+    world_size: int,
+) -> tuple[RecoveryMetadata, ...]:
+    local = (
+        None
+        if snapshot is None
+        else RecoveryMetadata(
+            _reown_manifest(snapshot.manifest, rank),
+            _reown_schema(snapshot.optimizer_schema, rank),
+            snapshot.scheduler_state,
+            snapshot.scaler_state,
+            snapshot.committed_step,
+        )
+    )
+    if dist is None:
+        return () if local is None else (local,)
+    gathered: list[RecoveryMetadata | None] = [None] * world_size
+    dist.all_gather_object(gathered, local)
+    return tuple(item for item in gathered if item is not None)
+
+
+def _dtype(value: str) -> torch.dtype:
+    name = value.removeprefix("torch.")
+    dtype = getattr(torch, name, None)
+    if not isinstance(dtype, torch.dtype):
+        raise TypeError(f"unsupported state dtype {value!r}")
+    return dtype
+
+
+def _copy_retained(
+    old_manifest: StateManifest,
+    new_manifest: StateManifest,
+    sources: Mapping[StateTensorKey, torch.Tensor],
+    destinations: MutableMapping[StateTensorKey, torch.Tensor],
+) -> set[StateTensorKey]:
+    old_entries = {
+        (entry.logical_key, entry.state_kind, entry.tp_lane): entry
+        for entry in old_manifest.entries
+    }
+    copied = set()
+    for entry in new_manifest.entries:
+        key = (entry.logical_key, entry.state_kind, entry.tp_lane)
+        source_entry = old_entries.get(key)
+        if source_entry is None or source_entry.shard_identity != entry.shard_identity:
+            continue
+        destinations[key].copy_(sources[key])
+        copied.add(key)
+    return copied
+
+
+def restore_context_state(context: Any, snapshot: RecoverySnapshot) -> RecoveryReport:
+    """Redistribute a committed snapshot into the context's active generation."""
+
+    dist, rank, world_size = _distributed_identity(context.owner_plan.rank)
+    if context.compiled.world_size != world_size:
+        raise RuntimeError(
+            f"activated plan expects world_size={context.compiled.world_size}, "
+            f"but the new WORLD has {world_size} ranks"
+        )
+    metadata = _gather_metadata(snapshot, rank=rank, dist=dist, world_size=world_size)
+    steps = {item.committed_step for item in metadata}
+    if steps != {snapshot.committed_step}:
+        raise RuntimeError(f"surviving ranks disagree on committed step: {sorted(steps)}")
+
+    model_manifest = version_manifest(context.partition.manifest, snapshot.committed_step)
+    if model_manifest.rank != rank:
+        model_manifest = _reown_manifest(model_manifest, rank)
+    named_parameters, model_destinations = logical_state_bindings(context.model, model_manifest)
+    parameter_entries = {
+        entry.logical_key: entry
+        for entry in model_manifest.entries
+        if entry.state_kind == "parameter"
+    }
+
+    optimizer_schema = None
+    optimizer_destinations: dict[StateTensorKey, torch.Tensor] = {}
+    schemas = tuple(item.optimizer_schema for item in metadata if item.optimizer_schema is not None)
+    if snapshot.optimizer_schema is not None:
+        if not schemas or context._optimizer_factory is None:
+            raise RuntimeError("optimizer recovery metadata/factory is unavailable")
+        optimizer_schema = optimizer_schema_for_partition(
+            schemas,
+            parameter_entries,
+            owner_rank=rank,
+            committed_step=snapshot.committed_step,
+        )
+        for entry in optimizer_schema.tensor_entries:
+            optimizer_destinations[(entry.logical_key, "optimizer", entry.tp_lane)] = torch.empty(
+                entry.local_shape, dtype=_dtype(entry.dtype), device=context.device
+            )
+
+    new_manifest = _combined_manifest(model_manifest, optimizer_schema)
+    old_manifests = tuple(item.manifest for item in metadata)
+    schedule = plan_state_redistribution(
+        old_manifests,
+        (new_manifest,),
+        chunk_bytes=context.config.state_transfer_chunk_bytes,
+        round_bytes=getattr(
+            context.config,
+            "state_transfer_round_bytes",
+            context.config.state_transfer_chunk_bytes * world_size,
+        ),
+        alignment=context.config.transfer_alignment_bytes,
+    )
+    if dist is not None:
+        hashes: list[str | None] = [None] * world_size
+        dist.all_gather_object(hashes, schedule.schedule_hash)
+        if set(hashes) != {schedule.schedule_hash}:
+            raise RuntimeError("ranks derived different state-transfer schedules")
+
+    destinations: dict[StateTensorKey, torch.Tensor] = dict(model_destinations)
+    destinations.update(optimizer_destinations)
+    local_old_manifest = metadata[rank].manifest
+    copied = _copy_retained(local_old_manifest, new_manifest, snapshot.tensors, destinations)
+    transfer_metrics = execute_transfer_schedule(
+        schedule,
+        rank=rank,
+        world_size=world_size,
+        sources=snapshot.tensors,
+        destinations=destinations,
+        device=context.device,
+    )
+    incoming = {
+        (item.logical_key, item.state_kind, item.tp_lane)
+        for item in schedule.transfers
+        if item.destination_rank == rank
+    }
+    missing = set(destinations) - copied - incoming
+    if missing:
+        raise RuntimeError(f"recovery left state uninitialized: {sorted(missing)[:3]}")
+
+    if optimizer_schema is not None:
+        context.optimizer = context._optimizer_factory(context.model.parameters())
+        restore_optimizer_state(
+            context.optimizer,
+            optimizer_schema,
+            {
+                entry.logical_key: optimizer_destinations[
+                    (entry.logical_key, "optimizer", entry.tp_lane)
+                ]
+                for entry in optimizer_schema.tensor_entries
+            },
+            named_parameters,
+        )
+        context.scheduler = (
+            context._scheduler_factory(context.optimizer)
+            if context._scheduler_factory is not None
+            else None
+        )
+        canonical = metadata[0]
+        if context.scheduler is not None and canonical.scheduler_state is not None:
+            context.scheduler.load_state_dict(copy.deepcopy(canonical.scheduler_state))
+        if context.scaler is not None and canonical.scaler_state is not None:
+            context.scaler.load_state_dict(copy.deepcopy(canonical.scaler_state))
+    if dist is not None:
+        dist.barrier()
+    return RecoveryReport(
+        schedule=schedule,
+        source_bytes=schedule.per_source_bytes,
+        destination_bytes=schedule.per_destination_bytes,
+        link_class_bytes=schedule.per_link_class_bytes,
+        actual_source_bytes=transfer_metrics.actual_source_bytes,
+        actual_destination_bytes=transfer_metrics.actual_destination_bytes,
+        actual_link_class_bytes=transfer_metrics.actual_link_class_bytes,
+        round_durations=transfer_metrics.round_durations,
+    )
+
+
+__all__ = [
+    "RecoveryReport",
+    "RecoverySnapshot",
+    "capture_context_state",
+    "logical_state_bindings",
+    "restore_context_state",
+    "version_manifest",
+]

--- a/oobleck/runtime.py
+++ b/oobleck/runtime.py
@@ -1,0 +1,287 @@
+"""Public runtime with committed-state generation replacement."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+import torch
+
+from oobleck.distributed import destroy_process_group_universe
+from oobleck.elastic.membership import MembershipSnapshot
+from oobleck.recovery import capture_context_state, restore_context_state
+from oobleck.runtime_base import *  # noqa: F403
+from oobleck.runtime_base import OobleckParallelContext
+from oobleck.topology import activate_gradient_synchronizer
+
+
+_base_init = OobleckParallelContext.__init__
+_base_configure_optimization = OobleckParallelContext.configure_optimization
+_base_step = OobleckParallelContext.step
+_base_close = OobleckParallelContext.close
+
+
+@dataclass(frozen=True, slots=True)
+class GenerationTransitionMetrics:
+    generation: int
+    snapshot_seconds: float
+    teardown_seconds: float
+    compile_seconds: float
+    world_initialization_seconds: float
+    activation_seconds: float
+    recovery_seconds: float
+    total_seconds: float
+    superseded: bool = False
+
+
+def _init_with_recovery(self: OobleckParallelContext, *args: Any, **kwargs: Any) -> None:
+    _base_init(self, *args, **kwargs)
+    self._optimizer_factory: (
+        Callable[[Iterable[torch.nn.Parameter]], torch.optim.Optimizer] | None
+    ) = None
+    self._scheduler_factory: Callable[[torch.optim.Optimizer], Any] | None = None
+    self.last_recovery_report = None
+    self._control_plane_managed = False
+    self._control_active_generation = self.generation
+    self.recovery_history: list[GenerationTransitionMetrics] = []
+    self._heterogeneous_gradient_sync = (
+        None
+        if self._needs_survivor_recovery
+        else activate_gradient_synchronizer(
+            self.model,
+            self.partition.manifest,
+            self.execution_plan,
+            microbatch_size=self.config.microbatch_size,
+        )
+    )
+
+
+def _configure_optimization(
+    self: OobleckParallelContext,
+    *,
+    optimizer_factory: Callable[[Iterable[torch.nn.Parameter]], torch.optim.Optimizer],
+    scheduler_factory: Callable[[torch.optim.Optimizer], Any] | None = None,
+    scaler: Any = None,
+) -> None:
+    _base_configure_optimization(
+        self,
+        optimizer_factory=optimizer_factory,
+        scheduler_factory=scheduler_factory,
+        scaler=scaler,
+    )
+    self._optimizer_factory = optimizer_factory
+    self._scheduler_factory = scheduler_factory
+
+
+def _world_initialized() -> bool:
+    try:
+        import torch.distributed as dist
+
+        return dist.is_initialized()
+    except (ImportError, RuntimeError):
+        return False
+
+
+def _retire_world(self: OobleckParallelContext) -> None:
+    if self._heterogeneous_gradient_sync is not None:
+        self._heterogeneous_gradient_sync.close()
+        self._heterogeneous_gradient_sync = None
+    self.partition.close()
+    if _world_initialized():
+        destroy_process_group_universe()
+
+
+def _activate_latest_generation(self: OobleckParallelContext) -> None:
+    """Replace WORLD and recover only the last committed training state.
+
+    The snapshot is captured once.  If a newer membership arrives during
+    preparation or activation, the partially created generation is retired and
+    the same committed snapshot is applied to the newest complete plan.
+    """
+
+    if self._pending_plan is None:
+        return
+    transition_started = time.perf_counter()
+    snapshot_started = transition_started
+    snapshot = capture_context_state(self)
+    snapshot_seconds = time.perf_counter() - snapshot_started
+    for loader in self._loaders:
+        loader.invalidate_prefetch()
+
+    while self._pending_plan is not None:
+        target = self._pending_plan
+        self._pending_plan = None
+        attempt_started = time.perf_counter()
+        teardown_started = attempt_started
+        _retire_world(self)
+        teardown_seconds = time.perf_counter() - teardown_started
+
+        # Compilation is deliberately process-group independent and occurs
+        # after the old universe is gone but before the replacement is created.
+        compile_started = time.perf_counter()
+        compiled = self.owner_plan.compile(target)
+        compile_seconds = time.perf_counter() - compile_started
+        world_started = time.perf_counter()
+        if self.owner_plan.world_initializer is not None:
+            self.owner_plan.world_initializer(target)
+        world_seconds = time.perf_counter() - world_started
+        activation_started = time.perf_counter()
+        activated = compiled.activate(self.device, self.dtype)
+        activation_seconds = time.perf_counter() - activation_started
+
+        # A complete newer snapshot supersedes this generation before any
+        # committed state is installed or the generation is made visible.
+        if self._pending_plan is not None and self._pending_plan.generation > target.generation:
+            activated.close()
+            if _world_initialized():
+                destroy_process_group_universe()
+            self.recovery_history.append(
+                GenerationTransitionMetrics(
+                    target.generation,
+                    snapshot_seconds,
+                    teardown_seconds,
+                    compile_seconds,
+                    world_seconds,
+                    activation_seconds,
+                    0.0,
+                    time.perf_counter() - attempt_started,
+                    True,
+                )
+            )
+            continue
+
+        self.compiled = compiled
+        self.partition = activated
+        self.execution_plan = target
+        self.owner_plan.rank = compiled.rank
+        self.owner_plan._last_execution_plan = target
+        for loader in self._loaders:
+            loader.reconfigure(target.instances)
+        recovery_started = time.perf_counter()
+        self.last_recovery_report = restore_context_state(self, snapshot)
+        recovery_seconds = time.perf_counter() - recovery_started
+        self._heterogeneous_gradient_sync = activate_gradient_synchronizer(
+            self.model,
+            self.partition.manifest,
+            self.execution_plan,
+            microbatch_size=self.config.microbatch_size,
+        )
+
+        if self._pending_plan is not None:
+            # Recovery completed at a safe boundary, but this generation is
+            # already stale.  Reuse the original committed snapshot so an
+            # intermediate activation can never become a source of truth.
+            self.recovery_history.append(
+                GenerationTransitionMetrics(
+                    target.generation,
+                    snapshot_seconds,
+                    teardown_seconds,
+                    compile_seconds,
+                    world_seconds,
+                    activation_seconds,
+                    recovery_seconds,
+                    time.perf_counter() - attempt_started,
+                    True,
+                )
+            )
+            continue
+        self.recovery_history.append(
+            GenerationTransitionMetrics(
+                target.generation,
+                snapshot_seconds,
+                teardown_seconds,
+                compile_seconds,
+                world_seconds,
+                activation_seconds,
+                recovery_seconds,
+                time.perf_counter() - transition_started,
+            )
+        )
+        break
+
+
+def _apply_membership(self: OobleckParallelContext, snapshot: MembershipSnapshot) -> bool:
+    """Convert one complete control-plane snapshot into a pending generation."""
+
+    newest_generation = max(
+        self.generation,
+        self._pending_plan.generation if self._pending_plan is not None else -1,
+    )
+    if snapshot.generation <= newest_generation:
+        return False
+    tensor_parallel_size = int(getattr(self.owner_plan.parallel_config, "tensor_parallel_size"))
+    invalid = [
+        node.agent_id for node in snapshot.nodes if len(node.gpu_ids) != tensor_parallel_size
+    ]
+    if invalid:
+        raise ValueError(
+            f"membership nodes {invalid} do not match fixed TP width {tensor_parallel_size}"
+        )
+    self.owner_plan.set_membership(
+        tuple(node.agent_id for node in snapshot.nodes), snapshot.generation
+    )
+    return self.announce_generation(self.owner_plan.build_execution_plan())
+
+
+def _enable_control_plane_barrier(self: OobleckParallelContext) -> None:
+    self._control_plane_managed = True
+    self._control_active_generation = self.generation
+
+
+def _prepare_generation(self: OobleckParallelContext) -> None:
+    if not self._control_plane_managed:
+        raise RuntimeError("enable the control-plane barrier before preparation")
+    _activate_latest_generation(self)
+
+
+def _mark_generation_active(self: OobleckParallelContext, generation: int) -> None:
+    if generation != self.generation:
+        raise RuntimeError(
+            f"cannot activate generation {generation}; prepared generation is {self.generation}"
+        )
+    self._control_active_generation = generation
+
+
+def _step_with_control_barrier(self: OobleckParallelContext, *args: Any, **kwargs: Any) -> Any:
+    if self._control_plane_managed and (
+        self._pending_plan is not None or self._control_active_generation != self.generation
+    ):
+        raise RuntimeError(
+            "generation is prepared but not active through the CPU control-plane barrier"
+        )
+    return _base_step(self, *args, **kwargs)
+
+
+def _recover_from_survivors(self: OobleckParallelContext) -> None:
+    """Bootstrap a joining worker that owns no pre-generation state."""
+
+    if not self._needs_survivor_recovery:
+        raise RuntimeError("materialize with recover_from_survivors=True for a joining worker")
+    self.last_recovery_report = restore_context_state(self, None)
+    self._heterogeneous_gradient_sync = activate_gradient_synchronizer(
+        self.model,
+        self.partition.manifest,
+        self.execution_plan,
+        microbatch_size=self.config.microbatch_size,
+    )
+    self._needs_survivor_recovery = False
+
+
+def _close_with_topology(self: OobleckParallelContext) -> None:
+    if self._heterogeneous_gradient_sync is not None:
+        self._heterogeneous_gradient_sync.close()
+        self._heterogeneous_gradient_sync = None
+    _base_close(self)
+
+
+OobleckParallelContext.__init__ = _init_with_recovery
+OobleckParallelContext.configure_optimization = _configure_optimization
+OobleckParallelContext._activate_latest_generation = _activate_latest_generation
+OobleckParallelContext.apply_membership = _apply_membership
+OobleckParallelContext.enable_control_plane_barrier = _enable_control_plane_barrier
+OobleckParallelContext.prepare_generation = _prepare_generation
+OobleckParallelContext.mark_generation_active = _mark_generation_active
+OobleckParallelContext.step = _step_with_control_barrier
+OobleckParallelContext.recover_from_survivors = _recover_from_survivors
+OobleckParallelContext.close = _close_with_topology

--- a/oobleck/state_transfer.py
+++ b/oobleck/state_transfer.py
@@ -1,0 +1,185 @@
+"""Collective execution of immutable state transfer schedules."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping
+
+import torch
+
+from oobleck.state import TransferSchedule, all_to_all_single_compat
+
+StateTensorKey = tuple[str, str, int]
+
+
+@dataclass(frozen=True, slots=True)
+class TransferExecutionMetrics:
+    actual_source_bytes: tuple[tuple[int, int], ...]
+    actual_destination_bytes: tuple[tuple[int, int], ...]
+    actual_link_class_bytes: tuple[tuple[str, int], ...]
+    round_durations: tuple[tuple[int, str, float], ...]
+
+
+def _bytes(tensor: torch.Tensor) -> torch.Tensor:
+    if not tensor.is_contiguous():
+        raise ValueError("state transfer tensors must be contiguous")
+    # ``view(dtype)`` rejects zero-dimensional tensors when element sizes
+    # differ.  Normalizing to a one-dimensional storage view also covers
+    # scalar optimizer slots such as Adam's step counter.
+    return tensor.reshape(-1).view(torch.uint8).flatten()
+
+
+def _transfer_identity(item) -> tuple[object, ...]:
+    return (
+        item.round,
+        item.source_rank,
+        item.destination_rank,
+        item.logical_key,
+        item.state_kind,
+        item.tp_lane,
+        item.chunk_start,
+        item.chunk_end,
+        item.version,
+    )
+
+
+def _checksum(payload: torch.Tensor) -> str:
+    return hashlib.sha256(payload.detach().cpu().numpy().tobytes()).hexdigest()
+
+
+def _validate_dtype(tensor: torch.Tensor, expected: str, key: StateTensorKey) -> None:
+    actual = str(tensor.dtype).removeprefix("torch.")
+    if actual != expected.removeprefix("torch."):
+        raise ValueError(
+            f"state transfer dtype mismatch for {key}: expected {expected}, got {actual}"
+        )
+
+
+def execute_transfer_schedule(
+    schedule: TransferSchedule,
+    *,
+    rank: int,
+    world_size: int,
+    sources: Mapping[StateTensorKey, torch.Tensor],
+    destinations: MutableMapping[StateTensorKey, torch.Tensor],
+    device: torch.device | str,
+    group=None,
+    verify_checksums: bool = True,
+) -> TransferExecutionMetrics:
+    """Pack, all-to-all, validate, and unpack every collective round.
+
+    Each rank calls this with the same schedule and participates with zero-sized
+    splits when it has no payload. Destination tensors are preallocated from the
+    new manifest, allowing unpacking directly into their storage.
+    """
+
+    if not 0 <= rank < world_size:
+        raise ValueError("rank is outside world_size")
+    target_device = torch.device(device)
+    round_durations = []
+    rounds = sorted({(item.round, item.dtype) for item in schedule.transfers})
+    for round_number, dtype in rounds:
+        round_started = time.perf_counter()
+        selected = [
+            item
+            for item in schedule.transfers
+            if item.round == round_number and item.dtype == dtype
+        ]
+        outgoing = [item for item in selected if item.source_rank == rank]
+        incoming = [item for item in selected if item.destination_rank == rank]
+        outgoing.sort(
+            key=lambda item: (
+                item.destination_rank,
+                item.logical_key,
+                item.state_kind,
+                item.tp_lane,
+                item.chunk_start,
+            )
+        )
+        incoming.sort(
+            key=lambda item: (
+                item.source_rank,
+                item.logical_key,
+                item.state_kind,
+                item.tp_lane,
+                item.chunk_start,
+            )
+        )
+        input_splits = [0] * world_size
+        output_splits = [0] * world_size
+        packed = []
+        local_checksums = {}
+        for item in outgoing:
+            key = (item.logical_key, item.state_kind, item.tp_lane)
+            if key not in sources:
+                raise KeyError(f"source rank {rank} is missing scheduled state {key}")
+            _validate_dtype(sources[key], item.dtype, key)
+            payload = _bytes(sources[key])
+            if item.chunk_end > payload.numel():
+                raise ValueError(f"scheduled chunk exceeds source tensor for {key}")
+            chunk = payload[item.chunk_start : item.chunk_end]
+            packed.append(chunk.to(target_device))
+            if verify_checksums:
+                local_checksums[_transfer_identity(item)] = _checksum(chunk)
+            input_splits[item.destination_rank] += item.byte_count
+        for item in incoming:
+            output_splits[item.source_rank] += item.byte_count
+        input_buffer = (
+            torch.cat(packed) if packed else torch.empty(0, dtype=torch.uint8, device=target_device)
+        )
+        output_buffer = torch.empty(sum(output_splits), dtype=torch.uint8, device=target_device)
+        expected_checksums = {}
+        if verify_checksums:
+            import torch.distributed as dist
+
+            checksum_maps: list[dict[tuple[object, ...], str] | None] = [None] * world_size
+            dist.all_gather_object(checksum_maps, local_checksums, group=group)
+            for values in checksum_maps:
+                if values is not None:
+                    expected_checksums.update(values)
+        all_to_all_single_compat(
+            output_buffer,
+            input_buffer,
+            output_splits,
+            input_splits,
+            group=group,
+        )
+        cursor = 0
+        for item in incoming:
+            key = (item.logical_key, item.state_kind, item.tp_lane)
+            if key not in destinations:
+                raise KeyError(f"destination rank {rank} is missing allocated state {key}")
+            _validate_dtype(destinations[key], item.dtype, key)
+            payload = _bytes(destinations[key])
+            if item.chunk_end > payload.numel():
+                raise ValueError(f"scheduled chunk exceeds destination tensor for {key}")
+            end = cursor + item.byte_count
+            payload[item.chunk_start : item.chunk_end].copy_(output_buffer[cursor:end])
+            if verify_checksums:
+                identity = _transfer_identity(item)
+                expected = expected_checksums.get(identity)
+                actual = _checksum(payload[item.chunk_start : item.chunk_end])
+                if expected is None or actual != expected:
+                    raise RuntimeError(
+                        f"state transfer checksum mismatch for {key} "
+                        f"bytes [{item.chunk_start}, {item.chunk_end})"
+                    )
+            cursor = end
+        if cursor != output_buffer.numel():
+            raise RuntimeError("state transfer unpack byte count mismatch")
+        elapsed = time.perf_counter() - round_started
+        if world_size > 1:
+            import torch.distributed as dist
+
+            duration_values: list[float | None] = [None] * world_size
+            dist.all_gather_object(duration_values, elapsed, group=group)
+            elapsed = max(value for value in duration_values if value is not None)
+        round_durations.append((round_number, dtype, elapsed))
+    return TransferExecutionMetrics(
+        schedule.per_source_bytes,
+        schedule.per_destination_bytes,
+        schedule.per_link_class_bytes,
+        tuple(round_durations),
+    )

--- a/oobleck/topology.py
+++ b/oobleck/topology.py
@@ -1,0 +1,215 @@
+"""Logical-layer/TP-lane gradient synchronization topology."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+import torch
+
+from oobleck.recovery import logical_state_bindings
+from oobleck.state import StateManifest
+from oobleck.types import OobleckExecutionPlan
+
+
+@dataclass(frozen=True, slots=True)
+class GradientSyncGroup:
+    logical_key: str
+    tp_lane: int
+    placements: tuple[str, ...]
+    ranks: tuple[int, ...]
+    sample_weights: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.ranks) != len(self.sample_weights) or not self.ranks:
+            raise ValueError("gradient group ranks and sample weights must align")
+        if tuple(sorted(self.ranks)) != self.ranks or len(set(self.ranks)) != len(self.ranks):
+            raise ValueError("gradient group ranks must be sorted and unique")
+        if abs(sum(self.sample_weights) - 1.0) > 1e-9:
+            raise ValueError("gradient sample weights must sum to one")
+
+
+def build_gradient_sync_groups(
+    manifests: Sequence[StateManifest],
+    rank_to_pipeline: Mapping[int, str],
+    pipeline_sample_counts: Mapping[str, int],
+) -> tuple[GradientSyncGroup, ...]:
+    owners: dict[tuple[str, int, tuple[str, ...]], set[int]] = {}
+    for manifest in manifests:
+        for entry in manifest.entries:
+            if entry.state_kind != "parameter":
+                continue
+            logical_key = entry.shared_state_id or entry.logical_key
+            owners.setdefault((logical_key, entry.tp_lane, entry.placements), set()).add(
+                manifest.rank
+            )
+    result = []
+    for (key, lane, placements), ranks_set in sorted(owners.items()):
+        ranks = tuple(sorted(ranks_set))
+        counts = [pipeline_sample_counts[rank_to_pipeline[rank]] for rank in ranks]
+        total = sum(counts)
+        if total <= 0:
+            raise ValueError(f"logical parameter {key} has no contributing samples")
+        result.append(
+            GradientSyncGroup(
+                key,
+                lane,
+                placements,
+                ranks,
+                tuple(count / total for count in counts),
+            )
+        )
+    return tuple(result)
+
+
+def create_process_groups(groups: Sequence[GradientSyncGroup]):
+    """Collectively create groups in deterministic logical-key order."""
+
+    import torch.distributed as dist
+
+    ordered = sorted(
+        groups,
+        key=lambda item: (item.logical_key, item.tp_lane, item.placements, item.ranks),
+    )
+    return {group: dist.new_group(ranks=list(group.ranks)) for group in ordered}
+
+
+def parameter_bindings_by_sync_key(
+    named_parameters: Mapping[str, torch.nn.Parameter],
+    manifest: StateManifest,
+) -> dict[str, torch.nn.Parameter]:
+    """Alias tied/shared state identities to their local parameter object."""
+
+    bindings = dict(named_parameters)
+    for entry in manifest.entries:
+        if entry.state_kind != "parameter" or entry.shared_state_id is None:
+            continue
+        parameter = named_parameters.get(entry.logical_key)
+        if parameter is None:
+            continue
+        existing = bindings.setdefault(entry.shared_state_id, parameter)
+        if existing is not parameter:
+            raise RuntimeError(
+                f"shared state {entry.shared_state_id!r} maps to distinct local tensors"
+            )
+    return bindings
+
+
+class HeterogeneousGradientSynchronizer:
+    """Sample-weighted logical-parameter reduction across pipeline replicas."""
+
+    def __init__(self, bindings, process_groups) -> None:
+        self._bindings = tuple(bindings)
+        self._process_groups = process_groups
+        self._closed = False
+
+    def sync(self) -> None:
+        if self._closed:
+            raise RuntimeError("gradient synchronizer is closed")
+        import torch.distributed as dist
+
+        for group, process_group, parameter, sample_weight in self._bindings:
+            if len(group.ranks) == 1:
+                continue
+            gradient = parameter.grad
+            has_gradient = gradient is not None
+            local_parameter = parameter.to_local() if hasattr(parameter, "to_local") else parameter
+            local_gradient = (
+                gradient.to_local()
+                if gradient is not None and hasattr(gradient, "to_local")
+                else gradient
+            )
+            backend = dist.get_backend(process_group)
+            collective_device = (
+                torch.device("cpu")
+                if backend == "gloo" and local_parameter.device.type == "cuda"
+                else local_parameter.device
+            )
+            present = torch.tensor(int(has_gradient), dtype=torch.int32, device=collective_device)
+            dist.all_reduce(present, group=process_group)
+            if int(present.item()) == 0:
+                continue
+            payload = (
+                torch.zeros_like(local_parameter, device=collective_device)
+                if local_gradient is None
+                else local_gradient.detach().to(collective_device).mul(sample_weight)
+            )
+            dist.all_reduce(payload, group=process_group)
+            if gradient is None:
+                parameter.grad = torch.zeros_like(parameter)
+                gradient = parameter.grad
+                local_gradient = gradient.to_local() if hasattr(gradient, "to_local") else gradient
+            assert local_gradient is not None
+            local_gradient.copy_(payload.to(local_gradient.device))
+
+    def close(self) -> None:
+        self._bindings = ()
+        self._process_groups = {}
+        self._closed = True
+
+
+def activate_gradient_synchronizer(
+    model: torch.nn.Module,
+    local_manifest: StateManifest,
+    execution_plan: OobleckExecutionPlan,
+    *,
+    microbatch_size: int,
+) -> HeterogeneousGradientSynchronizer | None:
+    """Gather ownership, create every logical group, and bind local parameters."""
+
+    import torch.distributed as dist
+
+    if not dist.is_initialized() or dist.get_world_size() == 1:
+        return None
+    world_size = dist.get_world_size()
+    manifests: list[StateManifest | None] = [None] * world_size
+    dist.all_gather_object(manifests, local_manifest)
+    if any(item is None for item in manifests):
+        raise RuntimeError("gradient ownership manifest exchange was incomplete")
+    rank_to_pipeline = {
+        rank: instance.instance_id
+        for instance in execution_plan.instances
+        for stage_ranks in instance.ranks
+        for rank in stage_ranks
+    }
+    sample_counts = {
+        instance.instance_id: instance.microbatches * microbatch_size
+        for instance in execution_plan.instances
+    }
+    groups = build_gradient_sync_groups(
+        tuple(item for item in manifests if item is not None),
+        rank_to_pipeline,
+        sample_counts,
+    )
+    process_groups = create_process_groups(groups)
+    named_parameters, _ = logical_state_bindings(model, local_manifest)
+    sync_parameters = parameter_bindings_by_sync_key(named_parameters, local_manifest)
+    rank = dist.get_rank()
+    bindings = []
+    for group in groups:
+        if rank not in group.ranks:
+            continue
+        parameter = sync_parameters.get(group.logical_key)
+        if parameter is None:
+            raise RuntimeError(
+                f"rank {rank} owns {group.logical_key!r} in topology but not in its model"
+            )
+        bindings.append(
+            (
+                group,
+                process_groups[group],
+                parameter,
+                group.sample_weights[group.ranks.index(rank)],
+            )
+        )
+    return HeterogeneousGradientSynchronizer(bindings, process_groups)
+
+
+__all__ = [
+    "GradientSyncGroup",
+    "HeterogeneousGradientSynchronizer",
+    "activate_gradient_synchronizer",
+    "build_gradient_sync_groups",
+    "create_process_groups",
+    "parameter_bindings_by_sync_key",
+]

--- a/tests/refactor/test_data_runtime.py
+++ b/tests/refactor/test_data_runtime.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import pytest
+import torch
+from torch.utils.data import DataLoader, Dataset, IterableDataset
+
+from oobleck import OobleckConfig, OobleckParallelizationPlan
+from oobleck.elastic import MembershipSnapshot, NodeIdentity
+
+
+class Samples(Dataset):
+    def __len__(self):
+        return 16
+
+    def __getitem__(self, index):
+        return {"x": torch.tensor([float(index)]), "y": torch.tensor([float(index * 2)])}
+
+
+class Stream(IterableDataset):
+    def __iter__(self):
+        yield {"x": 1}
+
+
+@dataclass
+class ParallelConfig:
+    tensor_parallel_size: int = 1
+    pipeline_parallel_size: None = None
+    data_parallel_size: int = 1
+    context_parallel_size: int = 1
+    expert_parallel_size: int = 1
+
+
+def context():
+    model = torch.nn.Linear(1, 1)
+    plan = OobleckParallelizationPlan(
+        OobleckConfig(global_batch_size=4, microbatch_size=2, max_nodes=1, seed=9)
+    )
+    plan.parallelize(model, ParallelConfig())
+    return model, plan.materialize("cpu")
+
+
+def test_sampler_does_not_advance_until_commit_and_replays_indices():
+    _, ctx = context()
+    dataset = Samples()
+    sampler = ctx.create_batch_sampler(dataset, shuffle=True)
+    first = list(next(iter(sampler)))
+    assert list(next(iter(sampler))) == first
+    assert sampler.committed_cursor == 0
+
+
+def test_dataset_contract_rejects_iterable_and_dataset_dict():
+    _, ctx = context()
+    with pytest.raises(TypeError, match="map-style"):
+        ctx.create_batch_sampler(Stream(), shuffle=False)
+    datasets = pytest.importorskip("datasets")
+    value = datasets.DatasetDict({"train": datasets.Dataset.from_dict({"x": [1, 2]})})
+    with pytest.raises(TypeError, match="Select a split"):
+        ctx.create_batch_sampler(value, shuffle=False)
+
+
+def test_generation_change_discards_gradients_and_replays_once():
+    model, ctx = context()
+    dataset = Samples()
+    sampler = ctx.create_batch_sampler(dataset, shuffle=False)
+    loader = ctx.prepare_dataloader(DataLoader(dataset, batch_sampler=sampler))
+    scheduler_steps = []
+
+    class Scheduler:
+        def step(self):
+            scheduler_steps.append(1)
+
+    ctx.configure_optimization(
+        optimizer_factory=lambda parameters: torch.optim.SGD(parameters, lr=0.01),
+        scheduler_factory=lambda optimizer: Scheduler(),
+    )
+    batch = next(iter(loader))
+    newer = replace(ctx.execution_plan, generation=1, previous_generation=0, plan_checksum="")
+    announced = False
+
+    def criterion(output, microbatch):
+        nonlocal announced
+        if not announced:
+            announced = True
+            ctx.announce_generation(newer)
+        return ((output - microbatch["y"]) ** 2).mean()
+
+    result = ctx.step(batch, lambda microbatch: model(microbatch["x"]), criterion=criterion)
+    assert result.attempts == 2
+    assert result.committed_step == 1
+    assert result.generation == 1
+    assert sampler.committed_cursor == 1
+    assert len(scheduler_steps) == 1
+
+
+def test_generation_change_restores_adam_scheduler_and_scaler_state():
+    model, ctx = context()
+
+    class Scheduler:
+        def __init__(self, optimizer):
+            self.optimizer = optimizer
+            self.count = 0
+
+        def step(self):
+            self.count += 1
+
+        def state_dict(self):
+            return {"count": self.count}
+
+        def load_state_dict(self, state):
+            self.count = state["count"]
+
+    class Scaler:
+        def __init__(self):
+            self.growth = 8
+
+        def state_dict(self):
+            return {"growth": self.growth}
+
+        def load_state_dict(self, state):
+            self.growth = state["growth"]
+
+    ctx.configure_optimization(
+        optimizer_factory=lambda parameters: torch.optim.AdamW(parameters, lr=0.03),
+        scheduler_factory=Scheduler,
+        scaler=Scaler(),
+    )
+    model(torch.tensor([[2.0]])).sum().backward()
+    ctx.optimizer.step()
+    ctx.optimizer.zero_grad(set_to_none=True)
+    ctx.scheduler.step()
+    ctx.committed_step = 1
+    expected_parameters = {name: value.detach().clone() for name, value in model.named_parameters()}
+    expected_slots = {
+        name: {slot: value.detach().clone() for slot, value in ctx.optimizer.state[param].items()}
+        for name, param in model.named_parameters()
+    }
+    old_optimizer = ctx.optimizer
+
+    newer = replace(ctx.execution_plan, generation=1, previous_generation=0, plan_checksum="")
+    assert ctx.announce_generation(newer)
+    ctx._activate_latest_generation()
+
+    assert ctx.optimizer is not old_optimizer
+    assert ctx.committed_step == 1
+    assert ctx.scheduler.count == 1
+    assert ctx.scaler.growth == 8
+    assert ctx.last_recovery_report.schedule.transfers == ()
+    for name, parameter in model.named_parameters():
+        torch.testing.assert_close(parameter, expected_parameters[name])
+        for slot, expected in expected_slots[name].items():
+            torch.testing.assert_close(ctx.optimizer.state[parameter][slot], expected)
+
+
+def test_newer_generation_supersedes_in_progress_activation():
+    _, ctx = context()
+    ctx.configure_optimization(
+        optimizer_factory=lambda parameters: torch.optim.SGD(parameters, lr=0.01)
+    )
+    first = replace(ctx.execution_plan, generation=1, previous_generation=0, plan_checksum="")
+    second = replace(ctx.execution_plan, generation=2, previous_generation=1, plan_checksum="")
+    initialized = []
+
+    def initialize(target):
+        initialized.append(target.generation)
+        if target.generation == 1:
+            ctx.announce_generation(second)
+
+    ctx.owner_plan.world_initializer = initialize
+    ctx.announce_generation(first)
+    ctx._activate_latest_generation()
+
+    assert initialized == [1, 2]
+    assert ctx.generation == 2
+    assert ctx.partition.closed is False
+
+
+def test_heterogeneous_pipelines_execute_disjoint_global_microbatches():
+    dataset = Samples()
+    template = __import__("oobleck").PipelineTemplate("one", ((0, 1),), 1, 1, 1)
+    observed = []
+    for rank in (0, 1):
+        model = torch.nn.Linear(1, 1)
+        plan = OobleckParallelizationPlan(
+            OobleckConfig(global_batch_size=8, microbatch_size=2, max_nodes=2),
+            templates=(template,),
+            node_ids=("node-a", "node-b"),
+            rank=rank,
+        )
+        plan.parallelize(model, ParallelConfig())
+        ctx = plan.materialize("cpu")
+        sampler = ctx.create_batch_sampler(dataset, shuffle=False)
+        loader = ctx.prepare_dataloader(DataLoader(dataset, batch_sampler=sampler))
+        ctx.configure_optimization(
+            optimizer_factory=lambda parameters: torch.optim.SGD(parameters, lr=0.01)
+        )
+        batch = next(iter(loader))
+        calls = []
+
+        def execute(microbatch):
+            calls.extend(int(item) for item in microbatch["x"].flatten())
+            return model(microbatch["x"])
+
+        ctx.step(batch, execute, criterion=lambda output, item: output.sum())
+        pipeline_id = ctx.execution_plan.rank_local_stage(rank).pipeline_id
+        assignment = next(
+            item for item in batch.descriptor.assignments if item.pipeline_id == pipeline_id
+        )
+        assert tuple(calls) == assignment.sample_indices
+        observed.extend(calls)
+
+    assert sorted(observed) == list(range(8))
+    assert len(observed) == len(set(observed))
+
+
+def test_complete_membership_snapshot_announces_deterministic_execution_plan():
+    _, ctx = context()
+    replacement = MembershipSnapshot(
+        1,
+        (NodeIdentity("local-node", "replacement", ("127.0.0.1",), ("0",)),),
+        ("replacement:local-node",),
+    )
+    assert ctx.apply_membership(replacement)
+    assert ctx._pending_plan.generation == 1
+    assert ctx._pending_plan.previous_generation == 0
+    assert ctx._pending_plan.plan_checksum
+    assert not ctx.apply_membership(replacement)
+
+    invalid = MembershipSnapshot(
+        2,
+        (NodeIdentity("local-node", "bad", ("127.0.0.1",), ("0", "1")),),
+        ("replacement:local-node",),
+    )
+    with pytest.raises(ValueError, match="fixed TP width"):
+        ctx.apply_membership(invalid)
+
+
+def test_initial_meta_partition_runs_checkpoint_initializer_before_training():
+    class CheckpointModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.weight = torch.nn.Parameter(torch.empty(3, device="meta"))
+            self.register_buffer("running", torch.empty(2, device="meta"))
+            self.initialized = False
+
+        def initialize_checkpoint(self):
+            with torch.no_grad():
+                self.weight.fill_(7)
+                self.running.fill_(11)
+            self.initialized = True
+
+        def forward(self, value):
+            return value * self.weight[0]
+
+    model = CheckpointModel()
+    plan = OobleckParallelizationPlan(OobleckConfig(global_batch_size=2, microbatch_size=1))
+    plan.parallelize(model, ParallelConfig())
+    context = plan.materialize("cpu")
+
+    assert model.initialized
+    assert not model.weight.is_meta and not model.running.is_meta
+    torch.testing.assert_close(model.weight, torch.full((3,), 7.0))
+    torch.testing.assert_close(model.running, torch.full((2,), 11.0))
+    context.close()
+
+
+def test_hugging_face_dataset_replays_through_standard_dataloader():
+    datasets = pytest.importorskip("datasets")
+    model, ctx = context()
+    dataset = datasets.Dataset.from_dict(
+        {
+            "x": [float(index) for index in range(16)],
+            "y": [float(index * 2) for index in range(16)],
+        }
+    )
+    sampler = ctx.create_batch_sampler(dataset, shuffle=False)
+
+    def collate(rows):
+        return {
+            key: torch.tensor([[row[key]] for row in rows], dtype=torch.float32)
+            for key in ("x", "y")
+        }
+
+    loader = ctx.prepare_dataloader(DataLoader(dataset, batch_sampler=sampler, collate_fn=collate))
+    ctx.configure_optimization(
+        optimizer_factory=lambda parameters: torch.optim.SGD(parameters, lr=0.01)
+    )
+    batch = next(iter(loader))
+    newer = replace(ctx.execution_plan, generation=1, previous_generation=0, plan_checksum="")
+    announced = False
+
+    def criterion(output, microbatch):
+        nonlocal announced
+        if not announced:
+            announced = True
+            ctx.announce_generation(newer)
+        return ((output - microbatch["y"]) ** 2).mean()
+
+    result = ctx.step(batch, lambda microbatch: model(microbatch["x"]), criterion=criterion)
+    assert result.attempts == 2
+    assert sampler.committed_cursor == 1
+    assert len(set(batch.sample_indices)) == len(batch.sample_indices) == 4
+    ctx.close()
+
+
+def test_prepare_dataloader_rejects_non_oobleck_and_persistent_worker_configs():
+    _, ctx = context()
+    dataset = Samples()
+    with pytest.raises(TypeError, match="OobleckBatchSampler"):
+        ctx.prepare_dataloader(DataLoader(dataset, batch_size=4))
+    sampler = ctx.create_batch_sampler(dataset, shuffle=False)
+    persistent = DataLoader(
+        dataset,
+        batch_sampler=sampler,
+        num_workers=1,
+        persistent_workers=True,
+    )
+    with pytest.raises(ValueError, match="persistent_workers"):
+        ctx.prepare_dataloader(persistent)
+    ctx.close()
+
+
+def test_collator_may_return_an_explicit_microbatch_list():
+    _, ctx = context()
+    dataset = Samples()
+    sampler = ctx.create_batch_sampler(dataset, shuffle=False)
+
+    def collate(rows):
+        return [
+            {key: torch.stack([row[key] for row in rows[start : start + 2]]) for key in ("x", "y")}
+            for start in (0, 2)
+        ]
+
+    loader = ctx.prepare_dataloader(DataLoader(dataset, batch_sampler=sampler, collate_fn=collate))
+    batch = next(iter(loader))
+    assert len(batch.microbatches) == 2
+    assert [item["x"].flatten().tolist() for item in batch.microbatches] == [
+        [0.0, 1.0],
+        [2.0, 3.0],
+    ]
+    ctx.close()

--- a/tests/refactor/test_distributed_transfer.py
+++ b/tests/refactor/test_distributed_transfer.py
@@ -1,0 +1,284 @@
+import torch
+import torch.distributed as dist
+from types import SimpleNamespace
+
+from oobleck.recovery import capture_context_state, restore_context_state
+from oobleck.state import LogicalStateEntry, StateManifest, plan_state_redistribution
+from oobleck.state_transfer import execute_transfer_schedule
+from oobleck.topology import activate_gradient_synchronizer
+from oobleck.types import OobleckExecutionPlan, PipelineInstance, PipelineTemplate
+from tests.distributed.distributed_base import GlooDistributedTestBase
+
+
+class TestDistributedStateTransfer(GlooDistributedTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_variable_split_all_to_all_reconstructs_cuda_state(self):
+        device = torch.device("cuda", self.rank % torch.cuda.device_count())
+
+        def entry(rank):
+            return LogicalStateEntry(
+                "layer.weight",
+                (17,),
+                (17,),
+                "float32",
+                "parameter",
+                ("replicate",),
+                0,
+                rank,
+                4,
+            )
+
+        schedule = plan_state_redistribution(
+            [StateManifest(0, (entry(0),), 4)],
+            [StateManifest(1, (entry(1),), 4)],
+            chunk_bytes=20,
+            alignment=4,
+        )
+        key = ("layer.weight", "parameter", 0)
+        expected = torch.arange(17, dtype=torch.float32, device=device)
+        sources = {key: expected} if self.rank == 0 else {}
+        destinations = {key: torch.zeros_like(expected)} if self.rank == 1 else {}
+        metrics = execute_transfer_schedule(
+            schedule,
+            rank=self.rank,
+            world_size=self.world_size,
+            sources=sources,
+            destinations=destinations,
+            device=device,
+        )
+        assert metrics.actual_source_bytes == schedule.per_source_bytes
+        assert metrics.actual_destination_bytes == schedule.per_destination_bytes
+        assert all(duration >= 0 for _, _, duration in metrics.round_durations)
+        if self.rank == 1:
+            torch.testing.assert_close(destinations[key], expected)
+
+    def test_runtime_recovery_moves_model_and_adam_state_between_cuda_ranks(self):
+        assert dist.get_backend() == "gloo"
+        device = torch.device("cuda", self.rank % torch.cuda.device_count())
+        rank = self.rank
+
+        class LogicalWeight(torch.nn.Module):
+            def __init__(self, logical_key):
+                super().__init__()
+                self.logical_key = logical_key
+                self.weight = torch.nn.Parameter(torch.full((5,), 10.0 + rank, device=device))
+
+            def _global_cornstarch_key(self, local_key):
+                return self.logical_key if local_key == "weight" else local_key
+
+        old_key = f"layer.{self.rank}.weight"
+        new_key = f"layer.{1 - self.rank}.weight"
+        model = LogicalWeight(old_key)
+
+        def optimizer_factory(parameters):
+            return torch.optim.AdamW(parameters, lr=0.02)
+
+        optimizer = optimizer_factory(model.parameters())
+        model.weight.grad = torch.full_like(model.weight, float(self.rank + 1))
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+
+        def manifest(logical_key):
+            return StateManifest(
+                self.rank,
+                (
+                    LogicalStateEntry(
+                        logical_key,
+                        (5,),
+                        (5,),
+                        "torch.float32",
+                        "parameter",
+                        ("replicate",),
+                        0,
+                        self.rank,
+                        3,
+                    ),
+                ),
+                3,
+            )
+
+        context = SimpleNamespace(
+            model=model,
+            partition=SimpleNamespace(manifest=manifest(old_key)),
+            optimizer=optimizer,
+            scheduler=None,
+            scaler=None,
+            committed_step=3,
+            owner_plan=SimpleNamespace(rank=self.rank),
+            compiled=SimpleNamespace(world_size=self.world_size),
+            config=SimpleNamespace(state_transfer_chunk_bytes=8, transfer_alignment_bytes=4),
+            device=device,
+            _optimizer_factory=optimizer_factory,
+            _scheduler_factory=None,
+        )
+        snapshot = capture_context_state(context)
+        source_weight = model.weight.detach().cpu().clone()
+        source_exp_avg = optimizer.state[model.weight]["exp_avg"].detach().cpu().clone()
+        gathered_weights = [None] * self.world_size
+        gathered_moments = [None] * self.world_size
+        dist.all_gather_object(gathered_weights, source_weight)
+        dist.all_gather_object(gathered_moments, source_exp_avg)
+
+        model.logical_key = new_key
+        context.partition.manifest = manifest(new_key)
+        report = restore_context_state(context, snapshot)
+
+        assert model.weight.is_cuda
+        assert report.schedule.transfers
+        assert report.actual_source_bytes == report.source_bytes
+        assert report.actual_destination_bytes == report.destination_bytes
+        assert report.round_durations
+        torch.testing.assert_close(model.weight.cpu(), gathered_weights[1 - self.rank])
+        torch.testing.assert_close(
+            context.optimizer.state[model.weight]["exp_avg"].cpu(),
+            gathered_moments[1 - self.rank],
+        )
+
+    def test_heterogeneous_pipeline_gradients_use_global_sample_weights_on_cuda(self):
+        assert dist.get_backend() == "gloo"
+        device = torch.device("cuda", self.rank % torch.cuda.device_count())
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.weight = torch.nn.Parameter(torch.ones(3, device=device))
+
+        model = Model()
+        model.weight.grad = torch.full_like(model.weight, float(self.rank + 1))
+        template = PipelineTemplate("single", ((0, 1),), 1, 1.0, 1.0)
+        instances = (
+            PipelineInstance("fast", template, ("node-0",), ((0,),), 3),
+            PipelineInstance("slow", template, ("node-1",), ((1,),), 1),
+        )
+        plan = OobleckExecutionPlan(
+            0,
+            instances,
+            (("node-0", (0,)), ("node-1", (1,))),
+        )
+        manifest = StateManifest(
+            self.rank,
+            (
+                LogicalStateEntry(
+                    "weight",
+                    (3,),
+                    (3,),
+                    "torch.float32",
+                    "parameter",
+                    ("replicate",),
+                    0,
+                    self.rank,
+                    0,
+                ),
+            ),
+            0,
+        )
+        synchronizer = activate_gradient_synchronizer(model, manifest, plan, microbatch_size=2)
+        assert synchronizer is not None
+        synchronizer.sync()
+
+        # 6 samples from rank 0 and 2 from rank 1: 1*(6/8) + 2*(2/8).
+        assert model.weight.grad.is_cuda
+        torch.testing.assert_close(model.weight.grad, torch.full_like(model.weight.grad, 1.25))
+        synchronizer.close()
+
+    def test_joining_rank_recovers_parameter_and_optimizer_without_local_snapshot(self):
+        assert dist.get_backend() == "gloo"
+        device = torch.device("cuda", self.rank % torch.cuda.device_count())
+
+        class StateModel(torch.nn.Module):
+            def __init__(self, keys, base):
+                super().__init__()
+                for offset, key in enumerate(keys):
+                    self.register_parameter(
+                        key,
+                        torch.nn.Parameter(torch.full((4,), base + offset, device=device)),
+                    )
+
+        def manifest(keys, committed_step):
+            return StateManifest(
+                self.rank,
+                tuple(
+                    LogicalStateEntry(
+                        key,
+                        (4,),
+                        (4,),
+                        "torch.float32",
+                        "parameter",
+                        ("replicate",),
+                        0,
+                        self.rank,
+                        committed_step,
+                    )
+                    for key in keys
+                ),
+                committed_step,
+            )
+
+        def optimizer_factory(parameters):
+            return torch.optim.AdamW(parameters, lr=0.01)
+
+        if self.rank == 0:
+            source_model = StateModel(("a", "b"), 5.0)
+            source_optimizer = optimizer_factory(source_model.parameters())
+            for index, parameter in enumerate(source_model.parameters()):
+                parameter.grad = torch.full_like(parameter, float(index + 1))
+            source_optimizer.step()
+            source_optimizer.zero_grad(set_to_none=True)
+            context = SimpleNamespace(
+                model=source_model,
+                partition=SimpleNamespace(manifest=manifest(("a", "b"), 5)),
+                optimizer=source_optimizer,
+                scheduler=None,
+                scaler=None,
+                committed_step=5,
+                owner_plan=SimpleNamespace(rank=0),
+                compiled=SimpleNamespace(world_size=self.world_size),
+                config=SimpleNamespace(state_transfer_chunk_bytes=8, transfer_alignment_bytes=4),
+                device=device,
+                _optimizer_factory=optimizer_factory,
+                _scheduler_factory=None,
+            )
+            snapshot = capture_context_state(context)
+            expected = (
+                source_model.b.detach().cpu(),
+                source_optimizer.state[source_model.b]["exp_avg"].detach().cpu(),
+            )
+            context.model = StateModel(("a",), -1.0)
+            context.partition.manifest = manifest(("a",), 5)
+        else:
+            target_model = StateModel(("b",), -1.0)
+            context = SimpleNamespace(
+                model=target_model,
+                partition=SimpleNamespace(manifest=manifest(("b",), 0)),
+                optimizer=optimizer_factory(target_model.parameters()),
+                scheduler=None,
+                scaler=None,
+                committed_step=0,
+                owner_plan=SimpleNamespace(rank=1),
+                compiled=SimpleNamespace(world_size=self.world_size),
+                config=SimpleNamespace(state_transfer_chunk_bytes=8, transfer_alignment_bytes=4),
+                device=device,
+                _optimizer_factory=optimizer_factory,
+                _scheduler_factory=None,
+            )
+            snapshot = None
+            expected = None
+
+        expected_values = [expected]
+        dist.broadcast_object_list(expected_values, src=0)
+        report = restore_context_state(context, snapshot)
+
+        assert context.committed_step == 5
+        assert report.total_seconds > 0
+        assert report.actual_source_bytes == report.source_bytes
+        assert report.round_durations
+        if self.rank == 1:
+            expected_weight, expected_moment = expected_values[0]
+            torch.testing.assert_close(context.model.b.cpu(), expected_weight)
+            torch.testing.assert_close(
+                context.optimizer.state[context.model.b]["exp_avg"].cpu(),
+                expected_moment,
+            )

--- a/tests/refactor/test_state.py
+++ b/tests/refactor/test_state.py
@@ -1,0 +1,135 @@
+import pytest
+import torch
+
+from oobleck.state import (
+    LogicalStateEntry,
+    StateManifest,
+    StateUnavailable,
+    Transfer,
+    TransferSchedule,
+    plan_state_redistribution,
+)
+from oobleck.state_transfer import execute_transfer_schedule
+
+
+def entry(rank: int, *, version: int = 3, size: int = 16):
+    return LogicalStateEntry(
+        "layers.0.weight",
+        (size,),
+        (size,),
+        "float32",
+        "parameter",
+        ("shard:0",),
+        0,
+        rank,
+        version,
+    )
+
+
+def test_large_tensor_is_striped_by_bytes_across_replicas():
+    schedule = plan_state_redistribution(
+        [StateManifest(0, (entry(0),), 3), StateManifest(1, (entry(1),), 3)],
+        [StateManifest(2, (entry(2),), 3)],
+        chunk_bytes=16,
+        round_bytes=16,
+        alignment=4,
+    )
+    assert dict(schedule.per_source_bytes) == {0: 32, 1: 32}
+    assert sum(item.byte_count for item in schedule.transfers) == 64
+    for round_number in {item.round for item in schedule.transfers}:
+        selected = [item for item in schedule.transfers if item.round == round_number]
+        for source in {item.source_rank for item in selected}:
+            assert sum(item.byte_count for item in selected if item.source_rank == source) <= 16
+        for destination in {item.destination_rank for item in selected}:
+            assert (
+                sum(item.byte_count for item in selected if item.destination_rank == destination)
+                <= 16
+            )
+    assert schedule.schedule_hash
+
+
+def test_retention_and_stale_version_filtering():
+    retained = plan_state_redistribution(
+        [StateManifest(0, (entry(0),), 3)],
+        [StateManifest(0, (entry(0),), 3)],
+        chunk_bytes=16,
+    )
+    assert retained.transfers == ()
+    assert retained.retained == ((0, "layers.0.weight", 0),)
+    with pytest.raises(StateUnavailable, match="no committed source"):
+        plan_state_redistribution(
+            [StateManifest(0, (entry(0, version=2),), 2)],
+            [StateManifest(1, (entry(1, version=3),), 3)],
+            chunk_bytes=16,
+        )
+
+
+def test_transfer_schedule_hash_and_tensor_dtype_are_validated_before_collectives():
+    transfer = Transfer(
+        0,
+        1,
+        "layers.0.weight",
+        "parameter",
+        0,
+        0,
+        4,
+        "float32",
+        0,
+        "network",
+        3,
+    )
+    schedule = TransferSchedule((transfer,), (), ((0, 4),), ((1, 4),), (("network", 4),))
+    with pytest.raises(ValueError, match="schedule hash"):
+        TransferSchedule(
+            schedule.transfers,
+            schedule.retained,
+            schedule.per_source_bytes,
+            schedule.per_destination_bytes,
+            schedule.per_link_class_bytes,
+            "invalid",
+        )
+    with pytest.raises(ValueError, match="dtype mismatch"):
+        execute_transfer_schedule(
+            schedule,
+            rank=0,
+            world_size=2,
+            sources={("layers.0.weight", "parameter", 0): torch.ones(4, dtype=torch.uint8)},
+            destinations={},
+            device="cpu",
+            verify_checksums=False,
+        )
+
+
+def test_locality_precedes_stable_rank_and_dtype_buckets_have_exact_splits():
+    local = plan_state_redistribution(
+        [StateManifest(0, (entry(0),), 3), StateManifest(1, (entry(1),), 3)],
+        [StateManifest(2, (entry(2),), 3)],
+        chunk_bytes=64,
+        rank_to_node={0: "node-a", 1: "node-b", 2: "node-a"},
+    )
+    assert {item.source_rank for item in local.transfers} == {0}
+    assert {item.link_class for item in local.transfers} == {"same-node"}
+
+    def integer_entry(rank):
+        return LogicalStateEntry(
+            "optimizer.step",
+            (2,),
+            (2,),
+            "int64",
+            "buffer",
+            ("replicate",),
+            0,
+            rank,
+            3,
+        )
+
+    source = StateManifest(0, (entry(0), integer_entry(0)), 3)
+    destination = StateManifest(1, (entry(1), integer_entry(1)), 3)
+    bucketed = plan_state_redistribution([source], [destination], chunk_bytes=64)
+    assert {item.dtype for item in bucketed.transfers} == {"float32", "int64"}
+    float_round = next(item.round for item in bucketed.transfers if item.dtype == "float32")
+    int_round = next(item.round for item in bucketed.transfers if item.dtype == "int64")
+    float_inputs, _ = bucketed.split_sizes(0, 2, round=float_round, dtype="float32")
+    int_inputs, _ = bucketed.split_sizes(0, 2, round=int_round, dtype="int64")
+    assert float_inputs == [0, 64]
+    assert int_inputs == [0, 16]

--- a/tests/refactor/test_state_bundles.py
+++ b/tests/refactor/test_state_bundles.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from oobleck.state import (
+    LogicalStateEntry,
+    StateManifest,
+    StateUnavailable,
+    plan_state_redistribution,
+)
+
+
+def entry(rank: int, logical_key: str, state_kind: str) -> LogicalStateEntry:
+    return LogicalStateEntry(
+        logical_key,
+        (4,),
+        (4,),
+        "float32",
+        state_kind,
+        ("replicate",),
+        0,
+        rank,
+        7,
+    )
+
+
+def manifest(rank: int, *, parameter: bool, optimizer: bool) -> StateManifest:
+    entries = []
+    if parameter:
+        entries.append(entry(rank, "layer.weight", "parameter"))
+    if optimizer:
+        entries.append(entry(rank, "layer.weight::optimizer::exp_avg", "optimizer"))
+    return StateManifest(rank, tuple(entries), 7)
+
+
+def test_bundle_candidates_exclude_partial_optimizer_replicas():
+    schedule = plan_state_redistribution(
+        [
+            manifest(0, parameter=True, optimizer=False),
+            manifest(1, parameter=True, optimizer=True),
+        ],
+        [manifest(2, parameter=True, optimizer=True)],
+        chunk_bytes=16,
+        alignment=4,
+    )
+    assert {item.source_rank for item in schedule.transfers} == {1}
+    assert dict(schedule.per_source_bytes) == {1: 32}
+
+
+def test_bundle_without_one_complete_surviving_replica_is_rejected():
+    with pytest.raises(StateUnavailable, match="complete state bundle"):
+        plan_state_redistribution(
+            [
+                manifest(0, parameter=True, optimizer=False),
+                manifest(1, parameter=False, optimizer=True),
+            ],
+            [manifest(2, parameter=True, optimizer=True)],
+            chunk_bytes=16,
+            alignment=4,
+        )

--- a/tests/refactor/test_topology.py
+++ b/tests/refactor/test_topology.py
@@ -1,0 +1,73 @@
+import pytest
+import torch
+
+from oobleck.state import LogicalStateEntry, StateManifest
+from oobleck.topology import (
+    build_gradient_sync_groups,
+    parameter_bindings_by_sync_key,
+)
+
+
+def test_gradient_groups_match_logical_tp_shards_and_sample_weights():
+    def manifest(rank, lane):
+        return StateManifest(
+            rank,
+            (
+                LogicalStateEntry(
+                    "layer.weight",
+                    (8, 8),
+                    (4, 8),
+                    "float32",
+                    "parameter",
+                    ("shard:0",),
+                    lane,
+                    rank,
+                    0,
+                ),
+            ),
+            0,
+        )
+
+    groups = build_gradient_sync_groups(
+        [manifest(0, 0), manifest(1, 0), manifest(2, 1)],
+        {0: "fast", 1: "slow", 2: "fast"},
+        {"fast": 6, "slow": 2},
+    )
+    assert len(groups) == 2
+    assert groups[0].ranks == (0, 1)
+    assert groups[0].sample_weights == (0.75, 0.25)
+    assert groups[1].ranks == (2,)
+    assert groups[1].sample_weights == (1.0,)
+
+
+def test_tied_parameters_bind_through_shared_state_identity():
+    parameter = torch.nn.Parameter(torch.ones(2))
+
+    def entry(key):
+        return LogicalStateEntry(
+            key,
+            (2,),
+            (2,),
+            "float32",
+            "parameter",
+            ("replicate",),
+            0,
+            0,
+            0,
+            shared_state_id="shared.embedding",
+        )
+
+    manifest = StateManifest(0, (entry("embed.weight"), entry("lm_head.weight")), 0)
+    bindings = parameter_bindings_by_sync_key(
+        {"embed.weight": parameter, "lm_head.weight": parameter}, manifest
+    )
+    assert bindings["shared.embedding"] is parameter
+
+    with pytest.raises(RuntimeError, match="distinct local tensors"):
+        parameter_bindings_by_sync_key(
+            {
+                "embed.weight": parameter,
+                "lm_head.weight": torch.nn.Parameter(torch.zeros(2)),
+            },
+            manifest,
+        )


### PR DESCRIPTION
## Summary

- snapshots committed model, buffer, optimizer, scheduler, and scaler state
- plans bounded, checksummed, locality-aware all-to-all transfer rounds
- stripes large state across surviving replicas and records predicted/actual load metrics
- restores generation state and supersedes stale in-progress recoveries safely
- builds logical-layer/TP-lane sample-weighted gradient synchronization groups

## Validation

- state, bundle, and topology tests: 8 passed
- transactional runtime tests: 11 passed
- CUDA-over-Gloo distributed transfer/recovery tests: 4 passed
- git diff --cached --check

Targets only refactor.