### PR TITLE
Implement managed generation rendezvous

### DIFF
--- a/examples/pretrain_llm.py
+++ b/examples/pretrain_llm.py
@@ -29,6 +29,9 @@ class ExampleTrainingConfig:
     dataset_name: str | None = None
     dataset_config: str | None = None
     split: str = "train"
+    max_nodes: int = 16
+    rendezvous_port: int = 29500
+    distributed_backend: str = "auto"
 
 
 def _one_step(model, context, loader, selected: str, model_backend: str):
@@ -74,6 +77,9 @@ def train_one_step(
     dataset_config: str | None = None,
     split: str = "train",
     model_backend: str = "tiny",
+    max_nodes: int = 1,
+    rendezvous_port: int = 29500,
+    distributed_backend: str = "auto",
 ):
     selected = device or ("cuda" if torch.cuda.is_available() else "cpu")
     model, context, loader = build_training(
@@ -82,6 +88,9 @@ def train_one_step(
         dataset_config=dataset_config,
         split=split,
         model_backend=model_backend,
+        max_nodes=max_nodes,
+        rendezvous_port=rendezvous_port,
+        distributed_backend=distributed_backend,
     )
     try:
         return _one_step(model, context, loader, selected, model_backend)
@@ -96,14 +105,22 @@ async def train_managed(config: ExampleTrainingConfig):
     node_id = os.environ["OOBLECK_NODE_ID"]
     worker_id = os.environ["OOBLECK_WORKER_ID"]
     selected = config.device or ("cuda" if torch.cuda.is_available() else "cpu")
+    worker = LocalWorkerClient(socket_path, node_id, worker_id)
+    await worker.connect()
+    snapshot = await worker.receive()
     model, context, loader = build_training(
         device=selected,
         dataset_name=config.dataset_name,
         dataset_config=config.dataset_config,
         split=config.split,
         model_backend=config.model_backend,
+        membership_snapshot=snapshot,
+        local_node_id=node_id,
+        local_tp_lane=int(os.environ["OOBLECK_LOCAL_RANK"]),
+        max_nodes=config.max_nodes,
+        rendezvous_port=config.rendezvous_port,
+        distributed_backend=config.distributed_backend,
     )
-    worker = LocalWorkerClient(socket_path, node_id, worker_id)
     active = asyncio.Event()
 
     async def prepare(snapshot) -> None:
@@ -112,9 +129,13 @@ async def train_managed(config: ExampleTrainingConfig):
     async def activated(generation: int) -> None:
         active.set()
 
-    await worker.connect()
     relay_task = asyncio.create_task(
-        worker.run_context(context, on_snapshot=prepare, on_active=activated)
+        worker.run_context(
+            context,
+            initial_snapshot=snapshot,
+            on_snapshot=prepare,
+            on_active=activated,
+        )
     )
     try:
         await asyncio.wait_for(active.wait(), timeout=30.0)
@@ -139,6 +160,9 @@ def main() -> None:
             dataset_config=config.dataset_config,
             split=config.split,
             model_backend=config.model_backend,
+            max_nodes=config.max_nodes,
+            rendezvous_port=config.rendezvous_port,
+            distributed_backend=config.distributed_backend,
         )
     print(
         f"committed_step={result.committed_step} generation={result.generation} "

--- a/examples/pretrain_llm_base.py
+++ b/examples/pretrain_llm_base.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
 import torch
 from torch.utils.data import DataLoader, Dataset
 
 from oobleck import OobleckConfig, OobleckParallelizationPlan
+from oobleck.types import stable_rank_map
+
+if TYPE_CHECKING:
+    from oobleck.elastic import MembershipSnapshot
 
 
 class FakeTextDataset(Dataset):
@@ -57,9 +63,18 @@ def build_dataset(
     return load_dataset(name, configuration, split=split)
 
 
-def _build_model(model_backend: str) -> tuple[torch.nn.Module, object, object | None, int]:
+def _build_model(
+    model_backend: str, tensor_parallel_size: int, world_size: int
+) -> tuple[torch.nn.Module, object, object | None, int]:
+    if tensor_parallel_size < 1 or world_size < tensor_parallel_size:
+        raise ValueError("tensor_parallel_size and world_size are inconsistent")
     if model_backend == "tiny":
-        return TinyLanguageModel(), ExampleParallelConfig(), None, 256
+        return (
+            TinyLanguageModel(),
+            ExampleParallelConfig(tensor_parallel_size=tensor_parallel_size),
+            None,
+            256,
+        )
     if model_backend != "cornstarch":
         raise ValueError("model_backend must be 'tiny' or 'cornstarch'")
     try:
@@ -83,8 +98,13 @@ def _build_model(model_backend: str) -> tuple[torch.nn.Module, object, object | 
     )
     model = from_hf_config(hf_config, model_kind="language")
     model.set_random_init()
-    cornstarch_plan = ParallelizationPlan(global_ranks=[0])
-    return model, ParallelConfig(tensor_parallel_size=1), cornstarch_plan, 64
+    cornstarch_plan = ParallelizationPlan(global_ranks=range(world_size))
+    return (
+        model,
+        ParallelConfig(tensor_parallel_size=tensor_parallel_size),
+        cornstarch_plan,
+        64,
+    )
 
 
 def build_training(
@@ -94,12 +114,54 @@ def build_training(
     split: str = "train",
     device: str = "cuda",
     model_backend: str = "tiny",
+    membership_snapshot: "MembershipSnapshot | None" = None,
+    local_node_id: str | None = None,
+    local_tp_lane: int = 0,
+    max_nodes: int = 1,
+    rendezvous_port: int = 29500,
+    distributed_backend: str = "auto",
 ):
-    model, parallel_config, cornstarch_plan, vocab_size = _build_model(model_backend)
+    nodes = (
+        tuple(sorted(node.agent_id for node in membership_snapshot.nodes))
+        if membership_snapshot is not None
+        else ()
+    )
+    tensor_parallel_size = (
+        len(membership_snapshot.nodes[0].gpu_ids) if membership_snapshot is not None else 1
+    )
+    if membership_snapshot is not None:
+        widths = {len(node.gpu_ids) for node in membership_snapshot.nodes}
+        if widths != {tensor_parallel_size}:
+            raise ValueError("every membership node must contribute the fixed TP width")
+        if local_node_id not in nodes:
+            raise ValueError("local_node_id must identify a node in the membership snapshot")
+        if not 0 <= local_tp_lane < tensor_parallel_size:
+            raise ValueError("local_tp_lane is outside the fixed TP width")
+        if len(nodes) > max_nodes:
+            raise ValueError("membership exceeds configured max_nodes")
+    rank_map = dict(stable_rank_map(nodes, tensor_parallel_size)) if nodes else {}
+    rank = rank_map[local_node_id][local_tp_lane] if local_node_id is not None else 0
+    world_size = max(1, len(nodes) * tensor_parallel_size)
+    model, parallel_config, cornstarch_plan, vocab_size = _build_model(
+        model_backend, tensor_parallel_size, world_size
+    )
     plan = OobleckParallelizationPlan(
-        OobleckConfig(global_batch_size=8, microbatch_size=2, max_nodes=1, seed=42),
+        OobleckConfig(
+            global_batch_size=8,
+            microbatch_size=2,
+            max_nodes=max_nodes,
+            seed=42,
+            rendezvous_port=rendezvous_port,
+            distributed_backend=distributed_backend,
+        ),
+        node_ids=nodes,
+        rank=rank,
         cornstarch_plan=cornstarch_plan,
     )
+    if membership_snapshot is not None:
+        plan.set_membership(nodes, membership_snapshot.generation)
+        coordinator = min(membership_snapshot.nodes, key=lambda node: node.agent_id)
+        plan.set_rendezvous_address(coordinator.addresses[0])
     plan.parallelize(model, parallel_config)
     context = plan.materialize(device, dtype=torch.float32)
     dataset = build_dataset(

--- a/oobleck/cli.py
+++ b/oobleck/cli.py
@@ -204,12 +204,22 @@ def _profile(config: ProfileCommandConfig) -> None:
     )
     if requested != actual:
         raise ValueError(f"profile compatibility mismatch: requested={requested}, actual={actual}")
+    device_memory_bytes = config.device_memory_bytes
+    if device_memory_bytes is None:
+        import torch
+
+        if not torch.cuda.is_available():
+            raise ValueError("device_memory_bytes is required when profiling without a CUDA device")
+        device_memory_bytes = torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).total_memory
     templates = create_pipeline_templates(
         config.model,
         profile.layers,
         config.resource_counts,
         config.tensor_parallel_size,
         fingerprint=fingerprint,
+        device_memory_bytes=device_memory_bytes,
     )
     save_templates(config.output, tuple(templates.values()), fingerprint)
 

--- a/oobleck/config.py
+++ b/oobleck/config.py
@@ -84,6 +84,7 @@ class ProfileCommandConfig:
     cornstarch_version: str | None = None
     warmup_steps: int = 2
     measurement_steps: int = 5
+    device_memory_bytes: int | None = None
 
     def __post_init__(self) -> None:
         if not self.model or self.tensor_parallel_size < 1 or self.microbatch_size < 1:
@@ -94,6 +95,8 @@ class ProfileCommandConfig:
             raise ValueError("provide either profile or measurement_factory, not both")
         if self.warmup_steps < 0 or self.measurement_steps < 1:
             raise ValueError("profiling step counts are invalid")
+        if self.device_memory_bytes is not None and self.device_memory_bytes < 1:
+            raise ValueError("device_memory_bytes must be positive when supplied")
 
 
 @dataclass(frozen=True, slots=True)

--- a/oobleck/distributed/__init__.py
+++ b/oobleck/distributed/__init__.py
@@ -1,3 +1,11 @@
-from oobleck.distributed.lifecycle import ProcessGroupLayoutError, destroy_process_group_universe
+from oobleck.distributed.lifecycle import (
+    ProcessGroupLayoutError,
+    destroy_process_group_universe,
+    initialize_process_group,
+)
 
-__all__ = ["ProcessGroupLayoutError", "destroy_process_group_universe"]
+__all__ = [
+    "ProcessGroupLayoutError",
+    "destroy_process_group_universe",
+    "initialize_process_group",
+]

--- a/oobleck/distributed/lifecycle.py
+++ b/oobleck/distributed/lifecycle.py
@@ -4,11 +4,48 @@ from __future__ import annotations
 
 import re
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
 from typing import Iterable
 
 
 class ProcessGroupLayoutError(RuntimeError):
     pass
+
+
+def initialize_process_group(
+    *,
+    backend: str,
+    master_address: str,
+    master_port: int,
+    rank: int,
+    world_size: int,
+    timeout_s: float,
+) -> None:
+    """Create one validated replacement WORLD from deterministic rendezvous data."""
+
+    import torch.distributed as dist
+
+    if dist.is_initialized():
+        raise RuntimeError("WORLD must be fully retired before replacement")
+    if not backend or not master_address:
+        raise ValueError("backend and rendezvous address are required")
+    if not 1 <= master_port <= 65535:
+        raise ValueError("rendezvous port must be between 1 and 65535")
+    if world_size < 1 or not 0 <= rank < world_size:
+        raise ValueError("rank/world_size are invalid")
+    if timeout_s <= 0:
+        raise ValueError("rendezvous timeout must be positive")
+    host = f"[{master_address}]" if ":" in master_address else master_address
+    dist.init_process_group(
+        backend=backend,
+        init_method=f"tcp://{host}:{master_port}",
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=timeout_s),
+    )
+    if dist.get_rank() != rank or dist.get_world_size() != world_size:
+        destroy_process_group_universe()
+        raise RuntimeError("initialized WORLD does not match the generation rank map")
 
 
 _REQUIRED = (

--- a/oobleck/elastic/local_ipc.py
+++ b/oobleck/elastic/local_ipc.py
@@ -245,6 +245,7 @@ class LocalWorkerClient:
         self,
         context: Any,
         *,
+        initial_snapshot: MembershipSnapshot | None = None,
         on_snapshot: Callable[[MembershipSnapshot], Awaitable[None]] | None = None,
         on_active: Callable[[int], Awaitable[None]] | None = None,
     ) -> None:
@@ -253,7 +254,9 @@ class LocalWorkerClient:
         enable_barrier = getattr(context, "enable_control_plane_barrier", None)
         if callable(enable_barrier):
             enable_barrier()
-        pending: MembershipSnapshot | None = None
+        if initial_snapshot is not None and initial_snapshot.generation != self.generation:
+            raise ValueError("initial snapshot must be the latest received membership")
+        pending: MembershipSnapshot | None = initial_snapshot
         while True:
             snapshot = pending or await self.receive()
             pending = None

--- a/oobleck/elastic/workers.py
+++ b/oobleck/elastic/workers.py
@@ -46,6 +46,7 @@ class LocalWorkerSupervisor:
                     "LOCAL_RANK": "0",
                     "OOBLECK_GPU_ID": gpu_id,
                     "OOBLECK_LOCAL_RANK": str(local_rank),
+                    "OOBLECK_TP_SIZE": str(len(self.gpu_ids)),
                     "OOBLECK_LOCAL_WORKER_SOCKET": str(self.socket_path),
                     "OOBLECK_NODE_ID": self.node_id,
                     "OOBLECK_WORKER_ID": f"{self.node_id}:gpu-{gpu_id}",

--- a/oobleck/planning/generator.py
+++ b/oobleck/planning/generator.py
@@ -38,6 +38,19 @@ def _partition(layers: Sequence[LayerExecutionResult], stages: int) -> tuple[tup
     )
 
 
+def _max_microbatches(
+    activation_memory: int, persistent_memory: int, device_memory_bytes: int | None
+) -> int | None:
+    if device_memory_bytes is None:
+        return None
+    available = device_memory_bytes - persistent_memory
+    if available < 0 or (activation_memory > 0 and available < activation_memory):
+        raise ValueError("pipeline template cannot fit one microbatch in device memory")
+    if activation_memory == 0:
+        return None
+    return available // activation_memory
+
+
 def create_pipeline_templates(
     model_name: str,
     profile_data: Sequence[LayerExecutionResult],
@@ -45,11 +58,14 @@ def create_pipeline_templates(
     tensor_parallel_size: int = 1,
     *,
     fingerprint: CompatibilityFingerprint | None = None,
+    device_memory_bytes: int | None = None,
 ) -> dict[int, PipelineTemplate]:
     if not model_name or not profile_data or not num_nodes:
         raise ValueError("model_name, profile_data, and num_nodes must be non-empty")
     if tensor_parallel_size < 1:
         raise ValueError("tensor_parallel_size must be positive")
+    if device_memory_bytes is not None and device_memory_bytes < 1:
+        raise ValueError("device_memory_bytes must be positive when supplied")
     if tuple(layer.layer_index for layer in profile_data) != tuple(range(len(profile_data))):
         raise ValueError("profile_data must have contiguous global layer indices")
     try:
@@ -73,7 +89,11 @@ def create_pipeline_templates(
                 float(value["communication_time"]),
                 int(value["activation_memory"]),
                 int(value["persistent_memory"]),
-                value["max_microbatches"],
+                _max_microbatches(
+                    int(value["activation_memory"]),
+                    int(value["persistent_memory"]),
+                    device_memory_bytes,
+                ),
                 fingerprint,
                 int(value["schema_version"]),
             )
@@ -109,6 +129,9 @@ def create_pipeline_templates(
             backward,
             activation_memory=activation_memory,
             persistent_memory=persistent_memory,
+            max_microbatches=_max_microbatches(
+                activation_memory, persistent_memory, device_memory_bytes
+            ),
             fingerprint=fingerprint,
         )
     return results

--- a/oobleck/recovery_base.py
+++ b/oobleck/recovery_base.py
@@ -61,6 +61,17 @@ class RecoveryReport:
     def maximum_destination_bytes(self) -> int:
         return max((value for _, value in self.destination_bytes), default=0)
 
+    @property
+    def source_scheduling_error_bytes(self) -> int:
+        planned = dict(self.source_bytes)
+        actual = dict(self.actual_source_bytes)
+        ranks = set(planned) | set(actual)
+        return max((abs(actual.get(rank, 0) - planned.get(rank, 0)) for rank in ranks), default=0)
+
+    @property
+    def straggler_round_seconds(self) -> float:
+        return max((duration for _, _, duration in self.round_durations), default=0.0)
+
 
 def version_manifest(manifest: StateManifest, committed_step: int) -> StateManifest:
     return StateManifest(

--- a/oobleck/runtime.py
+++ b/oobleck/runtime.py
@@ -33,6 +33,12 @@ class GenerationTransitionMetrics:
     recovery_seconds: float
     total_seconds: float
     superseded: bool = False
+    detection_seconds: float = 0.0
+    configuration_planning_seconds: float = 0.0
+    state_planning_seconds: float = 0.0
+    state_transfer_seconds: float = 0.0
+    straggler_round_seconds: float = 0.0
+    source_scheduling_error_bytes: int = 0
 
 
 def _init_with_recovery(self: OobleckParallelContext, *args: Any, **kwargs: Any) -> None:
@@ -45,6 +51,7 @@ def _init_with_recovery(self: OobleckParallelContext, *args: Any, **kwargs: Any)
     self._control_plane_managed = False
     self._control_active_generation = self.generation
     self.recovery_history: list[GenerationTransitionMetrics] = []
+    self._generation_control_metrics: dict[int, tuple[float, float]] = {}
     self._heterogeneous_gradient_sync = (
         None
         if self._needs_survivor_recovery
@@ -112,6 +119,9 @@ def _activate_latest_generation(self: OobleckParallelContext) -> None:
     while self._pending_plan is not None:
         target = self._pending_plan
         self._pending_plan = None
+        detection_seconds, configuration_planning_seconds = self._generation_control_metrics.pop(
+            target.generation, (0.0, 0.0)
+        )
         attempt_started = time.perf_counter()
         teardown_started = attempt_started
         _retire_world(self)
@@ -147,6 +157,8 @@ def _activate_latest_generation(self: OobleckParallelContext) -> None:
                     0.0,
                     time.perf_counter() - attempt_started,
                     True,
+                    detection_seconds=detection_seconds,
+                    configuration_planning_seconds=configuration_planning_seconds,
                 )
             )
             continue
@@ -183,6 +195,14 @@ def _activate_latest_generation(self: OobleckParallelContext) -> None:
                     recovery_seconds,
                     time.perf_counter() - attempt_started,
                     True,
+                    detection_seconds=detection_seconds,
+                    configuration_planning_seconds=configuration_planning_seconds,
+                    state_planning_seconds=self.last_recovery_report.planning_seconds,
+                    state_transfer_seconds=self.last_recovery_report.transfer_seconds,
+                    straggler_round_seconds=self.last_recovery_report.straggler_round_seconds,
+                    source_scheduling_error_bytes=(
+                        self.last_recovery_report.source_scheduling_error_bytes
+                    ),
                 )
             )
             continue
@@ -196,6 +216,14 @@ def _activate_latest_generation(self: OobleckParallelContext) -> None:
                 activation_seconds,
                 recovery_seconds,
                 time.perf_counter() - transition_started,
+                detection_seconds=detection_seconds,
+                configuration_planning_seconds=configuration_planning_seconds,
+                state_planning_seconds=self.last_recovery_report.planning_seconds,
+                state_transfer_seconds=self.last_recovery_report.transfer_seconds,
+                straggler_round_seconds=self.last_recovery_report.straggler_round_seconds,
+                source_scheduling_error_bytes=(
+                    self.last_recovery_report.source_scheduling_error_bytes
+                ),
             )
         )
         break
@@ -218,10 +246,24 @@ def _apply_membership(self: OobleckParallelContext, snapshot: MembershipSnapshot
         raise ValueError(
             f"membership nodes {invalid} do not match fixed TP width {tensor_parallel_size}"
         )
+    coordinator = min(snapshot.nodes, key=lambda node: node.agent_id)
+    self.owner_plan.set_rendezvous_address(coordinator.addresses[0])
+    planning_started = time.perf_counter()
     self.owner_plan.set_membership(
         tuple(node.agent_id for node in snapshot.nodes), snapshot.generation
     )
-    return self.announce_generation(self.owner_plan.build_execution_plan())
+    execution_plan = self.owner_plan.build_execution_plan()
+    planning_seconds = time.perf_counter() - planning_started
+    detection_seconds = (
+        self.config.lease_timeout_s
+        if any(reason.startswith("lease-expired:") for reason in snapshot.reasons)
+        else 0.0
+    )
+    self._generation_control_metrics[snapshot.generation] = (
+        detection_seconds,
+        planning_seconds,
+    )
+    return self.announce_generation(execution_plan)
 
 
 def _enable_control_plane_barrier(self: OobleckParallelContext) -> None:
@@ -273,6 +315,8 @@ def _close_with_topology(self: OobleckParallelContext) -> None:
         self._heterogeneous_gradient_sync.close()
         self._heterogeneous_gradient_sync = None
     _base_close(self)
+    if _world_initialized():
+        destroy_process_group_universe()
 
 
 OobleckParallelContext.__init__ = _init_with_recovery

--- a/oobleck/runtime_base.py
+++ b/oobleck/runtime_base.py
@@ -17,7 +17,7 @@ from oobleck.data import (
     logical_seed,
     prepare_dataloader,
 )
-from oobleck.distributed import destroy_process_group_universe
+from oobleck.distributed import destroy_process_group_universe, initialize_process_group
 from oobleck.planning import (
     PipelineTemplate,
     RecoveryUnavailable,
@@ -71,6 +71,7 @@ class OobleckParallelizationPlan:
         self._local_node_id: str | None = None
         self._tp_lane: int | None = None
         self._target_rank = rank
+        self._rendezvous_address: str | None = None
 
     def parallelize(self, model: torch.nn.Module, parallel_config: object) -> None:
         if self.model is not None:
@@ -121,6 +122,34 @@ class OobleckParallelizationPlan:
             self._generation = generation
         elif changed:
             self._generation += 1
+
+    def set_rendezvous_address(self, address: str) -> None:
+        if not address:
+            raise ValueError("rendezvous address must not be empty")
+        self._rendezvous_address = address
+        if self.world_initializer is None:
+            self.world_initializer = self.initialize_world
+
+    def initialize_world(self, execution_plan: OobleckExecutionPlan) -> None:
+        """Initialize WORLD for a managed generation using its concrete rank map."""
+
+        if self._rendezvous_address is None:
+            raise RuntimeError("managed WORLD initialization requires a rendezvous address")
+        world_size = sum(len(ranks) for _, ranks in execution_plan.rank_map)
+        backend = self.config.distributed_backend
+        if backend == "auto":
+            backend = "nccl" if torch.cuda.is_available() else "gloo"
+        rendezvous_port = self.config.rendezvous_port + execution_plan.generation
+        if rendezvous_port > 65535:
+            raise ValueError("rendezvous_port plus membership generation exceeds 65535")
+        initialize_process_group(
+            backend=backend,
+            master_address=self._rendezvous_address,
+            master_port=rendezvous_port,
+            rank=self.rank_for_plan(execution_plan),
+            world_size=world_size,
+            timeout_s=self.config.rendezvous_timeout_s,
+        )
 
     def _default_template(self) -> PipelineTemplate:
         assert self.model is not None and self.parallel_config is not None

--- a/oobleck/types.py
+++ b/oobleck/types.py
@@ -326,6 +326,9 @@ class OobleckConfig:
     seed: int = 0
     heartbeat_interval_s: float = 1.0
     lease_timeout_s: float = 5.0
+    rendezvous_port: int = 29500
+    rendezvous_timeout_s: float = 60.0
+    distributed_backend: str = "auto"
     max_control_frame_bytes: int = 1 << 20
     state_transfer_chunk_bytes: int = 64 << 20
     state_transfer_round_bytes: int = 256 << 20
@@ -344,6 +347,12 @@ class OobleckConfig:
             raise ValueError("heartbeat_interval_s must be positive")
         if self.lease_timeout_s <= self.heartbeat_interval_s:
             raise ValueError("lease_timeout_s must exceed heartbeat_interval_s")
+        if not 1 <= self.rendezvous_port <= 65535:
+            raise ValueError("rendezvous_port must be between 1 and 65535")
+        if self.rendezvous_timeout_s <= 0:
+            raise ValueError("rendezvous_timeout_s must be positive")
+        if self.distributed_backend not in {"auto", "gloo", "nccl"}:
+            raise ValueError("distributed_backend must be auto, gloo, or nccl")
         if self.max_control_frame_bytes < 256:
             raise ValueError("max_control_frame_bytes must be >= 256")
         if self.state_transfer_chunk_bytes < 1:

--- a/tests/refactor/test_data_runtime.py
+++ b/tests/refactor/test_data_runtime.py
@@ -226,9 +226,18 @@ def test_complete_membership_snapshot_announces_deterministic_execution_plan():
     assert ctx._pending_plan.previous_generation == 0
     assert ctx._pending_plan.plan_checksum
     assert not ctx.apply_membership(replacement)
+    assert ctx._generation_control_metrics[1][0] == 0.0
+
+    lease_expired = MembershipSnapshot(
+        2,
+        (NodeIdentity("local-node", "lease", ("127.0.0.1",), ("0",)),),
+        ("lease-expired:local-node",),
+    )
+    assert ctx.apply_membership(lease_expired)
+    assert ctx._generation_control_metrics[2][0] == ctx.config.lease_timeout_s
 
     invalid = MembershipSnapshot(
-        2,
+        3,
         (NodeIdentity("local-node", "bad", ("127.0.0.1",), ("0", "1")),),
         ("replacement:local-node",),
     )

--- a/tests/refactor/test_managed_distributed.py
+++ b/tests/refactor/test_managed_distributed.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import multiprocessing as mp
+import socket
+from typing import Any
+
+import pytest
+import torch
+
+
+def _free_tcp_port() -> int:
+    for base in range(30000, 60000):
+        listeners = [socket.socket(socket.AF_INET, socket.SOCK_STREAM) for _ in range(2)]
+        try:
+            listeners[0].bind(("127.0.0.1", base + 4))
+            listeners[1].bind(("127.0.0.1", base + 5))
+            return base
+        except OSError:
+            continue
+        finally:
+            for listener in listeners:
+                listener.close()
+    raise RuntimeError("could not reserve consecutive generation rendezvous ports")
+
+
+def _managed_gloo_worker(rank: int, port: int, results: Any) -> None:
+    import torch.distributed as dist
+
+    from examples.pretrain_llm_base import build_training
+    from oobleck.elastic import MembershipSnapshot, NodeIdentity
+
+    torch.manual_seed(17)
+    snapshot = MembershipSnapshot(
+        4,
+        (
+            NodeIdentity("node-a", "a1", ("127.0.0.1",), ("0",)),
+            NodeIdentity("node-b", "b1", ("127.0.0.1",), ("0",)),
+        ),
+        ("initial-cohort",),
+    )
+    node_id = ("node-a", "node-b")[rank]
+    model, context, loader = build_training(
+        device="cpu",
+        membership_snapshot=snapshot,
+        local_node_id=node_id,
+        local_tp_lane=0,
+        max_nodes=2,
+        rendezvous_port=port,
+        distributed_backend="gloo",
+    )
+    try:
+        assert dist.get_rank() == rank
+        assert dist.get_world_size() == 2
+        assert context.generation == 4
+        assert context.owner_plan.rank_for_plan(context.execution_plan) == rank
+
+        batch = next(iter(loader))
+        step = context.step(
+            batch,
+            lambda microbatch: model(microbatch["input_ids"]),
+            criterion=lambda logits, microbatch: torch.nn.functional.cross_entropy(
+                logits.flatten(0, 1), microbatch["labels"].flatten()
+            ),
+        )
+        checksum = sum(parameter.detach().double().sum() for parameter in model.parameters())
+        gathered = [torch.zeros_like(checksum) for _ in range(2)]
+        dist.all_gather(gathered, checksum)
+        torch.testing.assert_close(gathered[0], gathered[1])
+        assert step.committed_step == 1
+
+        replacement = MembershipSnapshot(
+            5,
+            (
+                NodeIdentity("node-a", "a2", ("127.0.0.1",), ("0",)),
+                NodeIdentity("node-b", "b2", ("127.0.0.1",), ("0",)),
+            ),
+            ("replacement-cohort",),
+        )
+        context.enable_control_plane_barrier()
+        assert context.apply_membership(replacement)
+        context.prepare_generation()
+        context.mark_generation_active(5)
+        transition = context.recovery_history[-1]
+        assert transition.generation == 5
+        assert transition.detection_seconds == 0.0
+        assert transition.configuration_planning_seconds >= 0.0
+        assert transition.state_planning_seconds >= 0.0
+        assert transition.state_transfer_seconds >= 0.0
+        assert transition.straggler_round_seconds >= 0.0
+        assert transition.source_scheduling_error_bytes == 0
+        assert dist.get_rank() == rank
+        assert dist.get_world_size() == 2
+
+        next_batch = next(iter(loader))
+        recovered_step = context.step(
+            next_batch,
+            lambda microbatch: model(microbatch["input_ids"]),
+            criterion=lambda logits, microbatch: torch.nn.functional.cross_entropy(
+                logits.flatten(0, 1), microbatch["labels"].flatten()
+            ),
+        )
+        results.put((rank, recovered_step.committed_step, recovered_step.generation))
+    finally:
+        context.close()
+        assert not dist.is_initialized()
+
+
+@pytest.mark.skipif(not torch.distributed.is_gloo_available(), reason="Gloo is unavailable")
+def test_membership_bootstraps_two_process_world_and_synchronized_step():
+    port = _free_tcp_port()
+    context = mp.get_context("spawn")
+    results = context.Queue()
+    processes = [
+        context.Process(target=_managed_gloo_worker, args=(rank, port, results))
+        for rank in range(2)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=60)
+    for process in processes:
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+            pytest.fail("managed Gloo worker timed out")
+        assert process.exitcode == 0
+    observed = sorted(results.get(timeout=5) for _ in processes)
+    assert observed == [(0, 2, 5), (1, 2, 5)]

--- a/tests/refactor/test_planning.py
+++ b/tests/refactor/test_planning.py
@@ -8,6 +8,7 @@ import torch
 from oobleck import OobleckConfig, OobleckParallelizationPlan, RuntimeCompatibility
 from oobleck.planning import (
     CompatibilityFingerprint,
+    LayerExecutionResult,
     ModelProfile,
     ModelProfiler,
     PipelineInstance,
@@ -68,6 +69,18 @@ def test_profiler_measures_and_records_materialized_layers(tmp_path):
     )
     assert all(item.persistent_memory > 0 for item in templates.values())
     assert all(item.activation_memory >= 0 for item in templates.values())
+
+
+def test_template_capacity_uses_device_memory_budget():
+    layers = (
+        LayerExecutionResult(0, "l0", 1.0, 1.0, 300, 100, 200),
+        LayerExecutionResult(1, "l1", 1.0, 1.0, 300, 100, 200),
+    )
+    templates = create_pipeline_templates("tiny", layers, (1, 2), device_memory_bytes=1000)
+    assert templates[1].max_microbatches == 3
+    assert templates[2].max_microbatches == 8
+    with pytest.raises(ValueError, match="cannot fit one microbatch"):
+        create_pipeline_templates("tiny", layers, (1,), device_memory_bytes=500)
 
 
 def test_composition_assigns_every_node_and_batch_once():


### PR DESCRIPTION
## What changed

- derive managed worker rank, TP lane, world size, and Cornstarch global ranks from complete membership snapshots
- initialize a generation-scoped Gloo/NCCL WORLD and fully retire it on replacement or context shutdown
- make rendezvous ports generation-specific to prevent stale TCPStore cross-wiring during rapid recovery
- add device-memory-based template microbatch capacity and unified recovery metrics
- add a two-process Gloo test that trains in generation 4, replaces WORLD, restores state, and continues in generation 5

## Why

The documented agent-managed example still hard-coded a one-node, TP=1 topology and never initialized a real distributed WORLD. Reusing one TCPStore endpoint across replacement generations also allowed fast and slow workers to mix collective sequences.

## Validation

- `python -m pytest -q tests/refactor` — 60 passed
- `cargo test --quiet` — 6 passed
- `ruff check oobleck examples tests/refactor`
- `ruff format --check oobleck examples tests/refactor`

CI remains intentionally removed and disabled per project direction.
