### PR TITLE
Enforce generation compatibility consensus

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -82,13 +82,13 @@ python examples/run_master.py --host 0.0.0.0 --port 29600
 
 python examples/run_agent.py \
   --node-id node-a --master-host MASTER --master-port 29600 \
-  --gpu-ids 0 1 2 3 \
+  --gpu-ids 0 1 2 3 --addresses 10.0.0.11 \
   --local-worker-socket /tmp/oobleck-node-a.sock \
   --worker-script examples/pretrain_llm.py
 
 python examples/run_agent.py \
   --node-id node-b --master-host MASTER --master-port 29600 \
-  --gpu-ids 0 1 2 3 \
+  --gpu-ids 0 1 2 3 --addresses 10.0.0.12 \
   --local-worker-socket /tmp/oobleck-node-b.sock \
   --worker-script examples/pretrain_llm.py
 ```

--- a/examples/pretrain_llm_base.py
+++ b/examples/pretrain_llm_base.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING
 import torch
 from torch.utils.data import DataLoader, Dataset
 
-from oobleck import OobleckConfig, OobleckParallelizationPlan
+from oobleck import (
+    OobleckConfig,
+    OobleckParallelizationPlan,
+    build_runtime_compatibility,
+)
 from oobleck.types import stable_rank_map
 
 if TYPE_CHECKING:
@@ -21,6 +25,9 @@ class FakeTextDataset(Dataset):
     ) -> None:
         generator = torch.Generator().manual_seed(7)
         self.tokens = torch.randint(vocab_size, (samples, sequence_length), generator=generator)
+        self.oobleck_fingerprint = (
+            f"fake-text:v1:samples={samples}:sequence={sequence_length}:vocab={vocab_size}:seed=7"
+        )
 
     def __len__(self) -> int:
         return len(self.tokens)
@@ -139,24 +146,41 @@ def build_training(
             raise ValueError("local_tp_lane is outside the fixed TP width")
         if len(nodes) > max_nodes:
             raise ValueError("membership exceeds configured max_nodes")
+    seed = 42
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
     rank_map = dict(stable_rank_map(nodes, tensor_parallel_size)) if nodes else {}
     rank = rank_map[local_node_id][local_tp_lane] if local_node_id is not None else 0
     world_size = max(1, len(nodes) * tensor_parallel_size)
     model, parallel_config, cornstarch_plan, vocab_size = _build_model(
         model_backend, tensor_parallel_size, world_size
     )
+    dataset = build_dataset(
+        dataset_name,
+        dataset_config,
+        split,
+        vocab_size=vocab_size,
+    )
+    compatibility = build_runtime_compatibility(
+        model,
+        dataset,
+        model_identity=f"{model_backend}:synthetic-v1:seed={seed}",
+        preprocessing_fingerprint="token-shift-v1",
+    )
     plan = OobleckParallelizationPlan(
         OobleckConfig(
             global_batch_size=8,
             microbatch_size=2,
             max_nodes=max_nodes,
-            seed=42,
+            seed=seed,
             rendezvous_port=rendezvous_port,
             distributed_backend=distributed_backend,
         ),
         node_ids=nodes,
         rank=rank,
         cornstarch_plan=cornstarch_plan,
+        compatibility=compatibility,
     )
     if membership_snapshot is not None:
         plan.set_membership(nodes, membership_snapshot.generation)
@@ -164,12 +188,6 @@ def build_training(
         plan.set_rendezvous_address(coordinator.addresses[0])
     plan.parallelize(model, parallel_config)
     context = plan.materialize(device, dtype=torch.float32)
-    dataset = build_dataset(
-        dataset_name,
-        dataset_config,
-        split,
-        vocab_size=vocab_size,
-    )
     sampler = context.create_batch_sampler(dataset, shuffle=True)
     dataloader = DataLoader(
         dataset,

--- a/oobleck/__init__.py
+++ b/oobleck/__init__.py
@@ -1,5 +1,10 @@
 """Oobleck heterogeneous elastic training API."""
 
+from oobleck.compatibility import (
+    build_runtime_compatibility,
+    dataset_fingerprint,
+    model_fingerprint,
+)
 from oobleck.data import OobleckBatch, OobleckBatchSampler
 from oobleck.runtime import (
     GenerationTransitionMetrics,
@@ -28,6 +33,9 @@ from oobleck.types import (
 
 __all__ = [
     "CompatibilityFingerprint",
+    "build_runtime_compatibility",
+    "dataset_fingerprint",
+    "model_fingerprint",
     "GenerationTransitionMetrics",
     "LogicalStateEntry",
     "OobleckBatch",

--- a/oobleck/compatibility.py
+++ b/oobleck/compatibility.py
@@ -1,0 +1,162 @@
+"""Runtime and dataset compatibility fingerprints for elastic generation consensus."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import json
+import platform
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch.utils.data import IterableDataset
+
+from oobleck.types import RuntimeCompatibility, checksum
+
+
+def _package_revision(distribution: str, module_name: str) -> str:
+    try:
+        direct_url = importlib.metadata.distribution(distribution).read_text("direct_url.json")
+        if direct_url:
+            value = json.loads(direct_url)
+            commit = value.get("vcs_info", {}).get("commit_id")
+            if isinstance(commit, str) and commit:
+                return commit
+    except (importlib.metadata.PackageNotFoundError, json.JSONDecodeError):
+        pass
+    try:
+        module = importlib.import_module(module_name)
+        location = Path(module.__file__).resolve()
+        for parent in location.parents:
+            if (parent / ".git").exists():
+                return subprocess.check_output(
+                    ["git", "-C", str(parent), "rev-parse", "HEAD"],
+                    text=True,
+                    timeout=2,
+                ).strip()
+    except (ImportError, OSError, subprocess.SubprocessError):
+        pass
+    try:
+        return importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return "not-installed"
+
+
+def model_fingerprint(model: torch.nn.Module, *, model_identity: str = "structure-only") -> str:
+    if not model_identity:
+        raise ValueError("model_identity must not be empty")
+    state = [
+        (kind, name, tuple(value.shape), str(value.dtype))
+        for kind, values in (
+            ("parameter", model.named_parameters(recurse=True, remove_duplicate=False)),
+            ("buffer", model.named_buffers(recurse=True, remove_duplicate=False)),
+        )
+        for name, value in values
+    ]
+    return checksum(
+        {
+            "type": f"{type(model).__module__}.{type(model).__qualname__}",
+            "identity": model_identity,
+            "state": state,
+        }
+    )
+
+
+def dataset_fingerprint(
+    dataset: object,
+    *,
+    explicit: str | None = None,
+    preprocessing: str = "identity",
+) -> str:
+    if isinstance(dataset, IterableDataset) or not (
+        hasattr(dataset, "__len__") and hasattr(dataset, "__getitem__")
+    ):
+        raise TypeError("runtime compatibility requires a stable map-style dataset")
+    length = len(dataset)  # type: ignore[arg-type]
+    if length < 1:
+        raise ValueError("runtime compatibility requires a non-empty dataset")
+    intrinsic = explicit
+    if intrinsic is None:
+        intrinsic = getattr(dataset, "_fingerprint", None)
+    if intrinsic is None:
+        intrinsic = getattr(dataset, "oobleck_fingerprint", None)
+    if not isinstance(intrinsic, str) or not intrinsic:
+        raise ValueError("dataset has no stable fingerprint; pass dataset_fingerprint explicitly")
+    if not preprocessing:
+        raise ValueError("preprocessing fingerprint must not be empty")
+    return checksum(
+        {
+            "type": f"{type(dataset).__module__}.{type(dataset).__qualname__}",
+            "length": length,
+            "intrinsic": intrinsic,
+            "preprocessing": preprocessing,
+        }
+    )
+
+
+def _hardware_fingerprint() -> str:
+    if torch.cuda.is_available():
+        device = torch.cuda.current_device()
+        properties = torch.cuda.get_device_properties(device)
+        value: dict[str, Any] = {
+            "kind": "cuda",
+            "name": properties.name,
+            "capability": torch.cuda.get_device_capability(device),
+            "total_memory": properties.total_memory,
+        }
+    else:
+        value = {
+            "kind": "cpu",
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+        }
+    return checksum(value)
+
+
+def build_runtime_compatibility(
+    model: torch.nn.Module,
+    dataset: object,
+    *,
+    model_identity: str,
+    dataset_identity: str | None = None,
+    preprocessing_fingerprint: str = "identity",
+    oobleck_revision: str | None = None,
+    cornstarch_revision: str | None = None,
+) -> RuntimeCompatibility:
+    cuda_version = torch.version.cuda
+    nccl_version = None
+    if torch.cuda.is_available() and torch.distributed.is_nccl_available():
+        try:
+            nccl_version = ".".join(str(item) for item in torch.cuda.nccl.version())
+        except (AttributeError, RuntimeError, TypeError):
+            nccl_version = "available"
+    try:
+        datasets_version = importlib.metadata.version("datasets")
+    except importlib.metadata.PackageNotFoundError:
+        datasets_version = "not-installed"
+    return RuntimeCompatibility(
+        oobleck_revision or _package_revision("oobleck", "oobleck"),
+        cornstarch_revision or _package_revision("cornstarch", "cornstarch"),
+        torch.__version__,
+        cuda_version,
+        nccl_version,
+        model_fingerprint(model, model_identity=model_identity),
+        1,
+        1,
+        datasets_version,
+        dataset_fingerprint(
+            dataset,
+            explicit=dataset_identity,
+            preprocessing=preprocessing_fingerprint,
+        ),
+        _hardware_fingerprint(),
+    )
+
+
+__all__ = [
+    "build_runtime_compatibility",
+    "dataset_fingerprint",
+    "model_fingerprint",
+]

--- a/oobleck/config.py
+++ b/oobleck/config.py
@@ -30,6 +30,7 @@ class AgentConfig:
     master_host: str = "127.0.0.1"
     master_port: int = 0
     gpu_ids: tuple[str, ...] = ("0",)
+    addresses: tuple[str, ...] = ()
     local_worker_socket: Path | None = None
     worker_script: Path | None = None
     worker_args: tuple[str, ...] = ()
@@ -40,6 +41,10 @@ class AgentConfig:
             raise ValueError("agent identity and master address are required")
         if not self.gpu_ids or len(set(self.gpu_ids)) != len(self.gpu_ids):
             raise ValueError("gpu_ids must be non-empty and unique")
+        if len(set(self.addresses)) != len(self.addresses) or any(
+            not address for address in self.addresses
+        ):
+            raise ValueError("addresses must be unique non-empty strings")
         if self.heartbeat_interval_s <= 0:
             raise ValueError("heartbeat_interval_s must be positive")
         if self.worker_script is not None and self.local_worker_socket is None:

--- a/oobleck/elastic/local_ipc.py
+++ b/oobleck/elastic/local_ipc.py
@@ -20,7 +20,7 @@ from oobleck.elastic.transport import (
     ProtocolError,
 )
 
-WorkerReadyCallback = Callable[[int, str], Awaitable[None]]
+WorkerReadyCallback = Callable[[int, str, str, str], Awaitable[None]]
 
 
 class LocalWorkerRelay:
@@ -46,7 +46,7 @@ class LocalWorkerRelay:
         self._workers: dict[str, ControlConnection] = {}
         self._latest_membership: MessageEnvelope | None = None
         self._latest_active: MessageEnvelope | None = None
-        self._acknowledged: set[str] = set()
+        self._acknowledged: dict[str, tuple[str, str, str]] = {}
         self._ready_notified_generation = -1
         self._lock = asyncio.Lock()
 
@@ -62,6 +62,14 @@ class LocalWorkerRelay:
             and len(self._workers) == self.expected_workers
             and len(self._acknowledged) == self.expected_workers
         )
+
+    def readiness_metadata(self, generation: int) -> tuple[str, str, str]:
+        if not self.generation_ready(generation):
+            raise RuntimeError("local generation is not ready")
+        values = set(self._acknowledged.values())
+        if len(values) != 1:
+            raise ProtocolError("local workers disagree on generation plan compatibility")
+        return next(iter(values))
 
     async def start(self) -> None:
         if self._server is not None:
@@ -112,33 +120,43 @@ class LocalWorkerRelay:
                 if (
                     message.agent_id != worker_id
                     or message.incarnation_id != registration.incarnation_id
-                    or message.payload != {"phase": "ready"}
                 ):
                     raise ProtocolError("invalid local worker readiness acknowledgement")
+                metadata = (
+                    str(message.payload["snapshot_hash"]),
+                    str(message.payload["plan_checksum"]),
+                    str(message.payload["compatibility_digest"]),
+                )
                 callback: WorkerReadyCallback | None = None
-                snapshot_hash = ""
                 async with self._lock:
                     latest = self._latest_membership
                     if latest is None or message.generation != latest.generation:
                         continue
-                    self._acknowledged.add(worker_id)
+                    if metadata[0] != latest.payload["snapshot_hash"]:
+                        raise ProtocolError("worker acknowledged a different membership snapshot")
+                    self._acknowledged[worker_id] = metadata
                     if (
                         self.generation_ready(message.generation)
                         and self._ready_notified_generation != message.generation
                     ):
+                        agreed = self.readiness_metadata(message.generation)
                         self._ready_notified_generation = message.generation
                         callback = self.on_generation_ready
-                        snapshot_hash = str(latest.payload["snapshot_hash"])
                 if callback is not None:
-                    await callback(message.generation, snapshot_hash)
-        except (asyncio.IncompleteReadError, ConnectionError, BrokenPipeError):
+                    await callback(message.generation, *agreed)
+        except (
+            asyncio.IncompleteReadError,
+            ConnectionError,
+            BrokenPipeError,
+            ProtocolError,
+        ):
             pass
         finally:
             if worker_id is not None:
                 async with self._lock:
                     if self._workers.get(worker_id) is connection:
                         self._workers.pop(worker_id, None)
-                        self._acknowledged.discard(worker_id)
+                        self._acknowledged.pop(worker_id, None)
             with contextlib.suppress(Exception):
                 await connection.close()
 
@@ -153,12 +171,17 @@ class LocalWorkerRelay:
                 self._ready_notified_generation = -1
             else:
                 latest = self._latest_membership
-                if (
-                    latest is None
-                    or message.generation != latest.generation
-                    or message.payload != {"snapshot_hash": latest.payload["snapshot_hash"]}
-                ):
+                if latest is None or message.generation != latest.generation:
                     raise ProtocolError("active generation does not match local membership")
+                snapshot_hash, plan_checksum, compatibility_digest = self.readiness_metadata(
+                    message.generation
+                )
+                if message.payload != {
+                    "snapshot_hash": snapshot_hash,
+                    "plan_checksum": plan_checksum,
+                    "compatibility_digest": compatibility_digest,
+                }:
+                    raise ProtocolError("active generation does not match local readiness")
                 self._latest_active = message
             workers = tuple(self._workers.items())
         results = await asyncio.gather(
@@ -174,7 +197,7 @@ class LocalWorkerRelay:
             async with self._lock:
                 for worker_id in failed:
                     self._workers.pop(worker_id, None)
-                    self._acknowledged.discard(worker_id)
+                    self._acknowledged.pop(worker_id, None)
 
     async def close(self) -> None:
         if self._server is not None:
@@ -263,6 +286,9 @@ class LocalWorkerClient:
             context.apply_membership(snapshot)
             if on_snapshot is not None:
                 await on_snapshot(snapshot)
+            execution_plan = getattr(context, "execution_plan", None)
+            plan_checksum = getattr(execution_plan, "plan_checksum", snapshot.snapshot_hash)
+            compatibility_digest = getattr(execution_plan, "compatibility_digest", None) or ""
             self.sequence += 1
             await self.connection.send(
                 MessageEnvelope(
@@ -272,7 +298,12 @@ class LocalWorkerClient:
                     self.incarnation_id,
                     self.sequence,
                     snapshot.generation,
-                    {"phase": "ready"},
+                    {
+                        "phase": "ready",
+                        "snapshot_hash": snapshot.snapshot_hash,
+                        "plan_checksum": plan_checksum,
+                        "compatibility_digest": compatibility_digest,
+                    },
                 )
             )
             while True:
@@ -285,7 +316,9 @@ class LocalWorkerClient:
                 if message.generation < snapshot.generation:
                     continue
                 if message.generation != snapshot.generation or message.payload != {
-                    "snapshot_hash": snapshot.snapshot_hash
+                    "snapshot_hash": snapshot.snapshot_hash,
+                    "plan_checksum": plan_checksum,
+                    "compatibility_digest": compatibility_digest,
                 }:
                     raise ProtocolError("active generation does not match prepared membership")
                 self.active_generation = message.generation

--- a/oobleck/elastic/service_base.py
+++ b/oobleck/elastic/service_base.py
@@ -42,7 +42,7 @@ class MasterControlService:
         self._lease_task: asyncio.Task[None] | None = None
         self._master_sequence = 0
         self._proposed_snapshot: MembershipSnapshot | None = None
-        self._ready_agents: set[str] = set()
+        self._ready_agents: dict[str, tuple[str, str]] = {}
         self.active_generation = 0
 
     async def start(self, host: str, port: int) -> asyncio.AbstractServer:
@@ -169,19 +169,27 @@ class MasterControlService:
                         if (
                             proposed is None
                             or message.generation != proposed.generation
-                            or message.payload != {"snapshot_hash": proposed.snapshot_hash}
+                            or message.payload["snapshot_hash"] != proposed.snapshot_hash
                         ):
                             continue
+                        metadata = (
+                            str(message.payload["plan_checksum"]),
+                            str(message.payload["compatibility_digest"]),
+                        )
+                        if self._ready_agents and metadata not in set(self._ready_agents.values()):
+                            raise ProtocolError(
+                                "agents disagree on execution plan or runtime compatibility"
+                            )
                         self.membership.acknowledge(
                             message.agent_id,
                             message.incarnation_id,
                             message.sequence_number,
                             message.generation,
                         )
-                        self._ready_agents.add(message.agent_id)
-                        if self._ready_agents == set(self.membership.agent_ids):
+                        self._ready_agents[message.agent_id] = metadata
+                        if set(self._ready_agents) == set(self.membership.agent_ids):
                             self.active_generation = proposed.generation
-                            active_message = self._generation_active_message(proposed)
+                            active_message = self._generation_active_message(proposed, *metadata)
                     elif message.message_type == "drain":
                         self.membership.drain(
                             message.agent_id,
@@ -200,7 +208,12 @@ class MasterControlService:
                     if snapshot is not None:
                         await self._broadcast(snapshot)
                     return
-        except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError):
+        except (
+            asyncio.IncompleteReadError,
+            ConnectionResetError,
+            BrokenPipeError,
+            ProtocolError,
+        ):
             pass
         finally:
             if identity is not None:
@@ -247,7 +260,12 @@ class MasterControlService:
             },
         )
 
-    def _generation_active_message(self, snapshot: MembershipSnapshot) -> MessageEnvelope:
+    def _generation_active_message(
+        self,
+        snapshot: MembershipSnapshot,
+        plan_checksum: str,
+        compatibility_digest: str,
+    ) -> MessageEnvelope:
         self._master_sequence += 1
         return MessageEnvelope(
             1,
@@ -256,7 +274,11 @@ class MasterControlService:
             "master",
             self._master_sequence,
             snapshot.generation,
-            {"snapshot_hash": snapshot.snapshot_hash},
+            {
+                "snapshot_hash": snapshot.snapshot_hash,
+                "plan_checksum": plan_checksum,
+                "compatibility_digest": compatibility_digest,
+            },
         )
 
 

--- a/oobleck/elastic/service_public_base.py
+++ b/oobleck/elastic/service_public_base.py
@@ -32,6 +32,7 @@ class NodeAgentClient:
         *,
         transport: ControlTransport | None = None,
         heartbeat_interval_s: float = 1.0,
+        addresses: Sequence[str] = (),
         on_membership: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
         on_generation_active: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
         local_worker_socket: str | Path | None = None,
@@ -40,6 +41,15 @@ class NodeAgentClient:
             raise ValueError("node_id, gpu_ids, and a positive heartbeat interval are required")
         self.node_id = node_id
         self.gpu_ids = tuple(gpu_ids)
+        discovered = tuple(addresses) or tuple(
+            sorted(set(socket.gethostbyname_ex(socket.gethostname())[2]))
+        )
+        self.addresses = discovered or (socket.gethostbyname(socket.gethostname()),)
+        for address in self.addresses:
+            try:
+                socket.getaddrinfo(address, None)
+            except socket.gaierror as exc:
+                raise ValueError(f"agent address {address!r} is not resolvable") from exc
         self.transport = transport or AsyncioTcpControlTransport()
         self.heartbeat_interval_s = heartbeat_interval_s
         self.on_membership = on_membership
@@ -55,6 +65,7 @@ class NodeAgentClient:
         self._last_master_sequence = -1
         self._prepared_generation = -1
         self._ready_sent_generation = -1
+        self._ready_metadata: tuple[str, str] | None = None
         self._send_lock = asyncio.Lock()
         self._ready_lock = asyncio.Lock()
         self._stopping = False
@@ -91,13 +102,20 @@ class NodeAgentClient:
                 )
             )
 
-    async def _local_workers_ready(self, generation: int, snapshot_hash: str) -> None:
+    async def _local_workers_ready(
+        self,
+        generation: int,
+        snapshot_hash: str,
+        plan_checksum: str,
+        compatibility_digest: str,
+    ) -> None:
         snapshot = self.snapshot
         if (
             snapshot is not None
             and generation == snapshot.generation
             and snapshot_hash == snapshot.snapshot_hash
         ):
+            self._ready_metadata = (plan_checksum, compatibility_digest)
             await self._send_ready_if_possible(generation)
 
     async def _send_ready_if_possible(self, generation: int) -> None:
@@ -111,16 +129,24 @@ class NodeAgentClient:
                 or self._ready_sent_generation >= generation
             ):
                 return
-            if self.local_worker_relay is not None and not self.local_worker_relay.generation_ready(
-                generation
-            ):
-                return
+            if self.local_worker_relay is not None:
+                if not self.local_worker_relay.generation_ready(generation):
+                    return
+                if self._ready_metadata is None:
+                    return
+                plan_checksum, compatibility_digest = self._ready_metadata
+            else:
+                plan_checksum, compatibility_digest = snapshot.snapshot_hash, ""
             self._ready_sent_generation = generation
             try:
                 await self._send_agent_message(
                     "generation_ready",
                     generation,
-                    {"snapshot_hash": snapshot.snapshot_hash},
+                    {
+                        "snapshot_hash": snapshot.snapshot_hash,
+                        "plan_checksum": plan_checksum,
+                        "compatibility_digest": compatibility_digest,
+                    },
                 )
             except BaseException:
                 self._ready_sent_generation = -1
@@ -144,6 +170,7 @@ class NodeAgentClient:
         self.snapshot = snapshot
         self._prepared_generation = -1
         self._ready_sent_generation = -1
+        self._ready_metadata = None
         if self.local_worker_relay is not None:
             await self.local_worker_relay.publish(message)
         if self.on_membership is not None:
@@ -159,11 +186,14 @@ class NodeAgentClient:
         if message.generation < self.generation:
             return
         snapshot = self.snapshot
-        if (
-            snapshot is None
-            or message.generation != snapshot.generation
-            or message.payload != {"snapshot_hash": snapshot.snapshot_hash}
-        ):
+        if snapshot is None:
+            raise ValueError("master activated a generation before membership")
+        ready_metadata = self._ready_metadata or (snapshot.snapshot_hash, "")
+        if message.generation != snapshot.generation or message.payload != {
+            "snapshot_hash": snapshot.snapshot_hash,
+            "plan_checksum": ready_metadata[0],
+            "compatibility_digest": ready_metadata[1],
+        }:
             raise ValueError("master activated an unprepared generation")
         self.active_generation = message.generation
         if self.local_worker_relay is not None:
@@ -185,7 +215,7 @@ class NodeAgentClient:
                 self.sequence,
                 self.generation,
                 {
-                    "addresses": [socket.gethostbyname(socket.gethostname())],
+                    "addresses": list(self.addresses),
                     "gpu_ids": list(self.gpu_ids),
                 },
             )

--- a/oobleck/elastic/transport.py
+++ b/oobleck/elastic/transport.py
@@ -23,16 +23,16 @@ _FIELDS = {
 _PAYLOAD_FIELDS = {
     "register": {"addresses", "gpu_ids"},
     "heartbeat": set(),
-    "generation_ready": {"snapshot_hash"},
+    "generation_ready": {"snapshot_hash", "plan_checksum", "compatibility_digest"},
     "drain": set(),
     "membership": {"nodes", "reasons", "snapshot_hash"},
-    "generation_active": {"snapshot_hash"},
+    "generation_active": {"snapshot_hash", "plan_checksum", "compatibility_digest"},
     "inspect": set(),
     "request_drain": {"node_id"},
     "drain_command": {"node_id"},
     "drain_accepted": {"node_id"},
     "worker_register": {"node_id"},
-    "worker_ack": {"phase"},
+    "worker_ack": {"phase", "snapshot_hash", "plan_checksum", "compatibility_digest"},
 }
 
 
@@ -65,8 +65,11 @@ def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
         if type(payload["snapshot_hash"]) is not str:
             raise ProtocolError("membership snapshot_hash must be a string")
     elif message_type in {"generation_ready", "generation_active"}:
-        if type(payload["snapshot_hash"]) is not str or not payload["snapshot_hash"]:
-            raise ProtocolError(f"{message_type} snapshot_hash must be a non-empty string")
+        for field in ("snapshot_hash", "plan_checksum"):
+            if type(payload[field]) is not str or not payload[field]:
+                raise ProtocolError(f"{message_type} {field} must be a non-empty string")
+        if type(payload["compatibility_digest"]) is not str:
+            raise ProtocolError(f"{message_type} compatibility_digest must be a string")
     elif message_type in {
         "request_drain",
         "drain_command",
@@ -75,8 +78,14 @@ def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
     }:
         if type(payload["node_id"]) is not str or not payload["node_id"]:
             raise ProtocolError(f"{message_type} node_id must be a non-empty string")
-    elif message_type == "worker_ack" and payload["phase"] != "ready":
-        raise ProtocolError("worker_ack phase must be 'ready'")
+    elif message_type == "worker_ack":
+        if payload["phase"] != "ready":
+            raise ProtocolError("worker_ack phase must be 'ready'")
+        for field in ("snapshot_hash", "plan_checksum"):
+            if type(payload[field]) is not str or not payload[field]:
+                raise ProtocolError(f"worker_ack {field} must be a non-empty string")
+        if type(payload["compatibility_digest"]) is not str:
+            raise ProtocolError("worker_ack compatibility_digest must be a string")
 
 
 @dataclass(frozen=True, slots=True)

--- a/oobleck/elastic/workers.py
+++ b/oobleck/elastic/workers.py
@@ -99,6 +99,7 @@ async def run_agent_service(
         config.node_id,
         config.gpu_ids,
         heartbeat_interval_s=config.heartbeat_interval_s,
+        addresses=config.addresses,
         on_membership=on_membership,
         on_generation_active=on_generation_active,
         local_worker_socket=config.local_worker_socket,

--- a/oobleck/recovery.py
+++ b/oobleck/recovery.py
@@ -39,6 +39,14 @@ def _gather_new_manifests(
     return tuple(item for item in gathered if item is not None)
 
 
+def _rank_to_node(context: Any) -> dict[int, str] | None:
+    execution_plan = getattr(context, "execution_plan", None)
+    rank_map = getattr(execution_plan, "rank_map", None)
+    if rank_map is None:
+        return None
+    return {rank: node_id for node_id, ranks in rank_map for rank in ranks}
+
+
 def restore_context_state(context: Any, snapshot: RecoverySnapshot | None) -> RecoveryReport:
     """Redistribute a committed snapshot into every rank of the active generation."""
 
@@ -97,6 +105,7 @@ def restore_context_state(context: Any, snapshot: RecoverySnapshot | None) -> Re
             context.config.state_transfer_chunk_bytes * world_size,
         ),
         alignment=context.config.transfer_alignment_bytes,
+        rank_to_node=_rank_to_node(context),
     )
     if dist is not None:
         hashes: list[str | None] = [None] * world_size

--- a/tests/refactor/test_compatibility.py
+++ b/tests/refactor/test_compatibility.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.utils.data import Dataset, IterableDataset
+
+from oobleck import (
+    build_runtime_compatibility,
+    dataset_fingerprint,
+    model_fingerprint,
+)
+
+
+class StableDataset(Dataset):
+    oobleck_fingerprint = "stable-v1"
+
+    def __init__(self, length: int = 4) -> None:
+        self.length = length
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, index: int) -> torch.Tensor:
+        return torch.tensor(index)
+
+
+class UnstableDataset(Dataset):
+    def __len__(self) -> int:
+        return 2
+
+    def __getitem__(self, index: int) -> int:
+        return index
+
+
+class Stream(IterableDataset):
+    def __iter__(self):
+        yield 1
+
+
+def test_runtime_compatibility_is_stable_and_sensitive_to_inputs():
+    torch.manual_seed(3)
+    model = torch.nn.Linear(2, 2)
+    first = build_runtime_compatibility(
+        model,
+        StableDataset(),
+        model_identity="linear-checkpoint-v1",
+        oobleck_revision="oobleck-sha",
+        cornstarch_revision="cornstarch-sha",
+    )
+    second = build_runtime_compatibility(
+        model,
+        StableDataset(),
+        model_identity="linear-checkpoint-v1",
+        oobleck_revision="oobleck-sha",
+        cornstarch_revision="cornstarch-sha",
+    )
+    assert first == second
+    assert first.digest == second.digest
+    assert first.model_fingerprint == model_fingerprint(
+        model, model_identity="linear-checkpoint-v1"
+    )
+    changed = dataset_fingerprint(StableDataset(), preprocessing="tokenizer-v2")
+    assert changed != first.dataset_fingerprint
+    assert dataset_fingerprint(StableDataset(5)) != first.dataset_fingerprint
+
+
+def test_dataset_compatibility_requires_stable_map_identity():
+    with pytest.raises(ValueError, match="no stable fingerprint"):
+        dataset_fingerprint(UnstableDataset())
+    with pytest.raises(TypeError, match="map-style"):
+        dataset_fingerprint(Stream())
+    assert dataset_fingerprint(UnstableDataset(), explicit="provided")

--- a/tests/refactor/test_control_service.py
+++ b/tests/refactor/test_control_service.py
@@ -134,3 +134,107 @@ def test_agent_relays_latest_membership_to_local_gpu_workers(tmp_path):
         assert not socket_path.exists()
 
     asyncio.run(check())
+
+
+def test_local_workers_must_agree_on_plan_and_compatibility(tmp_path):
+    import pytest
+
+    from oobleck.elastic import LocalWorkerRelay, MessageEnvelope, ProtocolError
+
+    relay = LocalWorkerRelay(tmp_path / "relay.sock", "node-a", expected_workers=2)
+    relay._latest_membership = MessageEnvelope(
+        1,
+        "membership",
+        "master",
+        "master",
+        1,
+        7,
+        {"nodes": [], "reasons": [], "snapshot_hash": "membership"},
+    )
+    relay._workers = {"gpu-0": object(), "gpu-1": object()}
+    relay._acknowledged = {
+        "gpu-0": ("membership", "plan-a", "compat"),
+        "gpu-1": ("membership", "plan-b", "compat"),
+    }
+    assert relay.generation_ready(7)
+    with pytest.raises(ProtocolError, match="disagree"):
+        relay.readiness_metadata(7)
+
+
+def test_master_rejects_cross_agent_plan_disagreement():
+    async def check():
+        from oobleck.elastic import AsyncioTcpControlTransport, MessageEnvelope
+
+        service = MasterControlService(lease_timeout_s=2, lease_check_interval_s=0.05)
+        server = await service.start("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        transport = AsyncioTcpControlTransport()
+        first = await transport.connect("127.0.0.1", port)
+        second = await transport.connect("127.0.0.1", port)
+        await first.send(
+            MessageEnvelope(
+                1,
+                "register",
+                "node-a",
+                "a1",
+                0,
+                0,
+                {"addresses": ["127.0.0.1"], "gpu_ids": ["0"]},
+            )
+        )
+        assert (await first.receive()).generation == 1
+        await second.send(
+            MessageEnvelope(
+                1,
+                "register",
+                "node-b",
+                "b1",
+                0,
+                0,
+                {"addresses": ["127.0.0.1"], "gpu_ids": ["0"]},
+            )
+        )
+        first_proposal = await first.receive()
+        second_proposal = await second.receive()
+        assert first_proposal.generation == second_proposal.generation == 2
+        snapshot_hash = first_proposal.payload["snapshot_hash"]
+        await first.send(
+            MessageEnvelope(
+                1,
+                "generation_ready",
+                "node-a",
+                "a1",
+                1,
+                2,
+                {
+                    "snapshot_hash": snapshot_hash,
+                    "plan_checksum": "plan-a",
+                    "compatibility_digest": "compat",
+                },
+            )
+        )
+        await second.send(
+            MessageEnvelope(
+                1,
+                "generation_ready",
+                "node-b",
+                "b1",
+                1,
+                2,
+                {
+                    "snapshot_hash": snapshot_hash,
+                    "plan_checksum": "plan-b",
+                    "compatibility_digest": "compat",
+                },
+            )
+        )
+        replacement = await asyncio.wait_for(first.receive(), timeout=2)
+        assert replacement.message_type == "membership"
+        assert replacement.generation == 3
+        assert replacement.payload["reasons"] == ["disconnect:node-b"]
+        assert service.active_generation != 2
+        await first.close()
+        await second.close()
+        await service.close()
+
+    asyncio.run(check())

--- a/tests/refactor/test_distributed_transfer.py
+++ b/tests/refactor/test_distributed_transfer.py
@@ -113,6 +113,7 @@ class TestDistributedStateTransfer(GlooDistributedTestBase):
             device=device,
             _optimizer_factory=optimizer_factory,
             _scheduler_factory=None,
+            execution_plan=SimpleNamespace(rank_map=(("one-node", (0, 1)),)),
         )
         snapshot = capture_context_state(context)
         source_weight = model.weight.detach().cpu().clone()
@@ -131,6 +132,8 @@ class TestDistributedStateTransfer(GlooDistributedTestBase):
         assert report.actual_source_bytes == report.source_bytes
         assert report.actual_destination_bytes == report.destination_bytes
         assert report.round_durations
+        assert report.link_class_bytes
+        assert {link for link, _ in report.link_class_bytes} == {"same-node"}
         torch.testing.assert_close(model.weight.cpu(), gathered_weights[1 - self.rank])
         torch.testing.assert_close(
             context.optimizer.state[model.weight]["exp_avg"].cpu(),

--- a/tests/refactor/test_examples.py
+++ b/tests/refactor/test_examples.py
@@ -28,8 +28,10 @@ def test_agent_worker_configuration_requires_local_ipc(tmp_path):
         master_port=29600,
         local_worker_socket=tmp_path / "agent.sock",
         worker_script=script,
+        addresses=("127.0.0.1",),
     )
     assert config.worker_script == script
+    assert config.addresses == ("127.0.0.1",)
 
 
 def test_one_node_master_agent_worker_subprocess_smoke():


### PR DESCRIPTION
## What changed

- fingerprint model/checkpoint identity, stable map-style datasets and preprocessing, source/package revisions, Torch/CUDA/NCCL, datasets, and hardware
- include execution-plan checksum and compatibility digest in worker, agent, master, and activation readiness barriers
- reject local TP-worker and cross-agent plan disagreement before generation activation
- make agent rendezvous addresses explicit, resolvable, and operator-configurable
- seed synthetic model initialization deterministically across worker processes
- feed active rank-to-node topology into recovery source scheduling and link metrics

## Why

Membership consensus alone did not prove that workers independently built the same execution plan or runtime state. Divergent templates, software, datasets, model identities, or hardware could therefore reach collective initialization and deadlock. Integrated recovery also omitted known node locality from its otherwise locality-aware scheduler.

## Validation

- `python -m pytest -q tests/refactor` — 64 passed
- explicit CUDA-over-Gloo suite — 5 passed
- `cargo test --quiet` — 6 passed
- full Ruff lint and format checks
- pinned Cornstarch CUDA compile/activate/training smoke

CI remains intentionally removed and disabled.
