### PR TITLE
Enforce generation preparation barriers

### DIFF
--- a/examples/pretrain_llm.py
+++ b/examples/pretrain_llm.py
@@ -18,6 +18,8 @@ from examples.pretrain_llm_base import (
     TinyLanguageModel,
     build_dataset,
     build_training,
+    configure_training,
+    prepare_training,
 )
 from oobleck.elastic import LocalWorkerClient
 
@@ -99,7 +101,7 @@ def train_one_step(
 
 
 async def train_managed(config: ExampleTrainingConfig):
-    """Prepare through the local agent and train only after generation_active."""
+    """Compile before rendezvous and train only after generation_active."""
 
     socket_path = os.environ["OOBLECK_LOCAL_WORKER_SOCKET"]
     node_id = os.environ["OOBLECK_NODE_ID"]
@@ -108,7 +110,7 @@ async def train_managed(config: ExampleTrainingConfig):
     worker = LocalWorkerClient(socket_path, node_id, worker_id)
     await worker.connect()
     snapshot = await worker.receive()
-    model, context, loader = build_training(
+    model, prepared, dataset = prepare_training(
         device=selected,
         dataset_name=config.dataset_name,
         dataset_config=config.dataset_config,
@@ -121,24 +123,14 @@ async def train_managed(config: ExampleTrainingConfig):
         rendezvous_port=config.rendezvous_port,
         distributed_backend=config.distributed_backend,
     )
-    active = asyncio.Event()
+    context = await worker.activate_prepared(prepared, snapshot)
+    model, context, loader = configure_training(model, context, dataset, device=selected)
 
     async def prepare(snapshot) -> None:
         context.prepare_generation()
 
-    async def activated(generation: int) -> None:
-        active.set()
-
-    relay_task = asyncio.create_task(
-        worker.run_context(
-            context,
-            initial_snapshot=snapshot,
-            on_snapshot=prepare,
-            on_active=activated,
-        )
-    )
+    relay_task = asyncio.create_task(worker.run_context(context, on_snapshot=prepare))
     try:
-        await asyncio.wait_for(active.wait(), timeout=30.0)
         return _one_step(model, context, loader, selected, config.model_backend)
     finally:
         relay_task.cancel()
@@ -182,6 +174,8 @@ __all__ = [
     "TinyLanguageModel",
     "build_dataset",
     "build_training",
+    "configure_training",
+    "prepare_training",
     "train_managed",
     "train_one_step",
 ]

--- a/examples/pretrain_llm_base.py
+++ b/examples/pretrain_llm_base.py
@@ -114,7 +114,7 @@ def _build_model(
     )
 
 
-def build_training(
+def prepare_training(
     *,
     dataset_name: str | None = None,
     dataset_config: str | None = None,
@@ -187,7 +187,13 @@ def build_training(
         coordinator = min(membership_snapshot.nodes, key=lambda node: node.agent_id)
         plan.set_rendezvous_address(coordinator.addresses[0])
     plan.parallelize(model, parallel_config)
-    context = plan.materialize(device, dtype=torch.float32)
+    prepared = plan.prepare(device, dtype=torch.float32)
+    return model, prepared, dataset
+
+
+def configure_training(model, context, dataset, *, device: str):
+    """Create data and optimization state only after the generation WORLD is active."""
+
     sampler = context.create_batch_sampler(dataset, shuffle=True)
     dataloader = DataLoader(
         dataset,
@@ -204,6 +210,14 @@ def build_training(
         ),
     )
     return model, context, loader
+
+
+def build_training(**kwargs):
+    """Compatibility wrapper that prepares and activates a standalone runtime."""
+
+    model, prepared, dataset = prepare_training(**kwargs)
+    context = prepared.activate()
+    return configure_training(model, context, dataset, device=str(prepared.device))
 
 
 def train_one_step(device: str | None = None):

--- a/oobleck/__init__.py
+++ b/oobleck/__init__.py
@@ -10,6 +10,7 @@ from oobleck.runtime import (
     GenerationTransitionMetrics,
     OobleckParallelContext,
     OobleckParallelizationPlan,
+    OobleckPreparedContext,
     OobleckStepResult,
 )
 from oobleck.state import (
@@ -44,6 +45,7 @@ __all__ = [
     "OobleckExecutionPlan",
     "OobleckParallelContext",
     "OobleckParallelizationPlan",
+    "OobleckPreparedContext",
     "OobleckStepResult",
     "PipelineInstance",
     "PipelineStageSpec",

--- a/oobleck/elastic/local_ipc.py
+++ b/oobleck/elastic/local_ipc.py
@@ -20,11 +20,11 @@ from oobleck.elastic.transport import (
     ProtocolError,
 )
 
-WorkerReadyCallback = Callable[[int, str, str, str], Awaitable[None]]
+WorkerPhaseCallback = Callable[[int, str, str, str], Awaitable[None]]
 
 
 class LocalWorkerRelay:
-    """Broadcast generations and aggregate readiness from local GPU workers."""
+    """Broadcast generation phases and aggregate local GPU-worker consensus."""
 
     def __init__(
         self,
@@ -32,7 +32,8 @@ class LocalWorkerRelay:
         node_id: str,
         *,
         expected_workers: int = 1,
-        on_generation_ready: WorkerReadyCallback | None = None,
+        on_generation_prepared: WorkerPhaseCallback | None = None,
+        on_generation_ready: WorkerPhaseCallback | None = None,
         max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
     ) -> None:
         if expected_workers < 1:
@@ -40,13 +41,17 @@ class LocalWorkerRelay:
         self.path = Path(path)
         self.node_id = node_id
         self.expected_workers = expected_workers
+        self.on_generation_prepared = on_generation_prepared
         self.on_generation_ready = on_generation_ready
         self.max_frame_bytes = max_frame_bytes
         self._server: asyncio.AbstractServer | None = None
         self._workers: dict[str, ControlConnection] = {}
         self._latest_membership: MessageEnvelope | None = None
+        self._latest_rendezvous: MessageEnvelope | None = None
         self._latest_active: MessageEnvelope | None = None
+        self._prepared: dict[str, tuple[str, str, str]] = {}
         self._acknowledged: dict[str, tuple[str, str, str]] = {}
+        self._prepared_notified_generation = -1
         self._ready_notified_generation = -1
         self._lock = asyncio.Lock()
 
@@ -54,22 +59,39 @@ class LocalWorkerRelay:
     def worker_ids(self) -> tuple[str, ...]:
         return tuple(sorted(self._workers))
 
-    def generation_ready(self, generation: int) -> bool:
+    def _phase_complete(self, generation: int, values: dict[str, tuple[str, str, str]]) -> bool:
         latest = self._latest_membership
         return (
             latest is not None
             and latest.generation == generation
             and len(self._workers) == self.expected_workers
-            and len(self._acknowledged) == self.expected_workers
+            and len(values) == self.expected_workers
         )
 
+    def generation_prepared(self, generation: int) -> bool:
+        return self._phase_complete(generation, self._prepared)
+
+    def generation_ready(self, generation: int) -> bool:
+        return self._phase_complete(generation, self._acknowledged)
+
+    def _phase_metadata(
+        self,
+        generation: int,
+        values: dict[str, tuple[str, str, str]],
+        phase: str,
+    ) -> tuple[str, str, str]:
+        if not self._phase_complete(generation, values):
+            raise RuntimeError(f"local generation is not {phase}")
+        agreed = set(values.values())
+        if len(agreed) != 1:
+            raise ProtocolError(f"local workers disagree on {phase} generation plan compatibility")
+        return next(iter(agreed))
+
+    def preparation_metadata(self, generation: int) -> tuple[str, str, str]:
+        return self._phase_metadata(generation, self._prepared, "prepared")
+
     def readiness_metadata(self, generation: int) -> tuple[str, str, str]:
-        if not self.generation_ready(generation):
-            raise RuntimeError("local generation is not ready")
-        values = set(self._acknowledged.values())
-        if len(values) != 1:
-            raise ProtocolError("local workers disagree on generation plan compatibility")
-        return next(iter(values))
+        return self._phase_metadata(generation, self._acknowledged, "ready")
 
     async def start(self) -> None:
         if self._server is not None:
@@ -101,18 +123,16 @@ class LocalWorkerRelay:
                 if previous is None and len(self._workers) >= self.expected_workers:
                     raise ProtocolError("more local workers registered than configured GPUs")
                 self._workers[worker_id] = connection
-                latest_membership = self._latest_membership
-                latest_active = self._latest_active
+                phases = (
+                    self._latest_membership,
+                    self._latest_rendezvous,
+                    self._latest_active,
+                )
             if previous is not None:
                 await previous.close()
-            if latest_membership is not None:
-                await connection.send(latest_membership)
-            if (
-                latest_active is not None
-                and latest_membership is not None
-                and latest_active.generation == latest_membership.generation
-            ):
-                await connection.send(latest_active)
+            for phase in phases:
+                if phase is not None:
+                    await connection.send(phase)
             while True:
                 message = await connection.receive()
                 if message.message_type != "worker_ack":
@@ -121,27 +141,52 @@ class LocalWorkerRelay:
                     message.agent_id != worker_id
                     or message.incarnation_id != registration.incarnation_id
                 ):
-                    raise ProtocolError("invalid local worker readiness acknowledgement")
+                    raise ProtocolError("invalid local worker phase acknowledgement")
                 metadata = (
                     str(message.payload["snapshot_hash"]),
                     str(message.payload["plan_checksum"]),
                     str(message.payload["compatibility_digest"]),
                 )
-                callback: WorkerReadyCallback | None = None
+                phase_name = str(message.payload["phase"])
+                callback: WorkerPhaseCallback | None = None
                 async with self._lock:
                     latest = self._latest_membership
                     if latest is None or message.generation != latest.generation:
                         continue
                     if metadata[0] != latest.payload["snapshot_hash"]:
                         raise ProtocolError("worker acknowledged a different membership snapshot")
-                    self._acknowledged[worker_id] = metadata
-                    if (
-                        self.generation_ready(message.generation)
-                        and self._ready_notified_generation != message.generation
-                    ):
-                        agreed = self.readiness_metadata(message.generation)
-                        self._ready_notified_generation = message.generation
-                        callback = self.on_generation_ready
+                    if phase_name == "prepared":
+                        values = self._prepared
+                        values[worker_id] = metadata
+                        if (
+                            self.generation_prepared(message.generation)
+                            and self._prepared_notified_generation != message.generation
+                        ):
+                            agreed = self.preparation_metadata(message.generation)
+                            self._prepared_notified_generation = message.generation
+                            callback = self.on_generation_prepared
+                    else:
+                        rendezvous = self._latest_rendezvous
+                        if (
+                            rendezvous is None
+                            or rendezvous.generation != message.generation
+                            or rendezvous.payload
+                            != {
+                                "snapshot_hash": metadata[0],
+                                "plan_checksum": metadata[1],
+                                "compatibility_digest": metadata[2],
+                            }
+                        ):
+                            raise ProtocolError("worker became ready before matching rendezvous")
+                        values = self._acknowledged
+                        values[worker_id] = metadata
+                        if (
+                            self.generation_ready(message.generation)
+                            and self._ready_notified_generation != message.generation
+                        ):
+                            agreed = self.readiness_metadata(message.generation)
+                            self._ready_notified_generation = message.generation
+                            callback = self.on_generation_ready
                 if callback is not None:
                     await callback(message.generation, *agreed)
         except (
@@ -156,30 +201,46 @@ class LocalWorkerRelay:
                 async with self._lock:
                     if self._workers.get(worker_id) is connection:
                         self._workers.pop(worker_id, None)
+                        self._prepared.pop(worker_id, None)
                         self._acknowledged.pop(worker_id, None)
             with contextlib.suppress(Exception):
                 await connection.close()
 
     async def publish(self, message: MessageEnvelope) -> None:
-        if message.message_type not in {"membership", "generation_active"}:
-            raise ValueError("local relay accepts membership and generation_active messages")
+        allowed = {"membership", "generation_rendezvous", "generation_active"}
+        if message.message_type not in allowed:
+            raise ValueError(f"local relay accepts only {sorted(allowed)} messages")
         async with self._lock:
             if message.message_type == "membership":
                 self._latest_membership = message
+                self._latest_rendezvous = None
                 self._latest_active = None
+                self._prepared.clear()
                 self._acknowledged.clear()
+                self._prepared_notified_generation = -1
                 self._ready_notified_generation = -1
-            else:
+            elif message.message_type == "generation_rendezvous":
                 latest = self._latest_membership
                 if latest is None or message.generation != latest.generation:
-                    raise ProtocolError("active generation does not match local membership")
-                snapshot_hash, plan_checksum, compatibility_digest = self.readiness_metadata(
-                    message.generation
-                )
+                    raise ProtocolError("rendezvous does not match local membership")
+                metadata = self.preparation_metadata(message.generation)
                 if message.payload != {
-                    "snapshot_hash": snapshot_hash,
-                    "plan_checksum": plan_checksum,
-                    "compatibility_digest": compatibility_digest,
+                    "snapshot_hash": metadata[0],
+                    "plan_checksum": metadata[1],
+                    "compatibility_digest": metadata[2],
+                }:
+                    raise ProtocolError("rendezvous does not match local preparation")
+                self._latest_rendezvous = message
+            else:
+                latest = self._latest_membership
+                rendezvous = self._latest_rendezvous
+                if latest is None or rendezvous is None or message.generation != latest.generation:
+                    raise ProtocolError("active generation does not follow local rendezvous")
+                metadata = self.readiness_metadata(message.generation)
+                if message.payload != {
+                    "snapshot_hash": metadata[0],
+                    "plan_checksum": metadata[1],
+                    "compatibility_digest": metadata[2],
                 }:
                     raise ProtocolError("active generation does not match local readiness")
                 self._latest_active = message
@@ -197,6 +258,7 @@ class LocalWorkerRelay:
             async with self._lock:
                 for worker_id in failed:
                     self._workers.pop(worker_id, None)
+                    self._prepared.pop(worker_id, None)
                     self._acknowledged.pop(worker_id, None)
 
     async def close(self) -> None:
@@ -207,6 +269,7 @@ class LocalWorkerRelay:
         async with self._lock:
             workers = tuple(self._workers.values())
             self._workers.clear()
+            self._prepared.clear()
             self._acknowledged.clear()
         await asyncio.gather(*(worker.close() for worker in workers), return_exceptions=True)
         if self.path.exists() and stat.S_ISSOCK(self.path.stat().st_mode):
@@ -214,7 +277,7 @@ class LocalWorkerRelay:
 
 
 class LocalWorkerClient:
-    """Prepare a generation, acknowledge it, then wait for the CPU barrier."""
+    """Execute the prepared/rendezvous/ready/active generation protocol."""
 
     def __init__(self, path: str | Path, node_id: str, worker_id: str) -> None:
         if not node_id or not worker_id:
@@ -258,11 +321,117 @@ class LocalWorkerClient:
         while True:
             message = await self.connection.receive()
             if message.message_type == "generation_active":
-                if message.generation < self.generation:
-                    continue
-                self.active_generation = message.generation
+                if message.generation >= self.generation:
+                    self.active_generation = message.generation
+                continue
+            if message.message_type == "generation_rendezvous":
                 continue
             return self._parse_membership(message)
+
+    @staticmethod
+    def _metadata(execution_plan: Any, snapshot: MembershipSnapshot) -> tuple[str, str, str]:
+        return (
+            snapshot.snapshot_hash,
+            str(getattr(execution_plan, "plan_checksum", snapshot.snapshot_hash)),
+            str(getattr(execution_plan, "compatibility_digest", None) or ""),
+        )
+
+    async def _acknowledge(
+        self,
+        phase: str,
+        snapshot: MembershipSnapshot,
+        metadata: tuple[str, str, str],
+    ) -> None:
+        assert self.connection is not None
+        self.sequence += 1
+        await self.connection.send(
+            MessageEnvelope(
+                1,
+                "worker_ack",
+                self.worker_id,
+                self.incarnation_id,
+                self.sequence,
+                snapshot.generation,
+                {
+                    "phase": phase,
+                    "snapshot_hash": metadata[0],
+                    "plan_checksum": metadata[1],
+                    "compatibility_digest": metadata[2],
+                },
+            )
+        )
+
+    @staticmethod
+    def _validate_phase(
+        message: MessageEnvelope,
+        expected_type: str,
+        snapshot: MembershipSnapshot,
+        metadata: tuple[str, str, str],
+    ) -> None:
+        if message.message_type != expected_type:
+            raise ProtocolError(
+                f"local agent sent {message.message_type!r}; expected {expected_type}"
+            )
+        if message.generation != snapshot.generation or message.payload != {
+            "snapshot_hash": metadata[0],
+            "plan_checksum": metadata[1],
+            "compatibility_digest": metadata[2],
+        }:
+            raise ProtocolError(f"{expected_type} does not match prepared membership")
+
+    @staticmethod
+    def _reprepare(prepared: Any, snapshot: MembershipSnapshot) -> Any:
+        owner = prepared.owner_plan
+        tp = int(getattr(owner.parallel_config, "tensor_parallel_size"))
+        if any(len(node.gpu_ids) != tp for node in snapshot.nodes):
+            raise ValueError("membership does not match the fixed tensor-parallel width")
+        coordinator = min(snapshot.nodes, key=lambda node: node.agent_id)
+        owner.set_rendezvous_address(coordinator.addresses[0])
+        owner.set_membership(tuple(node.agent_id for node in snapshot.nodes), snapshot.generation)
+        return owner.prepare(
+            prepared.device,
+            prepared.dtype,
+            recover_from_survivors=prepared.recover_from_survivors,
+        )
+
+    async def activate_prepared(self, prepared: Any, snapshot: MembershipSnapshot) -> Any:
+        """Activate initial ownership only after both CPU control-plane barriers."""
+
+        if self.connection is None:
+            raise RuntimeError("local worker is not connected")
+        if snapshot.generation != self.generation:
+            raise ValueError("snapshot must be the latest received membership")
+        while True:
+            if prepared.execution_plan.generation != snapshot.generation:
+                prepared = self._reprepare(prepared, snapshot)
+            metadata = self._metadata(prepared.execution_plan, snapshot)
+            await self._acknowledge("prepared", snapshot, metadata)
+            while True:
+                message = await self.connection.receive()
+                if message.message_type == "membership":
+                    snapshot = self._parse_membership(message)
+                    prepared = self._reprepare(prepared, snapshot)
+                    break
+                self._validate_phase(message, "generation_rendezvous", snapshot, metadata)
+                context = prepared.activate()
+                await self._acknowledge("ready", snapshot, metadata)
+                while True:
+                    message = await self.connection.receive()
+                    if message.message_type == "membership":
+                        context.close()
+                        snapshot = self._parse_membership(message)
+                        prepared = self._reprepare(prepared, snapshot)
+                        break
+                    self._validate_phase(message, "generation_active", snapshot, metadata)
+                    self.active_generation = message.generation
+                    enable = getattr(context, "enable_control_plane_barrier", None)
+                    if callable(enable):
+                        enable()
+                    mark = getattr(context, "mark_generation_active", None)
+                    if callable(mark):
+                        mark(message.generation)
+                    return context
+                break
 
     async def run_context(
         self,
@@ -286,47 +455,34 @@ class LocalWorkerClient:
             context.apply_membership(snapshot)
             if on_snapshot is not None:
                 await on_snapshot(snapshot)
-            execution_plan = getattr(context, "execution_plan", None)
-            plan_checksum = getattr(execution_plan, "plan_checksum", snapshot.snapshot_hash)
-            compatibility_digest = getattr(execution_plan, "compatibility_digest", None) or ""
-            self.sequence += 1
-            await self.connection.send(
-                MessageEnvelope(
-                    1,
-                    "worker_ack",
-                    self.worker_id,
-                    self.incarnation_id,
-                    self.sequence,
-                    snapshot.generation,
-                    {
-                        "phase": "ready",
-                        "snapshot_hash": snapshot.snapshot_hash,
-                        "plan_checksum": plan_checksum,
-                        "compatibility_digest": compatibility_digest,
-                    },
-                )
-            )
+            prepared_plan = getattr(context, "prepared_execution_plan", None)
+            if prepared_plan is None:
+                prepared_plan = getattr(context, "execution_plan", snapshot)
+            metadata = self._metadata(prepared_plan, snapshot)
+            await self._acknowledge("prepared", snapshot, metadata)
             while True:
                 message = await self.connection.receive()
                 if message.message_type == "membership":
                     pending = self._parse_membership(message)
                     break
-                if message.message_type != "generation_active":
-                    raise ProtocolError("local agent sent an invalid generation phase")
-                if message.generation < snapshot.generation:
-                    continue
-                if message.generation != snapshot.generation or message.payload != {
-                    "snapshot_hash": snapshot.snapshot_hash,
-                    "plan_checksum": plan_checksum,
-                    "compatibility_digest": compatibility_digest,
-                }:
-                    raise ProtocolError("active generation does not match prepared membership")
-                self.active_generation = message.generation
-                mark_active = getattr(context, "mark_generation_active", None)
-                if callable(mark_active):
-                    mark_active(message.generation)
-                if on_active is not None:
-                    await on_active(message.generation)
+                self._validate_phase(message, "generation_rendezvous", snapshot, metadata)
+                activate = getattr(context, "activate_generation", None)
+                if callable(activate):
+                    activate()
+                await self._acknowledge("ready", snapshot, metadata)
+                while True:
+                    message = await self.connection.receive()
+                    if message.message_type == "membership":
+                        pending = self._parse_membership(message)
+                        break
+                    self._validate_phase(message, "generation_active", snapshot, metadata)
+                    self.active_generation = message.generation
+                    mark_active = getattr(context, "mark_generation_active", None)
+                    if callable(mark_active):
+                        mark_active(message.generation)
+                    if on_active is not None:
+                        await on_active(message.generation)
+                    break
                 break
 
     async def close(self) -> None:

--- a/oobleck/elastic/service_base.py
+++ b/oobleck/elastic/service_base.py
@@ -42,6 +42,8 @@ class MasterControlService:
         self._lease_task: asyncio.Task[None] | None = None
         self._master_sequence = 0
         self._proposed_snapshot: MembershipSnapshot | None = None
+        self._prepared_agents: dict[str, tuple[str, str]] = {}
+        self._rendezvous_metadata: tuple[str, str] | None = None
         self._ready_agents: dict[str, tuple[str, str]] = {}
         self.active_generation = 0
 
@@ -72,7 +74,9 @@ class MasterControlService:
         """Install a proposal and invalidate every older readiness result."""
 
         self._proposed_snapshot = snapshot
+        self._prepared_agents.clear()
         self._ready_agents.clear()
+        self._rendezvous_metadata = None
         if not snapshot.nodes:
             self.active_generation = snapshot.generation
 
@@ -155,6 +159,7 @@ class MasterControlService:
             while True:
                 message = await connection.receive()
                 snapshot = None
+                rendezvous_message = None
                 active_message = None
                 async with self._lock:
                     if message.message_type == "heartbeat":
@@ -164,6 +169,36 @@ class MasterControlService:
                             message.sequence_number,
                             message.generation,
                         )
+                    elif message.message_type == "generation_prepared":
+                        proposed = self._proposed_snapshot
+                        if (
+                            proposed is None
+                            or message.generation != proposed.generation
+                            or message.payload["snapshot_hash"] != proposed.snapshot_hash
+                        ):
+                            continue
+                        metadata = (
+                            str(message.payload["plan_checksum"]),
+                            str(message.payload["compatibility_digest"]),
+                        )
+                        self.membership.acknowledge(
+                            message.agent_id,
+                            message.incarnation_id,
+                            message.sequence_number,
+                            message.generation,
+                        )
+                        if self._prepared_agents and metadata not in set(
+                            self._prepared_agents.values()
+                        ):
+                            raise ProtocolError(
+                                "agents disagree on prepared execution plan or runtime compatibility"
+                            )
+                        self._prepared_agents[message.agent_id] = metadata
+                        if set(self._prepared_agents) == set(self.membership.agent_ids):
+                            self._rendezvous_metadata = metadata
+                            rendezvous_message = self._generation_rendezvous_message(
+                                proposed, *metadata
+                            )
                     elif message.message_type == "generation_ready":
                         proposed = self._proposed_snapshot
                         if (
@@ -176,6 +211,12 @@ class MasterControlService:
                             str(message.payload["plan_checksum"]),
                             str(message.payload["compatibility_digest"]),
                         )
+                        if self._rendezvous_metadata is None:
+                            raise ProtocolError("agent became ready before rendezvous publication")
+                        if metadata != self._rendezvous_metadata:
+                            raise ProtocolError(
+                                "ready agent disagrees with the prepared generation"
+                            )
                         if self._ready_agents and metadata not in set(self._ready_agents.values()):
                             raise ProtocolError(
                                 "agents disagree on execution plan or runtime compatibility"
@@ -202,6 +243,8 @@ class MasterControlService:
                             self._begin_generation(snapshot)
                     else:
                         raise ProtocolError(f"unsupported agent message {message.message_type!r}")
+                if rendezvous_message is not None:
+                    await self._broadcast_message(rendezvous_message)
                 if active_message is not None:
                     await self._broadcast_message(active_message)
                 if message.message_type == "drain":
@@ -257,6 +300,27 @@ class MasterControlService:
                 "nodes": [asdict(node) for node in snapshot.nodes],
                 "reasons": list(snapshot.reasons),
                 "snapshot_hash": snapshot.snapshot_hash,
+            },
+        )
+
+    def _generation_rendezvous_message(
+        self,
+        snapshot: MembershipSnapshot,
+        plan_checksum: str,
+        compatibility_digest: str,
+    ) -> MessageEnvelope:
+        self._master_sequence += 1
+        return MessageEnvelope(
+            1,
+            "generation_rendezvous",
+            "master",
+            "master",
+            self._master_sequence,
+            snapshot.generation,
+            {
+                "snapshot_hash": snapshot.snapshot_hash,
+                "plan_checksum": plan_checksum,
+                "compatibility_digest": compatibility_digest,
             },
         )
 

--- a/oobleck/elastic/service_public_base.py
+++ b/oobleck/elastic/service_public_base.py
@@ -64,8 +64,10 @@ class NodeAgentClient:
         self._port: int | None = None
         self._last_master_sequence = -1
         self._prepared_generation = -1
+        self._prepared_sent_generation = -1
+        self._rendezvous_generation = -1
         self._ready_sent_generation = -1
-        self._ready_metadata: tuple[str, str] | None = None
+        self._phase_metadata: tuple[str, str] | None = None
         self._send_lock = asyncio.Lock()
         self._ready_lock = asyncio.Lock()
         self._stopping = False
@@ -74,6 +76,7 @@ class NodeAgentClient:
                 local_worker_socket,
                 node_id,
                 expected_workers=len(self.gpu_ids),
+                on_generation_prepared=self._local_workers_prepared,
                 on_generation_ready=self._local_workers_ready,
             )
             if local_worker_socket is not None
@@ -102,6 +105,22 @@ class NodeAgentClient:
                 )
             )
 
+    async def _local_workers_prepared(
+        self,
+        generation: int,
+        snapshot_hash: str,
+        plan_checksum: str,
+        compatibility_digest: str,
+    ) -> None:
+        snapshot = self.snapshot
+        if (
+            snapshot is not None
+            and generation == snapshot.generation
+            and snapshot_hash == snapshot.snapshot_hash
+        ):
+            self._phase_metadata = (plan_checksum, compatibility_digest)
+            await self._send_prepared_if_possible(generation)
+
     async def _local_workers_ready(
         self,
         generation: int,
@@ -115,8 +134,44 @@ class NodeAgentClient:
             and generation == snapshot.generation
             and snapshot_hash == snapshot.snapshot_hash
         ):
-            self._ready_metadata = (plan_checksum, compatibility_digest)
+            if self._phase_metadata != (plan_checksum, compatibility_digest):
+                raise ValueError("local ready metadata differs from local preparation")
             await self._send_ready_if_possible(generation)
+
+    async def _send_prepared_if_possible(self, generation: int) -> None:
+        async with self._ready_lock:
+            snapshot = self.snapshot
+            if (
+                self.connection is None
+                or snapshot is None
+                or generation != snapshot.generation
+                or self._prepared_generation != generation
+                or self._prepared_sent_generation >= generation
+            ):
+                return
+            if self.local_worker_relay is not None:
+                if not self.local_worker_relay.generation_prepared(generation):
+                    return
+                if self._phase_metadata is None:
+                    return
+                plan_checksum, compatibility_digest = self._phase_metadata
+            else:
+                plan_checksum, compatibility_digest = snapshot.snapshot_hash, ""
+                self._phase_metadata = (plan_checksum, compatibility_digest)
+            self._prepared_sent_generation = generation
+            try:
+                await self._send_agent_message(
+                    "generation_prepared",
+                    generation,
+                    {
+                        "snapshot_hash": snapshot.snapshot_hash,
+                        "plan_checksum": plan_checksum,
+                        "compatibility_digest": compatibility_digest,
+                    },
+                )
+            except BaseException:
+                self._prepared_sent_generation = -1
+                raise
 
     async def _send_ready_if_possible(self, generation: int) -> None:
         async with self._ready_lock:
@@ -125,18 +180,16 @@ class NodeAgentClient:
                 self.connection is None
                 or snapshot is None
                 or generation != snapshot.generation
-                or self._prepared_generation != generation
+                or self._rendezvous_generation != generation
                 or self._ready_sent_generation >= generation
+                or self._phase_metadata is None
             ):
                 return
-            if self.local_worker_relay is not None:
-                if not self.local_worker_relay.generation_ready(generation):
-                    return
-                if self._ready_metadata is None:
-                    return
-                plan_checksum, compatibility_digest = self._ready_metadata
-            else:
-                plan_checksum, compatibility_digest = snapshot.snapshot_hash, ""
+            if self.local_worker_relay is not None and not self.local_worker_relay.generation_ready(
+                generation
+            ):
+                return
+            plan_checksum, compatibility_digest = self._phase_metadata
             self._ready_sent_generation = generation
             try:
                 await self._send_agent_message(
@@ -169,15 +222,37 @@ class NodeAgentClient:
         self.generation = snapshot.generation
         self.snapshot = snapshot
         self._prepared_generation = -1
+        self._prepared_sent_generation = -1
+        self._rendezvous_generation = -1
         self._ready_sent_generation = -1
-        self._ready_metadata = None
+        self._phase_metadata = None
         if self.local_worker_relay is not None:
             await self.local_worker_relay.publish(message)
         if self.on_membership is not None:
             await self.on_membership(message)
         self._prepared_generation = snapshot.generation
-        await self._send_ready_if_possible(snapshot.generation)
+        await self._send_prepared_if_possible(snapshot.generation)
         return snapshot
+
+    async def _consume_rendezvous(self, message: MessageEnvelope) -> None:
+        if message.message_type != "generation_rendezvous":
+            raise ValueError("expected a generation_rendezvous message")
+        self._validate_master_sequence(message)
+        if message.generation < self.generation:
+            return
+        snapshot = self.snapshot
+        if snapshot is None or self._phase_metadata is None:
+            raise ValueError("master published rendezvous before local preparation")
+        if message.generation != snapshot.generation or message.payload != {
+            "snapshot_hash": snapshot.snapshot_hash,
+            "plan_checksum": self._phase_metadata[0],
+            "compatibility_digest": self._phase_metadata[1],
+        }:
+            raise ValueError("master rendezvous does not match local preparation")
+        self._rendezvous_generation = message.generation
+        if self.local_worker_relay is not None:
+            await self.local_worker_relay.publish(message)
+        await self._send_ready_if_possible(message.generation)
 
     async def _consume_active(self, message: MessageEnvelope) -> None:
         if message.message_type != "generation_active":
@@ -188,7 +263,7 @@ class NodeAgentClient:
         snapshot = self.snapshot
         if snapshot is None:
             raise ValueError("master activated a generation before membership")
-        ready_metadata = self._ready_metadata or (snapshot.snapshot_hash, "")
+        ready_metadata = self._phase_metadata or (snapshot.snapshot_hash, "")
         if message.generation != snapshot.generation or message.payload != {
             "snapshot_hash": snapshot.snapshot_hash,
             "plan_checksum": ready_metadata[0],
@@ -240,6 +315,8 @@ class NodeAgentClient:
                 return
             if message.message_type == "membership":
                 await self._consume_membership(message)
+            elif message.message_type == "generation_rendezvous":
+                await self._consume_rendezvous(message)
             elif message.message_type == "generation_active":
                 await self._consume_active(message)
             else:

--- a/oobleck/elastic/transport.py
+++ b/oobleck/elastic/transport.py
@@ -23,9 +23,11 @@ _FIELDS = {
 _PAYLOAD_FIELDS = {
     "register": {"addresses", "gpu_ids"},
     "heartbeat": set(),
+    "generation_prepared": {"snapshot_hash", "plan_checksum", "compatibility_digest"},
     "generation_ready": {"snapshot_hash", "plan_checksum", "compatibility_digest"},
     "drain": set(),
     "membership": {"nodes", "reasons", "snapshot_hash"},
+    "generation_rendezvous": {"snapshot_hash", "plan_checksum", "compatibility_digest"},
     "generation_active": {"snapshot_hash", "plan_checksum", "compatibility_digest"},
     "inspect": set(),
     "request_drain": {"node_id"},
@@ -64,7 +66,12 @@ def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
             raise ProtocolError("membership nodes and reasons must be lists")
         if type(payload["snapshot_hash"]) is not str:
             raise ProtocolError("membership snapshot_hash must be a string")
-    elif message_type in {"generation_ready", "generation_active"}:
+    elif message_type in {
+        "generation_prepared",
+        "generation_ready",
+        "generation_rendezvous",
+        "generation_active",
+    }:
         for field in ("snapshot_hash", "plan_checksum"):
             if type(payload[field]) is not str or not payload[field]:
                 raise ProtocolError(f"{message_type} {field} must be a non-empty string")
@@ -79,8 +86,8 @@ def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
         if type(payload["node_id"]) is not str or not payload["node_id"]:
             raise ProtocolError(f"{message_type} node_id must be a non-empty string")
     elif message_type == "worker_ack":
-        if payload["phase"] != "ready":
-            raise ProtocolError("worker_ack phase must be 'ready'")
+        if payload["phase"] not in {"prepared", "ready"}:
+            raise ProtocolError("worker_ack phase must be 'prepared' or 'ready'")
         for field in ("snapshot_hash", "plan_checksum"):
             if type(payload[field]) is not str or not payload[field]:
                 raise ProtocolError(f"worker_ack {field} must be a non-empty string")

--- a/oobleck/runtime.py
+++ b/oobleck/runtime.py
@@ -41,6 +41,21 @@ class GenerationTransitionMetrics:
     source_scheduling_error_bytes: int = 0
 
 
+@dataclass(slots=True)
+class _PreparedGenerationTransition:
+    target: Any
+    compiled: Any
+    snapshot: Any
+    snapshot_seconds: float
+    teardown_seconds: float
+    compile_seconds: float
+    transition_started: float
+    attempt_started: float
+    detection_seconds: float
+    configuration_planning_seconds: float
+    superseded_recorded: bool = False
+
+
 def _init_with_recovery(self: OobleckParallelContext, *args: Any, **kwargs: Any) -> None:
     _base_init(self, *args, **kwargs)
     self._optimizer_factory: (
@@ -52,6 +67,7 @@ def _init_with_recovery(self: OobleckParallelContext, *args: Any, **kwargs: Any)
     self._control_active_generation = self.generation
     self.recovery_history: list[GenerationTransitionMetrics] = []
     self._generation_control_metrics: dict[int, tuple[float, float]] = {}
+    self._prepared_transition: _PreparedGenerationTransition | None = None
     self._heterogeneous_gradient_sync = (
         None
         if self._needs_survivor_recovery
@@ -99,22 +115,65 @@ def _retire_world(self: OobleckParallelContext) -> None:
         destroy_process_group_universe()
 
 
-def _activate_latest_generation(self: OobleckParallelContext) -> None:
-    """Replace WORLD and recover only the last committed training state.
-
-    The snapshot is captured once.  If a newer membership arrives during
-    preparation or activation, the partially created generation is retired and
-    the same committed snapshot is applied to the newest complete plan.
-    """
-
-    if self._pending_plan is None:
+def _record_superseded(
+    self: OobleckParallelContext,
+    transition: _PreparedGenerationTransition,
+    *,
+    world_seconds: float = 0.0,
+    activation_seconds: float = 0.0,
+    recovery_seconds: float = 0.0,
+) -> None:
+    if transition.superseded_recorded:
         return
-    transition_started = time.perf_counter()
-    snapshot_started = transition_started
-    snapshot = capture_context_state(self)
-    snapshot_seconds = time.perf_counter() - snapshot_started
-    for loader in self._loaders:
-        loader.invalidate_prefetch()
+    transition.superseded_recorded = True
+    report = self.last_recovery_report if recovery_seconds else None
+    self.recovery_history.append(
+        GenerationTransitionMetrics(
+            transition.target.generation,
+            transition.snapshot_seconds,
+            transition.teardown_seconds,
+            transition.compile_seconds,
+            world_seconds,
+            activation_seconds,
+            recovery_seconds,
+            time.perf_counter() - transition.attempt_started,
+            True,
+            detection_seconds=transition.detection_seconds,
+            configuration_planning_seconds=transition.configuration_planning_seconds,
+            state_planning_seconds=0.0 if report is None else report.planning_seconds,
+            state_transfer_seconds=0.0 if report is None else report.transfer_seconds,
+            straggler_round_seconds=0.0 if report is None else report.straggler_round_seconds,
+            source_scheduling_error_bytes=(
+                0 if report is None else report.source_scheduling_error_bytes
+            ),
+        )
+    )
+
+
+def _prepare_latest_generation(self: OobleckParallelContext) -> bool:
+    """Retire WORLD and compile the newest ownership without creating a new WORLD."""
+
+    existing = self._prepared_transition
+    if self._pending_plan is None:
+        return existing is not None
+
+    if existing is None:
+        transition_started = time.perf_counter()
+        snapshot_started = transition_started
+        snapshot = capture_context_state(self)
+        snapshot_seconds = time.perf_counter() - snapshot_started
+        for loader in self._loaders:
+            loader.invalidate_prefetch()
+        teardown_started = time.perf_counter()
+        _retire_world(self)
+        teardown_seconds = time.perf_counter() - teardown_started
+    else:
+        transition_started = existing.transition_started
+        snapshot = existing.snapshot
+        snapshot_seconds = existing.snapshot_seconds
+        teardown_seconds = 0.0
+        _record_superseded(self, existing)
+        self._prepared_transition = None
 
     while self._pending_plan is not None:
         target = self._pending_plan
@@ -123,110 +182,119 @@ def _activate_latest_generation(self: OobleckParallelContext) -> None:
             target.generation, (0.0, 0.0)
         )
         attempt_started = time.perf_counter()
-        teardown_started = attempt_started
-        _retire_world(self)
-        teardown_seconds = time.perf_counter() - teardown_started
-
-        # Compilation is deliberately process-group independent and occurs
-        # after the old universe is gone but before the replacement is created.
-        compile_started = time.perf_counter()
+        compile_started = attempt_started
         compiled = self.owner_plan.compile(target)
         compile_seconds = time.perf_counter() - compile_started
-        world_started = time.perf_counter()
-        if self.owner_plan.world_initializer is not None:
-            self.owner_plan.world_initializer(target)
-        world_seconds = time.perf_counter() - world_started
-        activation_started = time.perf_counter()
-        activated = compiled.activate(self.device, self.dtype)
-        activation_seconds = time.perf_counter() - activation_started
-
-        # A complete newer snapshot supersedes this generation before any
-        # committed state is installed or the generation is made visible.
+        transition = _PreparedGenerationTransition(
+            target,
+            compiled,
+            snapshot,
+            snapshot_seconds,
+            teardown_seconds,
+            compile_seconds,
+            transition_started,
+            attempt_started,
+            detection_seconds,
+            configuration_planning_seconds,
+        )
         if self._pending_plan is not None and self._pending_plan.generation > target.generation:
-            activated.close()
-            if _world_initialized():
-                destroy_process_group_universe()
-            self.recovery_history.append(
-                GenerationTransitionMetrics(
-                    target.generation,
-                    snapshot_seconds,
-                    teardown_seconds,
-                    compile_seconds,
-                    world_seconds,
-                    activation_seconds,
-                    0.0,
-                    time.perf_counter() - attempt_started,
-                    True,
-                    detection_seconds=detection_seconds,
-                    configuration_planning_seconds=configuration_planning_seconds,
-                )
-            )
+            _record_superseded(self, transition)
+            teardown_seconds = 0.0
             continue
+        self._prepared_transition = transition
+        return True
+    return False
 
-        self.compiled = compiled
-        self.partition = activated
-        self.execution_plan = target
-        self.owner_plan.rank = compiled.rank
-        self.owner_plan._last_execution_plan = target
-        for loader in self._loaders:
-            loader.reconfigure(target.instances)
-        recovery_started = time.perf_counter()
-        self.last_recovery_report = restore_context_state(self, snapshot)
-        recovery_seconds = time.perf_counter() - recovery_started
-        self._heterogeneous_gradient_sync = activate_gradient_synchronizer(
-            self.model,
-            self.partition.manifest,
-            self.execution_plan,
-            microbatch_size=self.config.microbatch_size,
-        )
 
-        if self._pending_plan is not None:
-            # Recovery completed at a safe boundary, but this generation is
-            # already stale.  Reuse the original committed snapshot so an
-            # intermediate activation can never become a source of truth.
-            self.recovery_history.append(
-                GenerationTransitionMetrics(
-                    target.generation,
-                    snapshot_seconds,
-                    teardown_seconds,
-                    compile_seconds,
-                    world_seconds,
-                    activation_seconds,
-                    recovery_seconds,
-                    time.perf_counter() - attempt_started,
-                    True,
-                    detection_seconds=detection_seconds,
-                    configuration_planning_seconds=configuration_planning_seconds,
-                    state_planning_seconds=self.last_recovery_report.planning_seconds,
-                    state_transfer_seconds=self.last_recovery_report.transfer_seconds,
-                    straggler_round_seconds=self.last_recovery_report.straggler_round_seconds,
-                    source_scheduling_error_bytes=(
-                        self.last_recovery_report.source_scheduling_error_bytes
-                    ),
-                )
-            )
-            continue
-        self.recovery_history.append(
-            GenerationTransitionMetrics(
-                target.generation,
-                snapshot_seconds,
-                teardown_seconds,
-                compile_seconds,
-                world_seconds,
-                activation_seconds,
-                recovery_seconds,
-                time.perf_counter() - transition_started,
-                detection_seconds=detection_seconds,
-                configuration_planning_seconds=configuration_planning_seconds,
-                state_planning_seconds=self.last_recovery_report.planning_seconds,
-                state_transfer_seconds=self.last_recovery_report.transfer_seconds,
-                straggler_round_seconds=self.last_recovery_report.straggler_round_seconds,
-                source_scheduling_error_bytes=(
-                    self.last_recovery_report.source_scheduling_error_bytes
-                ),
-            )
+def _activate_prepared_generation(self: OobleckParallelContext) -> bool:
+    """Create WORLD, activate ownership, and recover after rendezvous publication."""
+
+    transition = self._prepared_transition
+    if transition is None:
+        raise RuntimeError("no prepared generation is waiting for rendezvous")
+    target = transition.target
+    world_started = time.perf_counter()
+    if self.owner_plan.world_initializer is not None:
+        self.owner_plan.world_initializer(target)
+    world_seconds = time.perf_counter() - world_started
+    activation_started = time.perf_counter()
+    activated = transition.compiled.activate(self.device, self.dtype)
+    activation_seconds = time.perf_counter() - activation_started
+
+    if self._pending_plan is not None and self._pending_plan.generation > target.generation:
+        activated.close()
+        if _world_initialized():
+            destroy_process_group_universe()
+        _record_superseded(
+            self,
+            transition,
+            world_seconds=world_seconds,
+            activation_seconds=activation_seconds,
         )
-        break
+        self._prepared_transition = transition
+        _prepare_latest_generation(self)
+        return False
+
+    self.compiled = transition.compiled
+    self.partition = activated
+    self.execution_plan = target
+    self.owner_plan.rank = transition.compiled.rank
+    self.owner_plan._last_execution_plan = target
+    for loader in self._loaders:
+        loader.reconfigure(target.instances)
+    recovery_started = time.perf_counter()
+    self.last_recovery_report = restore_context_state(self, transition.snapshot)
+    recovery_seconds = time.perf_counter() - recovery_started
+    self._heterogeneous_gradient_sync = activate_gradient_synchronizer(
+        self.model,
+        self.partition.manifest,
+        self.execution_plan,
+        microbatch_size=self.config.microbatch_size,
+    )
+
+    if self._pending_plan is not None:
+        _record_superseded(
+            self,
+            transition,
+            world_seconds=world_seconds,
+            activation_seconds=activation_seconds,
+            recovery_seconds=recovery_seconds,
+        )
+        _retire_world(self)
+        self._prepared_transition = transition
+        _prepare_latest_generation(self)
+        return False
+
+    self.recovery_history.append(
+        GenerationTransitionMetrics(
+            target.generation,
+            transition.snapshot_seconds,
+            transition.teardown_seconds,
+            transition.compile_seconds,
+            world_seconds,
+            activation_seconds,
+            recovery_seconds,
+            time.perf_counter() - transition.transition_started,
+            detection_seconds=transition.detection_seconds,
+            configuration_planning_seconds=transition.configuration_planning_seconds,
+            state_planning_seconds=self.last_recovery_report.planning_seconds,
+            state_transfer_seconds=self.last_recovery_report.transfer_seconds,
+            straggler_round_seconds=self.last_recovery_report.straggler_round_seconds,
+            source_scheduling_error_bytes=(self.last_recovery_report.source_scheduling_error_bytes),
+        )
+    )
+    self._prepared_transition = None
+    return True
+
+
+def _activate_latest_generation(self: OobleckParallelContext) -> None:
+    """Compatibility path that performs both generation phases synchronously."""
+
+    while self._pending_plan is not None or self._prepared_transition is not None:
+        if self._prepared_transition is None or self._pending_plan is not None:
+            _prepare_latest_generation(self)
+        if self._prepared_transition is not None:
+            _activate_prepared_generation(self)
 
 
 def _apply_membership(self: OobleckParallelContext, snapshot: MembershipSnapshot) -> bool:
@@ -235,6 +303,11 @@ def _apply_membership(self: OobleckParallelContext, snapshot: MembershipSnapshot
     newest_generation = max(
         self.generation,
         self._pending_plan.generation if self._pending_plan is not None else -1,
+        (
+            self._prepared_transition.target.generation
+            if self._prepared_transition is not None
+            else -1
+        ),
     )
     if snapshot.generation <= newest_generation:
         return False
@@ -274,7 +347,20 @@ def _enable_control_plane_barrier(self: OobleckParallelContext) -> None:
 def _prepare_generation(self: OobleckParallelContext) -> None:
     if not self._control_plane_managed:
         raise RuntimeError("enable the control-plane barrier before preparation")
-    _activate_latest_generation(self)
+    if not _prepare_latest_generation(self):
+        raise RuntimeError("no newer generation is available to prepare")
+
+
+def _activate_generation(self: OobleckParallelContext) -> None:
+    if not self._control_plane_managed:
+        raise RuntimeError("enable the control-plane barrier before activation")
+    if not _activate_prepared_generation(self):
+        raise RuntimeError("prepared generation was superseded during activation")
+
+
+def _prepared_execution_plan(self: OobleckParallelContext) -> Any:
+    transition = self._prepared_transition
+    return self.execution_plan if transition is None else transition.target
 
 
 def _mark_generation_active(self: OobleckParallelContext, generation: int) -> None:
@@ -287,7 +373,9 @@ def _mark_generation_active(self: OobleckParallelContext, generation: int) -> No
 
 def _step_with_control_barrier(self: OobleckParallelContext, *args: Any, **kwargs: Any) -> Any:
     if self._control_plane_managed and (
-        self._pending_plan is not None or self._control_active_generation != self.generation
+        self._pending_plan is not None
+        or self._prepared_transition is not None
+        or self._control_active_generation != self.generation
     ):
         raise RuntimeError(
             "generation is prepared but not active through the CPU control-plane barrier"
@@ -325,6 +413,8 @@ OobleckParallelContext._activate_latest_generation = _activate_latest_generation
 OobleckParallelContext.apply_membership = _apply_membership
 OobleckParallelContext.enable_control_plane_barrier = _enable_control_plane_barrier
 OobleckParallelContext.prepare_generation = _prepare_generation
+OobleckParallelContext.activate_generation = _activate_generation
+OobleckParallelContext.prepared_execution_plan = property(_prepared_execution_plan)
 OobleckParallelContext.mark_generation_active = _mark_generation_active
 OobleckParallelContext.step = _step_with_control_barrier
 OobleckParallelContext.recover_from_survivors = _recover_from_survivors

--- a/oobleck/runtime_base.py
+++ b/oobleck/runtime_base.py
@@ -42,6 +42,37 @@ class OobleckStepResult:
     output: Any = None
 
 
+@dataclass(slots=True)
+class OobleckPreparedContext:
+    """Rank-local ownership compiled before the distributed WORLD exists."""
+
+    owner_plan: "OobleckParallelizationPlan"
+    execution_plan: OobleckExecutionPlan
+    compiled: CompiledLocalPartition
+    device: torch.device
+    dtype: torch.dtype | None
+    recover_from_survivors: bool = False
+    _activated: bool = False
+
+    def activate(self) -> "OobleckParallelContext":
+        if self._activated:
+            raise RuntimeError("prepared context has already been activated")
+        if self.owner_plan.world_initializer is not None:
+            self.owner_plan.world_initializer(self.execution_plan)
+        partition = self.compiled.activate(self.device, self.dtype)
+        self._activated = True
+        return OobleckParallelContext(
+            config=self.owner_plan.config,
+            owner_plan=self.owner_plan,
+            execution_plan=self.execution_plan,
+            compiled=self.compiled,
+            partition=partition,
+            device=self.device,
+            dtype=self.dtype,
+            needs_survivor_recovery=self.recover_from_survivors,
+        )
+
+
 class OobleckParallelizationPlan:
     """Prepare rank-local ownership before creating the distributed world."""
 
@@ -288,20 +319,30 @@ class OobleckParallelizationPlan:
         *,
         recover_from_survivors: bool = False,
     ) -> "OobleckParallelContext":
+        return self.prepare(
+            device,
+            dtype,
+            recover_from_survivors=recover_from_survivors,
+        ).activate()
+
+    def prepare(
+        self,
+        device: str | torch.device = "cuda",
+        dtype: torch.dtype | None = None,
+        *,
+        recover_from_survivors: bool = False,
+    ) -> OobleckPreparedContext:
+        """Compile local ownership without initializing WORLD or allocating state."""
+
         execution_plan = self.build_execution_plan()
         compiled = self.compile(execution_plan)
-        if self.world_initializer is not None:
-            self.world_initializer(execution_plan)
-        activated = compiled.activate(device, dtype)
-        return OobleckParallelContext(
-            config=self.config,
+        return OobleckPreparedContext(
             owner_plan=self,
             execution_plan=execution_plan,
             compiled=compiled,
-            partition=activated,
             device=torch.device(device),
             dtype=dtype,
-            needs_survivor_recovery=recover_from_survivors,
+            recover_from_survivors=recover_from_survivors,
         )
 
 

--- a/tests/refactor/test_control_service.py
+++ b/tests/refactor/test_control_service.py
@@ -201,7 +201,7 @@ def test_master_rejects_cross_agent_plan_disagreement():
         await first.send(
             MessageEnvelope(
                 1,
-                "generation_ready",
+                "generation_prepared",
                 "node-a",
                 "a1",
                 1,
@@ -216,7 +216,7 @@ def test_master_rejects_cross_agent_plan_disagreement():
         await second.send(
             MessageEnvelope(
                 1,
-                "generation_ready",
+                "generation_prepared",
                 "node-b",
                 "b1",
                 1,
@@ -233,6 +233,79 @@ def test_master_rejects_cross_agent_plan_disagreement():
         assert replacement.generation == 3
         assert replacement.payload["reasons"] == ["disconnect:node-b"]
         assert service.active_generation != 2
+        await first.close()
+        await second.close()
+        await service.close()
+
+    asyncio.run(check())
+
+
+def test_master_enforces_prepared_rendezvous_ready_active_order():
+    async def check():
+        from oobleck.elastic import AsyncioTcpControlTransport, MessageEnvelope
+
+        service = MasterControlService(lease_timeout_s=2, lease_check_interval_s=0.05)
+        server = await service.start("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        transport = AsyncioTcpControlTransport()
+        first = await transport.connect("127.0.0.1", port)
+        second = await transport.connect("127.0.0.1", port)
+        await first.send(
+            MessageEnvelope(
+                1,
+                "register",
+                "node-a",
+                "a1",
+                0,
+                0,
+                {"addresses": ["127.0.0.1"], "gpu_ids": ["0"]},
+            )
+        )
+        await first.receive()
+        await second.send(
+            MessageEnvelope(
+                1,
+                "register",
+                "node-b",
+                "b1",
+                0,
+                0,
+                {"addresses": ["127.0.0.1"], "gpu_ids": ["0"]},
+            )
+        )
+        first_membership = await first.receive()
+        second_membership = await second.receive()
+        assert first_membership.generation == second_membership.generation == 2
+        snapshot_hash = first_membership.payload["snapshot_hash"]
+        metadata = {
+            "snapshot_hash": snapshot_hash,
+            "plan_checksum": "same-plan",
+            "compatibility_digest": "same-runtime",
+        }
+
+        await first.send(MessageEnvelope(1, "generation_prepared", "node-a", "a1", 1, 2, metadata))
+        await asyncio.sleep(0.02)
+        assert service._rendezvous_metadata is None
+        assert service.active_generation != 2
+
+        await second.send(MessageEnvelope(1, "generation_prepared", "node-b", "b1", 1, 2, metadata))
+        first_rendezvous = await first.receive()
+        second_rendezvous = await second.receive()
+        assert first_rendezvous.message_type == "generation_rendezvous"
+        assert second_rendezvous == first_rendezvous
+        assert service.active_generation != 2
+
+        await first.send(MessageEnvelope(1, "generation_ready", "node-a", "a1", 2, 2, metadata))
+        await asyncio.sleep(0.02)
+        assert service.active_generation != 2
+
+        await second.send(MessageEnvelope(1, "generation_ready", "node-b", "b1", 2, 2, metadata))
+        first_active = await first.receive()
+        second_active = await second.receive()
+        assert first_active.message_type == "generation_active"
+        assert second_active == first_active
+        assert service.active_generation == 2
+
         await first.close()
         await second.close()
         await service.close()

--- a/tests/refactor/test_data_runtime.py
+++ b/tests/refactor/test_data_runtime.py
@@ -349,3 +349,45 @@ def test_collator_may_return_an_explicit_microbatch_list():
         [2.0, 3.0],
     ]
     ctx.close()
+
+
+def test_initial_prepare_defers_world_initialization_until_activation():
+    model = torch.nn.Linear(1, 1)
+    initialized = []
+    plan = OobleckParallelizationPlan(
+        OobleckConfig(global_batch_size=4, microbatch_size=2, max_nodes=1),
+        world_initializer=lambda execution_plan: initialized.append(execution_plan.generation),
+    )
+    plan.parallelize(model, ParallelConfig())
+
+    prepared = plan.prepare("cpu")
+    assert initialized == []
+    assert prepared.execution_plan.generation == 0
+
+    ctx = prepared.activate()
+    try:
+        assert initialized == [0]
+        assert ctx.generation == 0
+    finally:
+        ctx.close()
+
+
+def test_managed_replacement_prepares_before_rendezvous_activation():
+    _, ctx = context()
+    initialized = []
+    ctx.owner_plan.world_initializer = lambda plan: initialized.append(plan.generation)
+    newer = replace(ctx.execution_plan, generation=1, previous_generation=0, plan_checksum="")
+    ctx.enable_control_plane_barrier()
+    assert ctx.announce_generation(newer)
+
+    ctx.prepare_generation()
+    assert initialized == []
+    assert ctx.generation == 0
+    assert ctx.prepared_execution_plan.generation == 1
+    assert ctx.partition.closed
+
+    ctx.activate_generation()
+    assert initialized == [1]
+    assert ctx.generation == 1
+    ctx.mark_generation_active(1)
+    ctx.close()

--- a/tests/refactor/test_managed_distributed.py
+++ b/tests/refactor/test_managed_distributed.py
@@ -79,6 +79,7 @@ def _managed_gloo_worker(rank: int, port: int, results: Any) -> None:
         context.enable_control_plane_barrier()
         assert context.apply_membership(replacement)
         context.prepare_generation()
+        context.activate_generation()
         context.mark_generation_active(5)
         transition = context.recovery_history[-1]
         assert transition.generation == 5


### PR DESCRIPTION
## Summary
- add a pre-WORLD prepared context and preserve materialize as a compatibility wrapper
- split replacement recovery into prepare and rendezvous-gated activation phases
- enforce prepared, rendezvous, ready, and active consensus across workers, agents, and the master
- move managed initial startup behind the same barriers and cover phase ordering/supersession
- keep CI completely removed

## Validation
- python -m pytest -q tests/refactor (67 passed)
- python -m pytest -q tests/refactor/test_distributed_smoke.py tests/refactor/test_distributed_transfer.py -s (5 passed)
- cargo test --quiet (6 passed)
- ruff check .
- ruff format --check .
- pinned Cornstarch 71cf4ad one-GPU CUDA smoke