### PR TITLE
Add chaos and churn acceptance validation

### DIFF
--- a/benchmarks/chaos_acceptance.py
+++ b/benchmarks/chaos_acceptance.py
@@ -1,0 +1,395 @@
+"""Opt-in multi-node NCCL chaos and long-churn acceptance orchestrator."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.metadata
+import json
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Awaitable, Callable, Mapping, Sequence
+
+import torch
+
+from oobleck.acceptance import load_metrics, verify_churn_metrics
+from oobleck.elastic import ControlStatus, inspect_status
+
+
+@dataclass(frozen=True, slots=True)
+class ChaosEvent:
+    name: str
+    commands: tuple[tuple[str, ...], ...]
+    expected_nodes: tuple[str, ...]
+    cascade_commands: tuple[tuple[str, ...], ...] = ()
+    cascade_expected_nodes: tuple[str, ...] = ()
+    timeout_s: float = 120.0
+
+    def __post_init__(self) -> None:
+        if not self.name or not self.commands or not self.expected_nodes:
+            raise ValueError("chaos event requires a name, commands, and expected nodes")
+        if any(not command or any(not item for item in command) for command in self.commands):
+            raise ValueError("chaos commands must be non-empty argv arrays")
+        if bool(self.cascade_commands) != bool(self.cascade_expected_nodes):
+            raise ValueError("cascade commands and expected nodes must be supplied together")
+        if self.timeout_s <= 0:
+            raise ValueError("chaos event timeout must be positive")
+
+
+@dataclass(frozen=True, slots=True)
+class ChaosAcceptanceConfig:
+    master_host: str
+    master_port: int
+    initial_nodes: tuple[str, ...]
+    events: tuple[ChaosEvent, ...]
+    metric_files: tuple[Path, ...]
+    required_strategies: tuple[str, ...] = ("simple", "borrow", "merge")
+    poll_interval_s: float = 0.1
+    max_cuda_reserved_growth_bytes: int = 256 * 1024 * 1024
+    max_process_group_growth: int = 16
+    require_clean_close: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.master_host or not 1 <= self.master_port <= 65535:
+            raise ValueError("a reachable master host and port are required")
+        if not self.initial_nodes or not self.events or not self.metric_files:
+            raise ValueError("initial nodes, events, and metric files are required")
+        if (
+            self.poll_interval_s <= 0
+            or self.max_cuda_reserved_growth_bytes < 0
+            or self.max_process_group_growth < 0
+        ):
+            raise ValueError("poll interval and memory growth bound are invalid")
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> "ChaosAcceptanceConfig":
+        expected = {
+            "schema_version",
+            "master_host",
+            "master_port",
+            "initial_nodes",
+            "events",
+            "metric_files",
+            "required_strategies",
+            "poll_interval_s",
+            "max_cuda_reserved_growth_bytes",
+            "require_clean_close",
+            "max_process_group_growth",
+        }
+        if set(value) != expected or value["schema_version"] != 1:
+            raise ValueError("chaos manifest fields or schema version are invalid")
+
+        def commands(raw: object) -> tuple[tuple[str, ...], ...]:
+            if not isinstance(raw, list) or not all(
+                isinstance(item, list)
+                and item
+                and all(isinstance(part, str) and part for part in item)
+                for item in raw
+            ):
+                raise ValueError("commands must be a list of non-empty string argv arrays")
+            return tuple(tuple(str(part) for part in item) for item in raw)
+
+        def sequence(raw: object, name: str) -> list[object]:
+            if not isinstance(raw, list):
+                raise ValueError(f"{name} must be a list")
+            return raw
+
+        def strings(raw: object, name: str) -> tuple[str, ...]:
+            values = sequence(raw, name)
+            if not all(isinstance(item, str) and item for item in values):
+                raise ValueError(f"{name} must contain non-empty strings")
+            return tuple(str(item) for item in values)
+
+        def string(raw: object, name: str) -> str:
+            if not isinstance(raw, str) or not raw:
+                raise ValueError(f"{name} must be a non-empty string")
+            return raw
+
+        def integer(raw: object, name: str) -> int:
+            if not isinstance(raw, int) or isinstance(raw, bool):
+                raise ValueError(f"{name} must be an integer")
+            return raw
+
+        def number(raw: object, name: str) -> float:
+            if not isinstance(raw, (int, float)) or isinstance(raw, bool):
+                raise ValueError(f"{name} must be a number")
+            return float(raw)
+
+        def boolean(raw: object, name: str) -> bool:
+            if not isinstance(raw, bool):
+                raise ValueError(f"{name} must be a boolean")
+            return raw
+
+        raw_events = value["events"]
+        if not isinstance(raw_events, list):
+            raise ValueError("events must be a list")
+        events = []
+        for raw in raw_events:
+            if not isinstance(raw, dict) or set(raw) != {
+                "name",
+                "commands",
+                "expected_nodes",
+                "cascade_commands",
+                "cascade_expected_nodes",
+                "timeout_s",
+            }:
+                raise ValueError("chaos event fields are invalid")
+            events.append(
+                ChaosEvent(
+                    string(raw["name"], "name"),
+                    commands(raw["commands"]),
+                    tuple(str(item) for item in sequence(raw["expected_nodes"], "expected_nodes")),
+                    commands(raw["cascade_commands"]),
+                    strings(raw["cascade_expected_nodes"], "cascade_expected_nodes"),
+                    number(raw["timeout_s"], "timeout_s"),
+                )
+            )
+        return cls(
+            master_host=string(value["master_host"], "master_host"),
+            master_port=integer(value["master_port"], "master_port"),
+            initial_nodes=strings(value["initial_nodes"], "initial_nodes"),
+            events=tuple(events),
+            metric_files=tuple(
+                Path(str(item)) for item in sequence(value["metric_files"], "metric_files")
+            ),
+            required_strategies=strings(value["required_strategies"], "required_strategies"),
+            poll_interval_s=number(value["poll_interval_s"], "poll_interval_s"),
+            max_cuda_reserved_growth_bytes=integer(
+                value["max_cuda_reserved_growth_bytes"], "max_cuda_reserved_growth_bytes"
+            ),
+            max_process_group_growth=integer(
+                value["max_process_group_growth"], "max_process_group_growth"
+            ),
+            require_clean_close=boolean(value["require_clean_close"], "require_clean_close"),
+        )
+
+
+def load_config(path: str | Path) -> ChaosAcceptanceConfig:
+    value = json.loads(Path(path).read_text())
+    if not isinstance(value, dict):
+        raise ValueError("chaos manifest must be a JSON object")
+    return ChaosAcceptanceConfig.from_mapping(value)
+
+
+async def _run_commands(commands: Sequence[Sequence[str]]) -> None:
+    processes = [
+        await asyncio.create_subprocess_exec(
+            *command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        for command in commands
+    ]
+    outputs = await asyncio.gather(*(process.communicate() for process in processes))
+    failures = []
+    for command, process, (stdout, stderr) in zip(commands, processes, outputs):
+        if process.returncode:
+            failures.append(
+                {
+                    "command": list(command),
+                    "returncode": process.returncode,
+                    "stdout": stdout.decode(errors="replace"),
+                    "stderr": stderr.decode(errors="replace"),
+                }
+            )
+    if failures:
+        raise RuntimeError(f"chaos commands failed: {failures}")
+
+
+async def _wait_for_status(
+    config: ChaosAcceptanceConfig,
+    predicate: Callable[[ControlStatus], bool],
+    *,
+    timeout_s: float,
+    status_reader: Callable[[str, int], Awaitable[ControlStatus]],
+) -> ControlStatus:
+    deadline = time.monotonic() + timeout_s
+    last: ControlStatus | None = None
+    while time.monotonic() < deadline:
+        last = await status_reader(config.master_host, config.master_port)
+        if predicate(last):
+            return last
+        await asyncio.sleep(config.poll_interval_s)
+    raise TimeoutError(f"control status did not converge; last={last}")
+
+
+def _cornstarch_identity() -> tuple[str, str]:
+    try:
+        distribution = importlib.metadata.distribution("cornstarch")
+        version = distribution.version
+        direct_url = json.loads(distribution.read_text("direct_url.json") or "{}")
+        revision = str(direct_url.get("vcs_info", {}).get("commit_id", ""))
+    except importlib.metadata.PackageNotFoundError:
+        version = "source-checkout"
+        revision = ""
+    project = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    for dependency in project.read_text().splitlines():
+        marker = "Cornstarch.git@"
+        if marker in dependency:
+            declared = dependency.split(marker, 1)[1][:40]
+            if revision and revision != declared:
+                raise RuntimeError(
+                    f"installed Cornstarch {revision} does not match declared pin {declared}"
+                )
+            revision = declared
+            break
+    return version, revision or "unknown"
+
+
+def _environment(records: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        commit = "unknown"
+    cornstarch_version, cornstarch_revision = _cornstarch_identity()
+    try:
+        datasets_version = importlib.metadata.version("datasets")
+    except importlib.metadata.PackageNotFoundError:
+        datasets_version = "unavailable"
+    return {
+        "oobleck_commit": commit,
+        "cornstarch_version": cornstarch_version,
+        "cornstarch_revision": cornstarch_revision,
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "nccl_version": (
+            list(torch.cuda.nccl.version())  # pyright: ignore[reportAttributeAccessIssue]
+            if torch.cuda.is_available() and torch.distributed.is_nccl_available()
+            else None
+        ),
+        "datasets_version": datasets_version,
+        "hardware": [
+            torch.cuda.get_device_name(index) for index in range(torch.cuda.device_count())
+        ],
+        "compatibility_digests": sorted(
+            {str(record["compatibility_digest"]) for record in records}
+        ),
+        "plan_checksums": sorted({str(record["plan_checksum"]) for record in records}),
+    }
+
+
+async def run(
+    config: ChaosAcceptanceConfig,
+    *,
+    command_runner: Callable[[Sequence[Sequence[str]]], Awaitable[None]] = _run_commands,
+    status_reader: Callable[[str, int], Awaitable[ControlStatus]] = inspect_status,
+) -> dict[str, object]:
+    initial = await _wait_for_status(
+        config,
+        lambda status: (
+            status.active
+            and tuple(sorted(node.agent_id for node in status.snapshot.nodes))
+            == tuple(sorted(config.initial_nodes))
+        ),
+        timeout_s=max(event.timeout_s for event in config.events),
+        status_reader=status_reader,
+    )
+    timeline = []
+    current_generation = initial.generation
+    for event in config.events:
+        started = time.monotonic()
+        await command_runner(event.commands)
+        proposal = await _wait_for_status(
+            config,
+            lambda status: (
+                status.generation > current_generation
+                and tuple(sorted(node.agent_id for node in status.snapshot.nodes))
+                == tuple(sorted(event.expected_nodes))
+            ),
+            timeout_s=event.timeout_s,
+            status_reader=status_reader,
+        )
+        detected_seconds = time.monotonic() - started
+        target_nodes = event.expected_nodes
+        if event.cascade_commands:
+            if proposal.active:
+                raise AssertionError(
+                    f"event {event.name} activated before cascading failure was injected"
+                )
+            await command_runner(event.cascade_commands)
+            previous_generation = proposal.generation
+            proposal = await _wait_for_status(
+                config,
+                lambda status: (
+                    status.generation > previous_generation
+                    and tuple(sorted(node.agent_id for node in status.snapshot.nodes))
+                    == tuple(sorted(event.cascade_expected_nodes))
+                ),
+                timeout_s=event.timeout_s,
+                status_reader=status_reader,
+            )
+            if proposal.active_generation >= previous_generation:
+                raise AssertionError(
+                    f"event {event.name} activated its intermediate generation before cascade"
+                )
+            target_nodes = event.cascade_expected_nodes
+        active = await _wait_for_status(
+            config,
+            lambda status: (
+                status.generation == proposal.generation
+                and status.active
+                and tuple(sorted(node.agent_id for node in status.snapshot.nodes))
+                == tuple(sorted(target_nodes))
+            ),
+            timeout_s=event.timeout_s,
+            status_reader=status_reader,
+        )
+        timeline.append(
+            {
+                "name": event.name,
+                "generation": active.generation,
+                "members": list(target_nodes),
+                "detection_seconds": detected_seconds,
+                "recovery_seconds": time.monotonic() - started,
+                "cascaded": bool(event.cascade_commands),
+            }
+        )
+        current_generation = active.generation
+
+    records = load_metrics(config.metric_files)
+    verification = verify_churn_metrics(
+        records,
+        required_strategies=config.required_strategies,
+        require_replay=True,
+        require_clean_close=config.require_clean_close,
+        max_cuda_reserved_growth_bytes=config.max_cuda_reserved_growth_bytes,
+        max_process_group_growth=config.max_process_group_growth,
+    )
+    return {
+        "schema_version": 1,
+        "scenario": "multi-node-nccl-chaos-churn",
+        "initial_generation": initial.generation,
+        "final_generation": current_generation,
+        "events": timeline,
+        "verification": verification,
+        "environment": _environment(records),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="execute the manifest's explicit failure/drain/restart argv arrays",
+    )
+    arguments = parser.parse_args()
+    config = load_config(arguments.manifest)
+    if not arguments.execute:
+        raise SystemExit("refusing to execute chaos commands without --execute")
+    result = asyncio.run(run(config))
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/chaos_manifest.example.json
+++ b/benchmarks/chaos_manifest.example.json
@@ -1,0 +1,56 @@
+{
+  "schema_version": 1,
+  "master_host": "10.0.0.10",
+  "master_port": 29600,
+  "initial_nodes": ["node-a", "node-b", "node-c", "node-d", "node-e", "node-f"],
+  "events": [
+    {
+      "name": "simultaneous-cross-pipeline-failure",
+      "commands": [
+        ["ssh", "10.0.0.15", "python", "examples/fail_agent.py", "--pid", "PID_E", "--expected-node-id", "node-e", "--confirmation", "FAIL:node-e"],
+        ["ssh", "10.0.0.16", "python", "examples/fail_agent.py", "--pid", "PID_F", "--expected-node-id", "node-f", "--confirmation", "FAIL:node-f"]
+      ],
+      "expected_nodes": ["node-a", "node-b", "node-c", "node-d"],
+      "cascade_commands": [],
+      "cascade_expected_nodes": [],
+      "timeout_s": 120.0
+    },
+    {
+      "name": "failure-during-recovery",
+      "commands": [
+        ["ssh", "10.0.0.14", "python", "examples/fail_agent.py", "--pid", "PID_D", "--expected-node-id", "node-d", "--confirmation", "FAIL:node-d"]
+      ],
+      "expected_nodes": ["node-a", "node-b", "node-c"],
+      "cascade_commands": [
+        ["ssh", "10.0.0.13", "python", "examples/fail_agent.py", "--pid", "PID_C", "--expected-node-id", "node-c", "--confirmation", "FAIL:node-c"]
+      ],
+      "cascade_expected_nodes": ["node-a", "node-b"],
+      "timeout_s": 120.0
+    },
+    {
+      "name": "replacement-and-join",
+      "commands": [
+        ["ssh", "10.0.0.13", "systemd-run", "--user", "--collect", "--unit", "oobleck-node-c", "python", "examples/run_agent.py", "--node-id", "node-c", "--master-host", "10.0.0.10", "--master-port", "29600", "--gpu-ids", "0", "--addresses", "10.0.0.13", "--local-worker-socket", "/tmp/oobleck-node-c.sock", "--worker-script", "examples/pretrain_llm.py", "--worker-args", "--steps", "100000", "--metrics-output", "/shared/oobleck-{worker_id}.jsonl"],
+        ["ssh", "10.0.0.17", "systemd-run", "--user", "--collect", "--unit", "oobleck-node-g", "python", "examples/run_agent.py", "--node-id", "node-g", "--master-host", "10.0.0.10", "--master-port", "29600", "--gpu-ids", "0", "--addresses", "10.0.0.17", "--local-worker-socket", "/tmp/oobleck-node-g.sock", "--worker-script", "examples/pretrain_llm.py", "--worker-args", "--steps", "100000", "--metrics-output", "/shared/oobleck-{worker_id}.jsonl"]
+      ],
+      "expected_nodes": ["node-a", "node-b", "node-c", "node-g"],
+      "cascade_commands": [],
+      "cascade_expected_nodes": [],
+      "timeout_s": 180.0
+    }
+  ],
+  "metric_files": [
+    "/shared/oobleck-node-a-gpu-0.jsonl",
+    "/shared/oobleck-node-b-gpu-0.jsonl",
+    "/shared/oobleck-node-c-gpu-0.jsonl",
+    "/shared/oobleck-node-d-gpu-0.jsonl",
+    "/shared/oobleck-node-e-gpu-0.jsonl",
+    "/shared/oobleck-node-f-gpu-0.jsonl",
+    "/shared/oobleck-node-g-gpu-0.jsonl"
+  ],
+  "required_strategies": ["simple", "borrow", "merge"],
+  "poll_interval_s": 0.01,
+  "max_cuda_reserved_growth_bytes": 268435456,
+  "require_clean_close": false,
+  "max_process_group_growth": 32
+}

--- a/docs/chaos_acceptance.md
+++ b/docs/chaos_acceptance.md
@@ -1,0 +1,102 @@
+# Multi-node NCCL chaos and churn acceptance
+
+This is an opt-in destructive validation for dedicated machines. It is not run
+by the regular developer test commands. Use disposable agent processes, the
+exact pinned Cornstarch commit, identical per-node GPU counts, a shared metrics
+directory, and a master address reachable from every worker.
+
+## Start a long-running workload
+
+Start the master and initial agents as described in `examples/README.md`. Put
+`--worker-args` last because it forwards all remaining arguments to the training
+worker. Each worker expands `{node_id}`, `{worker_id}`, and `{pid}` in the metric
+path.
+
+```bash
+python examples/run_agent.py \
+  --node-id node-a --master-host 10.0.0.10 --master-port 29600 \
+  --gpu-ids 0 --addresses 10.0.0.11 \
+  --local-worker-socket /tmp/oobleck-node-a.sock \
+  --worker-script examples/pretrain_llm.py \
+  --worker-args --steps 100000 --step-delay-s 0.01 \
+  --metrics-output '/shared/oobleck-{worker_id}.jsonl'
+```
+
+CUDA selects NCCL automatically. Repeat this command with a stable identity and
+address for every initial node. Before injecting failures, verify that status is
+active:
+
+```python
+import asyncio
+from oobleck.elastic import inspect_status
+
+status = asyncio.run(inspect_status("10.0.0.10", 29600))
+assert status.active
+print(status.generation, [node.agent_id for node in status.snapshot.nodes])
+```
+
+## Configure and execute chaos
+
+Copy `benchmarks/chaos_manifest.example.json`, replace every address and PID,
+and adjust expected membership to the chosen template layout. Every command is
+an explicit argv array; the runner never invokes a local shell. Commands must
+return after performing or scheduling the action. The example uses `systemd-run
+--user` for replacement agents so SSH returns while the agent continues.
+
+The example covers:
+
+- two agents killed concurrently across pipelines;
+- a second failure injected after a newer membership proposal but before that
+  proposal becomes active;
+- replacement of a stable node identity and addition of a new identity;
+- required observation of simple, borrow, and merge recovery strategies.
+
+Run only after reviewing every command:
+
+```bash
+python benchmarks/chaos_acceptance.py \
+  --manifest /path/to/chaos.json \
+  --output benchmarks/results/multinode-nccl-chaos.json \
+  --execute
+```
+
+Without `--execute`, the tool refuses to run. The cascading event also fails if
+the intermediate generation becomes active before the second failure, ensuring
+that the result really exercised recovery supersession rather than two ordinary
+sequential failures.
+
+## Long-running churn and leak checks
+
+For a churn run, repeat drain/failure and replacement/join events in the
+manifest for at least 25 generation changes. Keep the workload running across
+the entire sequence. The verifier rejects:
+
+- a worker generation moving backwards;
+- skipped or duplicated committed-step metrics;
+- a run with no replayed logical batch (`attempts > 1`);
+- missing required simple/borrow/merge strategies;
+- CUDA reserved-memory growth above
+  `max_cuda_reserved_growth_bytes`;
+- process-group-count growth above `max_process_group_growth`;
+- a nonempty process-group universe on a requested clean close.
+
+Abruptly killed workers cannot emit a clean-close record, so use
+`require_clean_close: false` for failure campaigns. Use a separate graceful
+finite-step campaign with `require_clean_close: true` to verify final WORLD and
+subgroup retirement.
+
+## Result schema
+
+The output is versioned JSON containing:
+
+- initial and final membership generations;
+- per-event detection and total recovery duration;
+- whether the event cascaded before activation;
+- per-worker generation, step, replay, CUDA-memory, and process-group growth;
+- observed reconfiguration strategies;
+- Oobleck commit, Cornstarch/PyTorch/CUDA/NCCL/datasets versions, GPU model,
+  runtime compatibility digests, and generation-plan checksums.
+
+Worker JSONL records also contain the decomposed recovery timings and source
+scheduling error. Preserve the manifest, worker JSONL files, master/agent logs,
+and final result together for a reproducible paper-style run.

--- a/examples/README.md
+++ b/examples/README.md
@@ -125,9 +125,11 @@ python -m oobleck.cli inspect-membership-config \
   --master-host MASTER --master-port 29600
 ```
 
-Multi-node NCCL churn requires dedicated machines and remains a manual or
-dedicated-runner validation; the regular suite exercises multi-rank model and
-optimizer recovery on the single CUDA GPU over Gloo.
+Multi-node NCCL churn requires dedicated machines. Follow
+`docs/chaos_acceptance.md` for the opt-in manifest runner, simultaneous and
+cascading failure scenarios, long-running leak bounds, and machine-readable
+results. The regular suite exercises multi-rank model and optimizer recovery on
+the single CUDA GPU over Gloo.
 
 ## Drain, failure, replacement, and replay
 

--- a/examples/pretrain_llm.py
+++ b/examples/pretrain_llm.py
@@ -7,6 +7,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 import sys
+import time
 
 import torch
 
@@ -21,6 +22,7 @@ from examples.pretrain_llm_base import (
     configure_training,
     prepare_training,
 )
+from oobleck.acceptance import append_metric, resolve_metrics_path, runtime_metric
 from oobleck.elastic import LocalWorkerClient
 
 
@@ -34,6 +36,13 @@ class ExampleTrainingConfig:
     max_nodes: int = 16
     rendezvous_port: int = 29500
     distributed_backend: str = "auto"
+    steps: int = 1
+    step_delay_s: float = 0.0
+    metrics_output: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.steps < 1 or self.step_delay_s < 0:
+            raise ValueError("steps must be positive and step_delay_s must be non-negative")
 
 
 def _one_step(model, context, loader, selected: str, model_backend: str):
@@ -126,17 +135,53 @@ async def train_managed(config: ExampleTrainingConfig):
     context = await worker.activate_prepared(prepared, snapshot)
     model, context, loader = configure_training(model, context, dataset, device=selected)
 
+    metrics_path = (
+        None
+        if config.metrics_output is None
+        else resolve_metrics_path(config.metrics_output, node_id=node_id, worker_id=worker_id)
+    )
+
+    def record(event: str, result=None, *, step_seconds: float = 0.0) -> None:
+        if metrics_path is not None:
+            append_metric(
+                metrics_path,
+                runtime_metric(
+                    context,
+                    event=event,
+                    node_id=node_id,
+                    worker_id=worker_id,
+                    result=result,
+                    step_seconds=step_seconds,
+                ),
+            )
+
     async def prepare(snapshot) -> None:
         context.prepare_generation()
 
-    relay_task = asyncio.create_task(worker.run_context(context, on_snapshot=prepare))
+    async def activated(generation: int) -> None:
+        record("generation_active")
+
+    record("generation_active")
+    relay_task = asyncio.create_task(
+        worker.run_context(context, on_snapshot=prepare, on_active=activated)
+    )
     try:
-        return _one_step(model, context, loader, selected, config.model_backend)
+        result = None
+        for _ in range(config.steps):
+            started = time.perf_counter()
+            result = await asyncio.to_thread(
+                _one_step, model, context, loader, selected, config.model_backend
+            )
+            record("step", result, step_seconds=time.perf_counter() - started)
+            await asyncio.sleep(config.step_delay_s)
+        assert result is not None
+        return result
     finally:
         relay_task.cancel()
         await asyncio.gather(relay_task, return_exceptions=True)
         await worker.close()
         context.close()
+        record("closed")
 
 
 def main() -> None:

--- a/oobleck/acceptance.py
+++ b/oobleck/acceptance.py
@@ -1,0 +1,255 @@
+"""Machine-readable metrics and verification for dedicated chaos/churn runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+import torch
+
+
+_METRIC_LOCK = threading.Lock()
+
+
+def _metric_int(record: Mapping[str, object], field: str) -> int:
+    value = record[field]
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"metric {field} must be an integer")
+    return value
+
+
+def _metric_float(record: Mapping[str, object], field: str) -> float:
+    value = record[field]
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"metric {field} must be a number")
+    return float(value)
+
+
+def resolve_metrics_path(template: str | Path, *, node_id: str, worker_id: str) -> Path:
+    value = str(template).format(
+        node_id=node_id,
+        worker_id=worker_id.replace(":", "-"),
+        pid=os.getpid(),
+    )
+    return Path(value)
+
+
+def _process_group_count() -> int:
+    try:
+        from torch.distributed import distributed_c10d as c10d
+
+        world = getattr(c10d, "_world", None)
+        return 0 if world is None else len(world.pg_map)
+    except (ImportError, AttributeError, RuntimeError):
+        return 0
+
+
+def runtime_metric(
+    context: Any,
+    *,
+    event: str,
+    node_id: str,
+    worker_id: str,
+    result: Any = None,
+    step_seconds: float = 0.0,
+) -> dict[str, object]:
+    if not event or step_seconds < 0:
+        raise ValueError("metric event and non-negative step duration are required")
+    device = getattr(context, "device", torch.device("cpu"))
+    cuda_allocated = 0
+    cuda_reserved = 0
+    if torch.cuda.is_available() and torch.device(device).type == "cuda":
+        cuda_allocated = int(torch.cuda.memory_allocated(device))
+        cuda_reserved = int(torch.cuda.memory_reserved(device))
+    reconfiguration = getattr(context.owner_plan, "last_reconfiguration", None)
+    strategies = list(getattr(reconfiguration, "strategies", ()))
+    history = getattr(context, "recovery_history", ())
+    transition = history[-1] if history else None
+    metric: dict[str, object] = {
+        "schema_version": 1,
+        "event": event,
+        "timestamp_ns": time.time_ns(),
+        "pid": os.getpid(),
+        "node_id": node_id,
+        "worker_id": worker_id,
+        "generation": int(context.generation),
+        "committed_step": int(context.committed_step),
+        "attempts": 0 if result is None else int(result.attempts),
+        "step_seconds": step_seconds,
+        "strategies": strategies,
+        "plan_checksum": str(context.execution_plan.plan_checksum),
+        "compatibility_digest": str(context.execution_plan.compatibility_digest or ""),
+        "cuda_allocated_bytes": cuda_allocated,
+        "cuda_reserved_bytes": cuda_reserved,
+        "process_group_count": _process_group_count(),
+        "distributed_initialized": bool(
+            torch.distributed.is_available() and torch.distributed.is_initialized()
+        ),
+    }
+    if transition is not None and transition.generation == context.generation:
+        metric["recovery"] = {
+            "detection_seconds": transition.detection_seconds,
+            "configuration_planning_seconds": transition.configuration_planning_seconds,
+            "teardown_seconds": transition.teardown_seconds,
+            "state_planning_seconds": transition.state_planning_seconds,
+            "state_transfer_seconds": transition.state_transfer_seconds,
+            "straggler_round_seconds": transition.straggler_round_seconds,
+            "world_initialization_seconds": transition.world_initialization_seconds,
+            "activation_seconds": transition.activation_seconds,
+            "total_seconds": transition.total_seconds,
+            "source_scheduling_error_bytes": transition.source_scheduling_error_bytes,
+        }
+    return metric
+
+
+def append_metric(path: str | Path, metric: Mapping[str, object]) -> None:
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(dict(metric), sort_keys=True, separators=(",", ":")) + "\n"
+    with _METRIC_LOCK:
+        with destination.open("a", encoding="utf-8") as stream:
+            stream.write(payload)
+            stream.flush()
+
+
+def load_metrics(paths: Iterable[str | Path]) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for path in paths:
+        source = Path(path)
+        with source.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, 1):
+                if not line.strip():
+                    continue
+                value = json.loads(line)
+                if not isinstance(value, dict):
+                    raise ValueError(f"{source}:{line_number} metric must be a JSON object")
+                records.append(value)
+    return records
+
+
+def verify_churn_metrics(
+    records: Sequence[Mapping[str, object]],
+    *,
+    required_strategies: Sequence[str] = (),
+    require_replay: bool = True,
+    require_clean_close: bool = False,
+    max_cuda_reserved_growth_bytes: int = 256 * 1024 * 1024,
+    max_process_group_growth: int = 16,
+) -> dict[str, object]:
+    if not records:
+        raise ValueError("at least one worker metric is required")
+    if max_cuda_reserved_growth_bytes < 0 or max_process_group_growth < 0:
+        raise ValueError("memory and process-group growth bounds must be non-negative")
+    by_worker: dict[str, list[Mapping[str, object]]] = {}
+    for record in records:
+        required = {
+            "schema_version",
+            "event",
+            "timestamp_ns",
+            "worker_id",
+            "generation",
+            "committed_step",
+            "attempts",
+            "step_seconds",
+            "strategies",
+            "plan_checksum",
+            "compatibility_digest",
+            "cuda_reserved_bytes",
+            "process_group_count",
+            "distributed_initialized",
+        }
+        missing = required - set(record)
+        if missing:
+            raise ValueError(f"metric is missing fields {sorted(missing)}")
+        if record["schema_version"] != 1:
+            raise ValueError("unsupported worker metric schema")
+        by_worker.setdefault(str(record["worker_id"]), []).append(record)
+
+    observed_strategies: set[str] = set()
+    replay_count = 0
+    maximum_growth = 0
+    maximum_group_growth = 0
+    worker_summaries: dict[str, object] = {}
+    for worker_id, worker_records in sorted(by_worker.items()):
+        ordered = sorted(worker_records, key=lambda item: _metric_int(item, "timestamp_ns"))
+        generations = [_metric_int(item, "generation") for item in ordered]
+        if generations != sorted(generations):
+            raise AssertionError(f"worker {worker_id} generations moved backwards")
+        steps = [item for item in ordered if item["event"] == "step"]
+        committed = [_metric_int(item, "committed_step") for item in steps]
+        step_durations = [_metric_float(item, "step_seconds") for item in steps]
+        if any(duration < 0 for duration in step_durations):
+            raise ValueError("metric step_seconds must be non-negative")
+        if any(right != left + 1 for left, right in zip(committed, committed[1:])):
+            raise AssertionError(f"worker {worker_id} committed steps skipped or duplicated")
+        replay_count += sum(_metric_int(item, "attempts") > 1 for item in steps)
+        for item in ordered:
+            strategies = item["strategies"]
+            if not isinstance(strategies, list) or not all(
+                isinstance(strategy, str) for strategy in strategies
+            ):
+                raise ValueError("metric strategies must be a list of strings")
+            observed_strategies.update(strategies)
+        reserved = [_metric_int(item, "cuda_reserved_bytes") for item in ordered]
+        live_reserved = [
+            value for item, value in zip(ordered, reserved) if item["event"] != "closed"
+        ]
+        growth = max(0, max(live_reserved) - live_reserved[0]) if live_reserved else 0
+        maximum_growth = max(maximum_growth, growth)
+        if growth > max_cuda_reserved_growth_bytes:
+            raise AssertionError(f"worker {worker_id} CUDA reserved memory grew by {growth} bytes")
+        group_counts = [_metric_int(item, "process_group_count") for item in ordered]
+        live_group_counts = [
+            count for item, count in zip(ordered, group_counts) if item["event"] != "closed"
+        ]
+        group_growth = max(live_group_counts) - live_group_counts[0] if live_group_counts else 0
+        maximum_group_growth = max(maximum_group_growth, group_growth)
+        if group_growth > max_process_group_growth:
+            raise AssertionError(f"worker {worker_id} process-group count grew by {group_growth}")
+        closed = [item for item in ordered if item["event"] == "closed"]
+        if require_clean_close and (
+            not closed
+            or _metric_int(closed[-1], "process_group_count") != 0
+            or bool(closed[-1]["distributed_initialized"])
+        ):
+            raise AssertionError(f"worker {worker_id} did not retire all process groups")
+        worker_summaries[worker_id] = {
+            "records": len(ordered),
+            "steps": len(steps),
+            "first_generation": generations[0],
+            "last_generation": generations[-1],
+            "first_committed_step": committed[0] if committed else 0,
+            "last_committed_step": committed[-1] if committed else 0,
+            "average_step_seconds": (
+                sum(step_durations) / len(step_durations) if step_durations else 0.0
+            ),
+            "cuda_reserved_growth_bytes": growth,
+            "process_group_growth": group_growth,
+        }
+
+    missing_strategies = set(required_strategies) - observed_strategies
+    if missing_strategies:
+        raise AssertionError(f"recovery strategies were not observed: {sorted(missing_strategies)}")
+    if require_replay and replay_count == 0:
+        raise AssertionError("no interrupted logical batch was replayed")
+    return {
+        "schema_version": 1,
+        "workers": worker_summaries,
+        "observed_strategies": sorted(observed_strategies),
+        "replayed_steps": replay_count,
+        "maximum_cuda_reserved_growth_bytes": maximum_growth,
+        "maximum_process_group_growth": maximum_group_growth,
+    }
+
+
+__all__ = [
+    "append_metric",
+    "load_metrics",
+    "resolve_metrics_path",
+    "runtime_metric",
+    "verify_churn_metrics",
+]

--- a/oobleck/elastic/__init__.py
+++ b/oobleck/elastic/__init__.py
@@ -9,9 +9,11 @@ from oobleck.elastic.membership import (
 from oobleck.elastic.hostfile import InitialHost, load_initial_hostfile, ssh_agent_command
 from oobleck.elastic.local_ipc import LocalWorkerClient, LocalWorkerRelay
 from oobleck.elastic.service import (
+    ControlStatus,
     MasterControlService,
     NodeAgentClient,
     inspect_membership,
+    inspect_status,
     request_drain,
 )
 from oobleck.elastic.transport import (
@@ -30,6 +32,7 @@ from oobleck.elastic.workers import LocalWorkerSupervisor, run_agent_service
 __all__ = [
     "AsyncioTcpControlTransport",
     "ControlConnection",
+    "ControlStatus",
     "ControlTransport",
     "FrameTooLarge",
     "IncarnationMismatch",
@@ -50,6 +53,7 @@ __all__ = [
     "read_frame",
     "write_frame",
     "inspect_membership",
+    "inspect_status",
     "load_initial_hostfile",
     "request_drain",
     "run_agent_service",

--- a/oobleck/elastic/service.py
+++ b/oobleck/elastic/service.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import asyncio
 
 from oobleck.elastic.service_base import MasterControlService as _MasterControlService
-from oobleck.elastic.service_public_base import NodeAgentClient, inspect_membership, request_drain
+from oobleck.elastic.service_public_base import (
+    ControlStatus,
+    NodeAgentClient,
+    inspect_membership,
+    inspect_status,
+    request_drain,
+)
 from oobleck.elastic.transport import MessageEnvelope
 
 
@@ -20,4 +26,11 @@ class MasterControlService(_MasterControlService):
             return
 
 
-__all__ = ["MasterControlService", "NodeAgentClient", "inspect_membership", "request_drain"]
+__all__ = [
+    "ControlStatus",
+    "MasterControlService",
+    "NodeAgentClient",
+    "inspect_membership",
+    "inspect_status",
+    "request_drain",
+]

--- a/oobleck/elastic/service_base.py
+++ b/oobleck/elastic/service_base.py
@@ -97,10 +97,16 @@ class MasterControlService:
         identity: NodeIdentity | None = None
         try:
             first = await connection.receive()
-            if first.message_type == "inspect":
+            if first.message_type in {"inspect", "inspect_status"}:
                 if first.payload:
-                    raise ProtocolError("inspect payload must be empty")
-                await connection.send(self._membership_message(self.membership.snapshot()))
+                    raise ProtocolError(f"{first.message_type} payload must be empty")
+                snapshot = self.membership.snapshot()
+                reply = (
+                    self._membership_message(snapshot)
+                    if first.message_type == "inspect"
+                    else self._status_message(snapshot)
+                )
+                await connection.send(reply)
                 return
             if first.message_type == "request_drain":
                 if set(first.payload) != {"node_id"}:
@@ -300,6 +306,25 @@ class MasterControlService:
                 "nodes": [asdict(node) for node in snapshot.nodes],
                 "reasons": list(snapshot.reasons),
                 "snapshot_hash": snapshot.snapshot_hash,
+            },
+        )
+
+    def _status_message(self, snapshot: MembershipSnapshot) -> MessageEnvelope:
+        self._master_sequence += 1
+        return MessageEnvelope(
+            1,
+            "status",
+            "master",
+            "master",
+            self._master_sequence,
+            snapshot.generation,
+            {
+                "nodes": [asdict(node) for node in snapshot.nodes],
+                "reasons": list(snapshot.reasons),
+                "snapshot_hash": snapshot.snapshot_hash,
+                "active_generation": self.active_generation,
+                "prepared_agents": sorted(self._prepared_agents),
+                "ready_agents": sorted(self._ready_agents),
             },
         )
 

--- a/oobleck/elastic/service_public_base.py
+++ b/oobleck/elastic/service_public_base.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import socket
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Awaitable, Callable, Mapping, Sequence
 
@@ -22,6 +23,22 @@ from oobleck.elastic.transport import (
     ControlTransport,
     MessageEnvelope,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class ControlStatus:
+    snapshot: MembershipSnapshot
+    active_generation: int
+    prepared_agents: tuple[str, ...]
+    ready_agents: tuple[str, ...]
+
+    @property
+    def generation(self) -> int:
+        return self.snapshot.generation
+
+    @property
+    def active(self) -> bool:
+        return self.active_generation == self.snapshot.generation
 
 
 class NodeAgentClient:
@@ -393,6 +410,39 @@ async def inspect_membership(
         await connection.close()
 
 
+async def inspect_status(
+    host: str,
+    port: int,
+    *,
+    transport: ControlTransport | None = None,
+) -> ControlStatus:
+    selected = transport or AsyncioTcpControlTransport()
+    connection = await selected.connect(host, port)
+    try:
+        identity = str(uuid.uuid4())
+        await connection.send(MessageEnvelope(1, "inspect_status", "operator", identity, 0, 0, {}))
+        message = await connection.receive()
+        if message.message_type != "status":
+            raise ValueError("master returned an invalid status response")
+        payload = message.payload
+        snapshot = membership_snapshot_from_payload(
+            message.generation,
+            {
+                "nodes": payload["nodes"],
+                "reasons": payload["reasons"],
+                "snapshot_hash": payload["snapshot_hash"],
+            },
+        )
+        return ControlStatus(
+            snapshot,
+            int(payload["active_generation"]),
+            tuple(str(item) for item in payload["prepared_agents"]),
+            tuple(str(item) for item in payload["ready_agents"]),
+        )
+    finally:
+        await connection.close()
+
+
 async def request_drain(
     host: str,
     port: int,
@@ -426,8 +476,10 @@ async def request_drain(
 
 
 __all__ = [
+    "ControlStatus",
     "MasterControlService",
     "NodeAgentClient",
     "inspect_membership",
+    "inspect_status",
     "request_drain",
 ]

--- a/oobleck/elastic/transport.py
+++ b/oobleck/elastic/transport.py
@@ -30,6 +30,15 @@ _PAYLOAD_FIELDS = {
     "generation_rendezvous": {"snapshot_hash", "plan_checksum", "compatibility_digest"},
     "generation_active": {"snapshot_hash", "plan_checksum", "compatibility_digest"},
     "inspect": set(),
+    "inspect_status": set(),
+    "status": {
+        "nodes",
+        "reasons",
+        "snapshot_hash",
+        "active_generation",
+        "prepared_agents",
+        "ready_agents",
+    },
     "request_drain": {"node_id"},
     "drain_command": {"node_id"},
     "drain_accepted": {"node_id"},
@@ -61,11 +70,18 @@ def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
                 or not all(type(item) is str for item in values)
             ):
                 raise ProtocolError(f"register {field} must be a non-empty list of strings")
-    elif message_type == "membership":
+    elif message_type in {"membership", "status"}:
         if type(payload["nodes"]) is not list or type(payload["reasons"]) is not list:
-            raise ProtocolError("membership nodes and reasons must be lists")
+            raise ProtocolError(f"{message_type} nodes and reasons must be lists")
         if type(payload["snapshot_hash"]) is not str:
-            raise ProtocolError("membership snapshot_hash must be a string")
+            raise ProtocolError(f"{message_type} snapshot_hash must be a string")
+        if message_type == "status":
+            if type(payload["active_generation"]) is not int or payload["active_generation"] < 0:
+                raise ProtocolError("status active_generation must be non-negative")
+            for field in ("prepared_agents", "ready_agents"):
+                values = payload[field]
+                if type(values) is not list or not all(type(item) is str for item in values):
+                    raise ProtocolError(f"status {field} must be a list of strings")
     elif message_type in {
         "generation_prepared",
         "generation_ready",

--- a/oobleck/runtime.py
+++ b/oobleck/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Iterable
@@ -68,6 +69,7 @@ def _init_with_recovery(self: OobleckParallelContext, *args: Any, **kwargs: Any)
     self.recovery_history: list[GenerationTransitionMetrics] = []
     self._generation_control_metrics: dict[int, tuple[float, float]] = {}
     self._prepared_transition: _PreparedGenerationTransition | None = None
+    self._generation_condition = threading.Condition()
     self._heterogeneous_gradient_sync = (
         None
         if self._needs_survivor_recovery
@@ -363,23 +365,37 @@ def _prepared_execution_plan(self: OobleckParallelContext) -> Any:
     return self.execution_plan if transition is None else transition.target
 
 
+def _generation_transition_pending(self: OobleckParallelContext) -> bool:
+    return self._control_plane_managed and (
+        self._pending_plan is not None
+        or self._prepared_transition is not None
+        or self._control_active_generation != self.generation
+    )
+
+
+def _wait_for_generation_barrier(self: OobleckParallelContext) -> None:
+    deadline = time.monotonic() + self.config.rendezvous_timeout_s
+    with self._generation_condition:
+        while _generation_transition_pending(self):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("timed out waiting for generation_active")
+            self._generation_condition.wait(timeout=remaining)
+
+
 def _mark_generation_active(self: OobleckParallelContext, generation: int) -> None:
     if generation != self.generation:
         raise RuntimeError(
             f"cannot activate generation {generation}; prepared generation is {self.generation}"
         )
     self._control_active_generation = generation
+    with self._generation_condition:
+        self._generation_condition.notify_all()
 
 
 def _step_with_control_barrier(self: OobleckParallelContext, *args: Any, **kwargs: Any) -> Any:
-    if self._control_plane_managed and (
-        self._pending_plan is not None
-        or self._prepared_transition is not None
-        or self._control_active_generation != self.generation
-    ):
-        raise RuntimeError(
-            "generation is prepared but not active through the CPU control-plane barrier"
-        )
+    if _generation_transition_pending(self):
+        _wait_for_generation_barrier(self)
     return _base_step(self, *args, **kwargs)
 
 
@@ -415,6 +431,8 @@ OobleckParallelContext.enable_control_plane_barrier = _enable_control_plane_barr
 OobleckParallelContext.prepare_generation = _prepare_generation
 OobleckParallelContext.activate_generation = _activate_generation
 OobleckParallelContext.prepared_execution_plan = property(_prepared_execution_plan)
+OobleckParallelContext._generation_transition_pending = _generation_transition_pending
+OobleckParallelContext._wait_for_generation_barrier = _wait_for_generation_barrier
 OobleckParallelContext.mark_generation_active = _mark_generation_active
 OobleckParallelContext.step = _step_with_control_barrier
 OobleckParallelContext.recover_from_survivors = _recover_from_survivors

--- a/oobleck/runtime_base.py
+++ b/oobleck/runtime_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import threading
 from dataclasses import dataclass, replace
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
@@ -374,6 +375,7 @@ class OobleckParallelContext:
         self._loaders: list[PreparedDataLoader] = []
         self._closed = False
         self._needs_survivor_recovery = needs_survivor_recovery
+        self._commit_lock = threading.RLock()
 
     @property
     def model(self) -> torch.nn.Module:
@@ -419,11 +421,12 @@ class OobleckParallelContext:
         self.scaler = scaler
 
     def announce_generation(self, plan: OobleckExecutionPlan) -> bool:
-        if plan.generation <= self.generation:
-            return False
-        if self._pending_plan is None or plan.generation > self._pending_plan.generation:
-            self._pending_plan = plan
-        return True
+        with self._commit_lock:
+            if plan.generation <= self.generation:
+                return False
+            if self._pending_plan is None or plan.generation > self._pending_plan.generation:
+                self._pending_plan = plan
+            return True
 
     def _activate_latest_generation(self) -> None:
         while self._pending_plan is not None:
@@ -527,38 +530,73 @@ class OobleckParallelContext:
             raise RuntimeError("context is closed")
         if self.optimizer is None:
             raise RuntimeError("call configure_optimization() before step()")
+
+        transition_pending = getattr(self, "_generation_transition_pending", None)
+        wait_for_generation = getattr(self, "_wait_for_generation_barrier", None)
+
+        def managed_transition_pending() -> bool:
+            return callable(transition_pending) and bool(transition_pending())
+
+        def wait_if_managed() -> None:
+            if managed_transition_pending():
+                if not callable(wait_for_generation):
+                    raise RuntimeError("managed generation has no control-plane waiter")
+                wait_for_generation()
+
         attempts = 0
         while True:
+            wait_if_managed()
             attempts += 1
             if self._pending_plan is not None:
                 self._activate_latest_generation()
+            attempt_generation = self.generation
             self.optimizer.zero_grad(set_to_none=True)
-            loss, result = self._execute_attempt(batch, execution_plan, output, criterion)
-            sync = getattr(self.partition.external_context, "sync_gradients", None)
-            if callable(sync):
-                sync()
-            heterogeneous_sync = getattr(self, "_heterogeneous_gradient_sync", None)
-            if heterogeneous_sync is not None:
-                heterogeneous_sync.sync()
-            if self._pending_plan is not None:
+            try:
+                loss, result = self._execute_attempt(batch, execution_plan, output, criterion)
+                sync = getattr(self.partition.external_context, "sync_gradients", None)
+                if callable(sync):
+                    sync()
+                heterogeneous_sync = getattr(self, "_heterogeneous_gradient_sync", None)
+                if heterogeneous_sync is not None:
+                    heterogeneous_sync.sync()
+            except Exception:
+                if self.generation == attempt_generation and not managed_transition_pending():
+                    raise
                 self.optimizer.zero_grad(set_to_none=True)
-                self._activate_latest_generation()
+                wait_if_managed()
                 continue
-            if self.scaler is not None:
-                self.scaler.step(self.optimizer)
-                self.scaler.update()
-            else:
-                self.optimizer.step()
-            if self.scheduler is not None:
-                self.scheduler.step()
-            self.committed_step += 1
-            for loader in self._loaders:
+
+            retry = False
+            with self._commit_lock:
                 if (
-                    loader.sampler.descriptor_at(loader.sampler.committed_cursor)
-                    == batch.descriptor
+                    self.generation != attempt_generation
+                    or self._pending_plan is not None
+                    or managed_transition_pending()
                 ):
-                    loader.sampler.commit(batch.descriptor)
-                    break
+                    retry = True
+                else:
+                    if self.scaler is not None:
+                        self.scaler.step(self.optimizer)
+                        self.scaler.update()
+                    else:
+                        self.optimizer.step()
+                    if self.scheduler is not None:
+                        self.scheduler.step()
+                    self.committed_step += 1
+                    for loader in self._loaders:
+                        if (
+                            loader.sampler.descriptor_at(loader.sampler.committed_cursor)
+                            == batch.descriptor
+                        ):
+                            loader.sampler.commit(batch.descriptor)
+                            break
+            if retry:
+                self.optimizer.zero_grad(set_to_none=True)
+                if managed_transition_pending():
+                    wait_if_managed()
+                elif self._pending_plan is not None:
+                    self._activate_latest_generation()
+                continue
             return OobleckStepResult(
                 True,
                 self.committed_step,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ include = [
     "oobleck/types.py",
     "oobleck/data.py",
     "oobleck/data_base.py",
+    "oobleck/acceptance.py",
     "oobleck/state_base.py",
     "oobleck/state_transfer.py",
     "oobleck/planning",

--- a/tests/refactor/test_acceptance.py
+++ b/tests/refactor/test_acceptance.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from benchmarks.chaos_acceptance import ChaosAcceptanceConfig, ChaosEvent, run
+
+from oobleck.acceptance import append_metric, load_metrics, verify_churn_metrics
+from oobleck.elastic import ControlStatus, MembershipSnapshot, NodeIdentity
+
+
+def metric(
+    timestamp: int,
+    *,
+    event: str = "step",
+    generation: int = 1,
+    step: int = 1,
+    attempts: int = 1,
+    strategies: list[str] | None = None,
+    reserved: int = 100,
+    groups: int = 1,
+    initialized: bool = True,
+):
+    return {
+        "schema_version": 1,
+        "event": event,
+        "timestamp_ns": timestamp,
+        "worker_id": "node-a:gpu-0",
+        "generation": generation,
+        "committed_step": step,
+        "attempts": attempts,
+        "step_seconds": 0.1,
+        "strategies": strategies or [],
+        "plan_checksum": f"plan-{generation}",
+        "compatibility_digest": "runtime",
+        "cuda_reserved_bytes": reserved,
+        "process_group_count": groups,
+        "distributed_initialized": initialized,
+    }
+
+
+def test_churn_verifier_proves_replay_strategies_memory_and_clean_close(tmp_path):
+    records = [
+        metric(1, step=1),
+        metric(2, generation=2, step=2, attempts=2, strategies=["simple"]),
+        metric(3, generation=3, step=3, strategies=["borrow", "merge"], reserved=120),
+        metric(
+            4,
+            event="closed",
+            generation=3,
+            step=3,
+            reserved=120,
+            groups=0,
+            initialized=False,
+        ),
+    ]
+    path = tmp_path / "worker.jsonl"
+    for record in records:
+        append_metric(path, record)
+    observed = load_metrics([path])
+    result = verify_churn_metrics(
+        observed,
+        required_strategies=("simple", "borrow", "merge"),
+        require_clean_close=True,
+        max_cuda_reserved_growth_bytes=20,
+    )
+    assert result["replayed_steps"] == 1
+    assert result["observed_strategies"] == ["borrow", "merge", "simple"]
+    assert result["maximum_cuda_reserved_growth_bytes"] == 20
+
+
+def test_churn_verifier_rejects_commit_gaps_memory_growth_and_group_leaks():
+    with pytest.raises(AssertionError, match="skipped or duplicated"):
+        verify_churn_metrics(
+            [metric(1, step=1), metric(2, step=3, attempts=2)],
+            require_replay=False,
+        )
+    with pytest.raises(AssertionError, match="CUDA reserved memory"):
+        verify_churn_metrics(
+            [metric(1, step=1), metric(2, step=2, attempts=2, reserved=200)],
+            max_cuda_reserved_growth_bytes=10,
+        )
+    with pytest.raises(AssertionError, match="process-group count"):
+        verify_churn_metrics(
+            [metric(1, step=1, groups=1), metric(2, step=2, groups=4)],
+            require_replay=False,
+            max_process_group_growth=2,
+        )
+    with pytest.raises(AssertionError, match="retire all process groups"):
+        verify_churn_metrics(
+            [metric(1, step=1, attempts=2), metric(2, event="closed", groups=1)],
+            require_clean_close=True,
+        )
+
+
+def test_churn_verifier_handles_twenty_five_generation_campaign():
+    records = [
+        metric(
+            generation,
+            generation=generation,
+            step=generation,
+            attempts=2 if generation == 2 else 1,
+        )
+        for generation in range(1, 26)
+    ]
+    result = verify_churn_metrics(records)
+    assert result["workers"]["node-a:gpu-0"]["records"] == 25
+    assert result["workers"]["node-a:gpu-0"]["last_generation"] == 25
+
+
+def test_chaos_runner_injects_cascade_before_activation_and_verifies_metrics(tmp_path):
+    def status(
+        generation: int,
+        nodes: tuple[str, ...],
+        active: bool,
+        active_generation: int | None = None,
+    ) -> ControlStatus:
+        snapshot = MembershipSnapshot(
+            generation,
+            tuple(
+                NodeIdentity(node, f"{node}-{generation}", ("127.0.0.1",), ("0",)) for node in nodes
+            ),
+            (),
+        )
+        agents = nodes if active else ()
+        if active_generation is None:
+            active_generation = generation if active else generation - 1
+        return ControlStatus(snapshot, active_generation, agents, agents)
+
+    statuses = [
+        status(1, ("a", "b", "c", "d"), True),
+        status(2, ("a", "b", "c"), False),
+        status(3, ("a", "b"), False, 1),
+        status(3, ("a", "b"), True),
+    ]
+
+    async def read_status(host: str, port: int) -> ControlStatus:
+        return statuses.pop(0)
+
+    commands = []
+
+    async def run_commands(argv):
+        commands.append(tuple(tuple(item) for item in argv))
+
+    metrics_path = tmp_path / "metrics.jsonl"
+    for record in (
+        metric(1, step=1),
+        metric(2, generation=3, step=2, attempts=2, strategies=["simple", "borrow", "merge"]),
+    ):
+        append_metric(metrics_path, record)
+    config = ChaosAcceptanceConfig(
+        "master",
+        29600,
+        ("a", "b", "c", "d"),
+        (
+            ChaosEvent(
+                "cascading-failure",
+                (("kill", "d"),),
+                ("a", "b", "c"),
+                (("kill", "c"),),
+                ("a", "b"),
+                1.0,
+            ),
+        ),
+        (metrics_path,),
+        poll_interval_s=0.001,
+    )
+    result = asyncio.run(run(config, command_runner=run_commands, status_reader=read_status))
+    assert commands == [(("kill", "d"),), (("kill", "c"),)]
+    assert result["initial_generation"] == 1
+    assert result["final_generation"] == 3
+    assert result["events"][0]["cascaded"] is True
+    assert result["verification"]["replayed_steps"] == 1

--- a/tests/refactor/test_control_service.py
+++ b/tests/refactor/test_control_service.py
@@ -7,6 +7,7 @@ from oobleck.elastic import (
     MasterControlService,
     NodeAgentClient,
     inspect_membership,
+    inspect_status,
     request_drain,
 )
 
@@ -308,6 +309,31 @@ def test_master_enforces_prepared_rendezvous_ready_active_order():
 
         await first.close()
         await second.close()
+        await service.close()
+
+    asyncio.run(check())
+
+
+def test_status_reports_prepared_ready_and_active_generation():
+    async def check():
+        service = MasterControlService(lease_timeout_s=2, lease_check_interval_s=0.02)
+        server = await service.start("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        client = NodeAgentClient("node-a", ("0",), heartbeat_interval_s=0.01)
+        await client.connect("127.0.0.1", port)
+        task = asyncio.create_task(client.run())
+        for _ in range(100):
+            status = await inspect_status("127.0.0.1", port)
+            if status.active:
+                break
+            await asyncio.sleep(0.01)
+        assert status.generation == 1
+        assert status.active_generation == 1
+        assert status.prepared_agents == ("node-a",)
+        assert status.ready_agents == ("node-a",)
+        await client.close()
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
         await service.close()
 
     asyncio.run(check())

--- a/tests/refactor/test_data_runtime.py
+++ b/tests/refactor/test_data_runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 
 import pytest
+import threading
 import torch
 from torch.utils.data import DataLoader, Dataset, IterableDataset
 
@@ -390,4 +391,54 @@ def test_managed_replacement_prepares_before_rendezvous_activation():
     assert initialized == [1]
     assert ctx.generation == 1
     ctx.mark_generation_active(1)
+    ctx.close()
+
+
+def test_concurrent_membership_replays_inflight_managed_step_after_active_barrier():
+    model, ctx = context()
+    dataset = Samples()
+    sampler = ctx.create_batch_sampler(dataset, shuffle=False)
+    loader = ctx.prepare_dataloader(DataLoader(dataset, batch_sampler=sampler))
+    ctx.configure_optimization(
+        optimizer_factory=lambda parameters: torch.optim.SGD(parameters, lr=0.01)
+    )
+    ctx.enable_control_plane_barrier()
+    batch = next(iter(loader))
+    newer = replace(ctx.execution_plan, generation=1, previous_generation=0, plan_checksum="")
+    announced = threading.Event()
+    result = []
+    errors = []
+    first_attempt = True
+
+    def criterion(output, microbatch):
+        nonlocal first_attempt
+        if first_attempt:
+            first_attempt = False
+            assert ctx.announce_generation(newer)
+            announced.set()
+        return ((output - microbatch["y"]) ** 2).mean()
+
+    def train():
+        try:
+            result.append(ctx.step(batch, lambda item: model(item["x"]), criterion=criterion))
+        except BaseException as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=train)
+    worker.start()
+    assert announced.wait(timeout=5)
+    ctx.prepare_generation()
+    assert worker.is_alive()
+    ctx.activate_generation()
+    assert worker.is_alive()
+    ctx.mark_generation_active(1)
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert errors == []
+    assert len(result) == 1
+    assert result[0].attempts == 2
+    assert result[0].committed_step == 1
+    assert result[0].generation == 1
+    assert sampler.committed_cursor == 1
     ctx.close()


### PR DESCRIPTION
## Summary
- make managed training steps concurrently interruptible and generation-barrier safe
- add a destructive multi-node NCCL chaos/churn runner with simultaneous and cascading failures
- emit and verify machine-readable replay, strategy, timing, CUDA-memory, and process-group metrics
- document dedicated deployment and 25-generation churn validation

## Local validation
- 73 refactor Python tests
- 6 Rust tests
- 6 CUDA/Gloo distributed tests
- one-node managed deployment with verified JSONL metrics
- one-GPU Cornstarch execution-future smoke at 71cf4ad681cfefdbf4a5b61d524af9033bebd055
- Ruff formatting/lint and Pyright

No hosted CI or GitHub workflow is added; validation remains developer-run and repository-local.

The real multi-node NCCL campaign remains pending access to dedicated multi-node hardware.