### PR TITLE
Refactor pipeline planner around Oobleck Section 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,198 +3,16 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "anstream"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
-
-[[package]]
-name = "anstyle-parse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
- "rayon",
-]
-
-[[package]]
-name = "defmt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
-dependencies = [
- "defmt-parser",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror",
-]
-
-[[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "env_filter"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -212,79 +30,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itoa"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184d09547b80eb7e20d141ba2fb1fbac843ca53f4cf1b31210adc4c1adc6e16"
-dependencies = [
- "defmt",
- "jiff-core",
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
-dependencies = [
- "defmt",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323da076b7a6faf914dc677cb05a4b907742ff7375c8322c9e7f5061e5e0e9de"
-dependencies = [
- "jiff-core",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "memchr"
-version = "2.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -302,36 +51,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "oobleck"
 version = "0.1.1"
 dependencies = [
- "dashmap",
- "env_logger",
- "log",
  "pyo3",
  "pyo3-build-config",
- "rayon",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
 ]
 
 [[package]]
@@ -339,15 +63,6 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -405,7 +120,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -418,7 +133,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.119",
+ "syn",
 ]
 
 [[package]]
@@ -431,123 +146,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.1",
-]
-
-[[package]]
-name = "regex"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
 name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "serde"
-version = "1.0.229"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
-dependencies = [
- "serde_core",
- "serde_derive",
-]
-
-[[package]]
-name = "serde_core"
-version = "1.0.229"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.229"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.151"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "syn"
@@ -561,41 +163,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
-name = "thiserror"
-version = "2.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
-]
 
 [[package]]
 name = "unicode-ident"
@@ -608,30 +179,3 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "zmij"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,6 @@ edition = "2021"
 
 [dependencies]
 pyo3 = { version = "0.24.1", features = ["extension-module"] }
-dashmap = { version = "5.5", features = ["rayon"] }
-rayon = "=1.10.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-log = "0.4"
-env_logger = "0.11"
 
 [lib]
 name = "planner"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ active intermediate layer, `state_public_base.py`.
 | --- | --- |
 | [`__init__.py`](oobleck/planning/__init__.py) | Re-exports the supported profiling, template, composition, and reconfiguration API. |
 | [`profiler.py`](oobleck/planning/profiler.py) | Measures model layers with a model-agnostic workload and records versioned execution/memory profiles. |
-| [`generator.py`](oobleck/planning/generator.py) | Narrow binding around the Rust template generator with deterministic Python partitioning fallback. |
+| [`generator.py`](oobleck/planning/generator.py) | Narrow binding around the exact Rust minimax template generator with an equivalent deterministic Python fallback; see [`docs/pipeline_planner.md`](docs/pipeline_planner.md). |
 | [`planner.pyi`](oobleck/planning/planner.pyi) | Type stub for the compiled Rust `create_pipeline_templates` extension. |
 | [`cache.py`](oobleck/planning/cache.py) | Saves and loads versioned templates while validating schema and compatibility fingerprints. |
 | [`composer.py`](oobleck/planning/composer.py) | Selects a deterministic heterogeneous template composition, maps it to nodes, allocates global microbatches, and computes gradient sample weights. |
@@ -136,6 +136,7 @@ pytest -q
 cargo test
 python examples/run_local.py
 python benchmarks/recovery_schedule.py
+python benchmarks/pipeline_planner.py
 python benchmarks/transaction_overhead.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ active intermediate layer, `state_public_base.py`.
 | --- | --- |
 | [`__init__.py`](oobleck/planning/__init__.py) | Re-exports the supported profiling, template, composition, and reconfiguration API. |
 | [`profiler.py`](oobleck/planning/profiler.py) | Measures model layers with a model-agnostic workload and records versioned execution/memory profiles. |
-| [`generator.py`](oobleck/planning/generator.py) | Narrow binding around the exact Rust minimax template generator with an equivalent deterministic Python fallback; see [`docs/pipeline_planner.md`](docs/pipeline_planner.md). |
+| [`generator.py`](oobleck/planning/generator.py) | Narrow binding around the Rust implementation of the Section 4.1.2 T1/T2/T3 template planner with an equivalent deterministic Python fallback; see [`docs/pipeline_planner.md`](docs/pipeline_planner.md). |
 | [`planner.pyi`](oobleck/planning/planner.pyi) | Type stub for the compiled Rust `create_pipeline_templates` extension. |
 | [`cache.py`](oobleck/planning/cache.py) | Saves and loads versioned templates while validating schema and compatibility fingerprints. |
 | [`composer.py`](oobleck/planning/composer.py) | Selects a deterministic heterogeneous template composition, maps it to nodes, allocates global microbatches, and computes gradient sample weights. |

--- a/benchmarks/pipeline_planner.py
+++ b/benchmarks/pipeline_planner.py
@@ -1,0 +1,82 @@
+"""Machine-readable Rust/Python pipeline planner benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from statistics import mean
+
+from oobleck.planning import LayerExecutionResult, create_pipeline_templates
+from oobleck.planning.generator import _create_python_templates
+
+
+def run(*, layers: int = 96, max_resources: int = 64, repeats: int = 3) -> dict[str, object]:
+    if layers < 1 or max_resources < 1 or max_resources > layers or repeats < 1:
+        raise ValueError("layers, resources, and repeats must be positive with resources <= layers")
+    profile = tuple(
+        LayerExecutionResult(
+            index,
+            f"layer.{index}",
+            (index % 13 + 1) / 1000,
+            (index % 7 + 1) / 1000,
+            1024,
+            768,
+            256,
+        )
+        for index in range(layers)
+    )
+    resource_counts = tuple(range(1, max_resources + 1))
+    rust_seconds = []
+    python_seconds = []
+    rust_templates = {}
+    python_templates = {}
+    for _ in range(repeats):
+        started = time.perf_counter()
+        rust_templates = create_pipeline_templates("benchmark", profile, resource_counts)
+        rust_seconds.append(time.perf_counter() - started)
+
+        started = time.perf_counter()
+        python_templates = _create_python_templates(
+            "benchmark", profile, resource_counts, 1, None, None
+        )
+        python_seconds.append(time.perf_counter() - started)
+
+    rust_average = mean(rust_seconds)
+    python_average = mean(python_seconds)
+    return {
+        "schema_version": 1,
+        "scenario": {
+            "layers": layers,
+            "max_resources": max_resources,
+            "template_count": len(resource_counts),
+            "repeats": repeats,
+        },
+        "backends_match": rust_templates == python_templates,
+        "rust_seconds": rust_average,
+        "python_seconds": python_average,
+        "rust_speedup": python_average / rust_average if rust_average else None,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--layers", type=int, default=96)
+    parser.add_argument("--max-resources", type=int, default=64)
+    parser.add_argument("--repeats", type=int, default=3)
+    arguments = parser.parse_args()
+    print(
+        json.dumps(
+            run(
+                layers=arguments.layers,
+                max_resources=arguments.max_resources,
+                repeats=arguments.repeats,
+            ),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/pipeline_planner.md
+++ b/docs/pipeline_planner.md
@@ -1,0 +1,50 @@
+# Pipeline planner boundary
+
+Oobleck owns offline profiling, pipeline-template generation, heterogeneous
+composition, and elastic reconfiguration. The compiled Rust extension is a
+narrow accelerator for **template partitioning only**; it does not choose
+membership, compose replicas, allocate the global batch, or initialize a
+distributed runtime.
+
+## Supported planning model
+
+The refactor release uses a fixed tensor-parallel width per node. One template
+resource corresponds to one pipeline stage backed by one node, so a template
+for `n` resources contains exactly `n` non-empty contiguous global layer
+ranges. This is intentionally narrower than the variable GPU-to-stage mapping
+in Section 4.1.2 of the Oobleck paper.
+
+For every requested resource count, both the Rust backend and Python fallback
+minimize the maximum per-stage `forward + backward` profile time. This minimax
+objective is the steady-state coefficient used by `PipelineTemplate.iteration_time`.
+Equal-cost layouts use the lexicographically smallest stage-start vector, which
+makes generated ownership deterministic across processes and backends.
+
+If device memory is supplied, a candidate stage is feasible only when its
+persistent state plus one microbatch of activation memory fits. The generated
+template records the minimum per-stage microbatch capacity. Composition later
+honors that capacity when assigning the fixed global batch.
+
+## Python/Rust API
+
+`oobleck.planning.generator.create_pipeline_templates` is the supported API.
+It validates the versioned Python profile, calls
+`oobleck.planning.planner.create_pipeline_templates` when the extension is
+installed, and otherwise executes the equivalent Python dynamic program. Both
+backends return the same serialized `PipelineTemplate` fields and layer ranges.
+
+The Rust extension accepts only plain profile records and scalar configuration;
+it never imports Cornstarch, PyTorch distributed state, or legacy ColossalAI
+objects. Invalid inputs and infeasible layouts raise `ValueError` from the supported
+Python API. Direct extension callers receive `RuntimeError` for an infeasible
+layout, preserving a distinct native error category.
+
+## Algorithm and complexity
+
+Prefix sums make every contiguous stage metric an O(1) lookup. The dynamic
+program stores the best partition for each `(stage_count, prefix_length)` and
+examines every final cut, giving O(S L²) candidate evaluations for `L` layers
+and at most `S` stages. Backpointers are represented by the stable stage-start
+vector because template generation is offline and model layer counts are
+small; this keeps tie-breaking auditable without concurrent hash maps or
+schedule-dependent reductions.

--- a/docs/pipeline_planner.md
+++ b/docs/pipeline_planner.md
@@ -1,50 +1,94 @@
-# Pipeline planner boundary
+# Pipeline planner and paper traceability
 
 Oobleck owns offline profiling, pipeline-template generation, heterogeneous
-composition, and elastic reconfiguration. The compiled Rust extension is a
-narrow accelerator for **template partitioning only**; it does not choose
-membership, compose replicas, allocate the global batch, or initialize a
-distributed runtime.
+composition, and elastic reconfiguration. The compiled Rust extension implements
+the GPU--stage mapping cost model from Section 4.1.2 of the Oobleck paper. It does
+not choose the template node specifications from Section 4.1.1 or compose
+pipeline replicas from Section 4.2; those are separate planning layers.
 
-## Supported planning model
+## Refactored runtime specialization
 
-The refactor release uses a fixed tensor-parallel width per node. One template
-resource corresponds to one pipeline stage backed by one node, so a template
-for `n` resources contains exactly `n` non-empty contiguous global layer
-ranges. This is intentionally narrower than the variable GPU-to-stage mapping
-in Section 4.1.2 of the Oobleck paper.
+The paper state is `T(S, u, v, d)`: layers `[u, v)` are partitioned into `S`
+stages running on `d` GPUs. It also searches a GPU split `m` because several
+stages may split the GPUs within one node.
 
-For every requested resource count, both the Rust backend and Python fallback
-minimize the maximum per-stage `forward + backward` profile time. This minimax
-objective is the steady-state coefficient used by `PipelineTemplate.iteration_time`.
-Equal-cost layouts use the lexicographically smallest stage-start vector, which
-makes generated ownership deterministic across processes and backends.
+The refactored Cornstarch runtime deliberately fixes tensor parallelism to one
+complete node. A planner resource is therefore an indivisible fixed-TP logical
+device, one resource is assigned to each stage, and:
 
-If device memory is supplied, a candidate stage is feasible only when its
-persistent state plus one microbatch of activation memory fits. The generated
-template records the minimum per-stage microbatch capacity. Composition later
-honors that capacity when assigning the fixed global batch.
+```text
+S = d = number of nodes in the template
+```
+
+This is the `S = n` endpoint of the paper's search. It preserves the paper's
+layer-partition and timing algorithm, but does not search `S > n` or `m` because
+the current runtime cannot instantiate variable-TP stages sharing one node.
+`tensor_parallel_size` records the width of each logical device; it is not a
+search dimension.
+
+## Equations 1--4 in the implementation
+
+For stage `i`, let `w_i = F_i + B_i`. The implementation selects the rightmost
+slowest stage `k*`, matching the published artifact, and evaluates:
+
+```text
+T1 = sum(w_i)
+T2 = (Nb - S + k* - 1) * w_k*
+T3 = sum(w_i for i from k* through S - 1)
+T  = T1 + T2 + T3
+```
+
+As specified in Section 4.1.2, template generation temporarily sets `Nb = 4S`.
+Generated `PipelineTemplate` objects serialize `paper_t1`, `paper_t3`, and
+`paper_bottleneck_stage`, so heterogeneous composition evaluates the same model
+for its concrete microbatch allocation instead of switching to a minimax
+surrogate.
+
+## Exact optimized search
+
+The old divide-and-conquer cache retained one locally best result for each
+subproblem. That is unsafe: whether a subplan is best after composition depends
+on `k*` and `T3`, not only its local total time.
+
+The refactor evaluates the same paper objective without discarding that state.
+For every possible bottleneck layer range `[a, b)` with latency `B`:
+
+1. preceding stages may have latency at most `B`;
+2. following stages must have latency strictly less than `B`, because `k*` is
+   the rightmost bottleneck;
+3. `T3` is the work of the complete layer suffix `[a, L)`; and
+4. Equation 2 determines the cost for every feasible bottleneck position.
+
+Because latency and memory are non-negative and additive, greedily taking the
+longest feasible stage gives the minimum number of stages needed on either side
+of a candidate bottleneck. Any larger feasible count is obtained by splitting
+stages. The planner caches these bounds once, scans them for every requested
+resource count, and reconstructs the lexicographically smallest equal-cost
+partition.
+
+Prefix sums make every stage latency and memory query constant time. Building
+all bottleneck feasibility summaries takes `O(L^3)` time; selecting templates up
+to `S` resources takes `O(S L^2)` additional candidate checks. The `O(L^2)`
+stage table and bottleneck summaries are shared by every template generated in
+the call.
+
+## Memory and deterministic output
+
+A stage is feasible only when its persistent state plus one microbatch of
+activation memory fits the supplied device capacity. The final template records
+the minimum per-stage microbatch capacity, and composition rejects larger batch
+allocations.
+
+Equal paper iteration times use the lexicographically smallest stage-start
+vector. Rust and the Python oracle implement the same rule and return identical
+serialized templates.
 
 ## Python/Rust API
 
-`oobleck.planning.generator.create_pipeline_templates` is the supported API.
-It validates the versioned Python profile, calls
-`oobleck.planning.planner.create_pipeline_templates` when the extension is
-installed, and otherwise executes the equivalent Python dynamic program. Both
-backends return the same serialized `PipelineTemplate` fields and layer ranges.
-
-The Rust extension accepts only plain profile records and scalar configuration;
-it never imports Cornstarch, PyTorch distributed state, or legacy ColossalAI
-objects. Invalid inputs and infeasible layouts raise `ValueError` from the supported
-Python API. Direct extension callers receive `RuntimeError` for an infeasible
-layout, preserving a distinct native error category.
-
-## Algorithm and complexity
-
-Prefix sums make every contiguous stage metric an O(1) lookup. The dynamic
-program stores the best partition for each `(stage_count, prefix_length)` and
-examines every final cut, giving O(S L²) candidate evaluations for `L` layers
-and at most `S` stages. Backpointers are represented by the stable stage-start
-vector because template generation is offline and model layer counts are
-small; this keeps tie-breaking auditable without concurrent hash maps or
-schedule-dependent reductions.
+`oobleck.planning.generator.create_pipeline_templates` is the supported API. It
+validates the versioned profile, calls the Rust extension when installed, and
+otherwise runs the equivalent Python implementation. Rust accepts only plain
+profile records and scalar configuration; it does not import Cornstarch or
+PyTorch distributed state. Invalid inputs and infeasible layouts become
+`ValueError` through the supported API, while direct extension calls preserve a
+separate `RuntimeError` for infeasible planning.

--- a/oobleck/planning/generator.py
+++ b/oobleck/planning/generator.py
@@ -1,8 +1,9 @@
-"""Narrow Python planner API with equivalent Rust and Python backends."""
+"""Paper-traceable Python planner API with equivalent Rust and Python backends."""
 
 from __future__ import annotations
 
 import math
+from dataclasses import dataclass
 from typing import Sequence
 
 from oobleck.planning.profiler import LayerExecutionResult
@@ -15,6 +16,15 @@ def _effective_activation_memory(layer: LayerExecutionResult) -> int:
     return layer.mem_required
 
 
+def _sequential_sum(values: Sequence[float]) -> float:
+    """Match Rust's left-associated f64 accumulation (Python 3.12 sum is compensated)."""
+
+    result = 0.0
+    for value in values:
+        result += value
+    return result
+
+
 def _prefix(values: Sequence[float | int]) -> list[float | int]:
     result: list[float | int] = [0]
     for value in values:
@@ -25,66 +35,271 @@ def _prefix(values: Sequence[float | int]) -> list[float | int]:
     return result
 
 
+@dataclass(frozen=True, slots=True)
+class _StageMetrics:
+    forward: float
+    backward: float
+    activation: int
+    persistent: int
+
+    @property
+    def latency(self) -> float:
+        return self.forward + self.backward
+
+
+@dataclass(frozen=True, slots=True)
+class _BottleneckCandidate:
+    start: int
+    end: int
+    latency: float
+    min_prefix_stages: int
+    min_suffix_stages: int
+
+
+@dataclass(frozen=True, slots=True)
+class _PaperPlan:
+    ranges: tuple[tuple[int, int], ...]
+    forward: float
+    backward: float
+    activation: int
+    persistent: int
+    capacity: int | None
+    t1: float
+    t3: float
+    kstar: int
+
+    @property
+    def planning_iteration_time(self) -> float:
+        stages = len(self.ranges)
+        return self.t1 + (3 * stages + self.kstar - 1) * (self.forward + self.backward) + self.t3
+
+
+class _PaperWorkspace:
+    """Shared Section 4.1.2 stage cache for all requested templates."""
+
+    def __init__(self, layers: Sequence[LayerExecutionResult], device_memory_bytes: int | None):
+        self.layers = layers
+        self.device_memory_bytes = device_memory_bytes
+        self.forward = _prefix([layer.forward for layer in layers])
+        self.backward = _prefix([layer.backward for layer in layers])
+        self.activation = _prefix([_effective_activation_memory(layer) for layer in layers])
+        self.persistent = _prefix([layer.persistent_memory for layer in layers])
+
+    def stage(self, start: int, end: int) -> _StageMetrics:
+        return _StageMetrics(
+            float(self.forward[end] - self.forward[start]),
+            float(self.backward[end] - self.backward[start]),
+            int(self.activation[end] - self.activation[start]),
+            int(self.persistent[end] - self.persistent[start]),
+        )
+
+    def allowed(self, start: int, end: int, threshold: float, *, inclusive: bool) -> bool:
+        stage = self.stage(start, end)
+        if (
+            self.device_memory_bytes is not None
+            and stage.activation + stage.persistent > self.device_memory_bytes
+        ):
+            return False
+        return stage.latency <= threshold if inclusive else stage.latency < threshold
+
+    def min_segments(
+        self, start: int, end: int, threshold: float, *, inclusive: bool
+    ) -> int | None:
+        """Greedily conquer an interval with the fewest bounded stages."""
+
+        position = start
+        count = 0
+        while position < end:
+            farthest = None
+            for next_position in range(position + 1, end + 1):
+                if self.allowed(position, next_position, threshold, inclusive=inclusive):
+                    farthest = next_position
+                else:
+                    break
+            if farthest is None:
+                return None
+            position = farthest
+            count += 1
+        return count
+
+    def lexicographic_partition(
+        self,
+        start: int,
+        end: int,
+        count: int,
+        threshold: float,
+        *,
+        inclusive: bool,
+    ) -> tuple[int, ...] | None:
+        if count == 0:
+            return () if start == end else None
+        if count > end - start:
+            return None
+
+        starts: list[int] = []
+        position = start
+        for stage_index in range(count):
+            starts.append(position)
+            remaining = count - stage_index - 1
+            if remaining == 0:
+                return (
+                    tuple(starts)
+                    if self.allowed(position, end, threshold, inclusive=inclusive)
+                    else None
+                )
+            latest = end - remaining
+            chosen = None
+            for next_position in range(position + 1, latest + 1):
+                if not self.allowed(position, next_position, threshold, inclusive=inclusive):
+                    break
+                minimum = self.min_segments(
+                    next_position, end, threshold, inclusive=inclusive
+                )
+                if minimum is not None and minimum <= remaining <= end - next_position:
+                    chosen = next_position
+                    break
+            if chosen is None:
+                return None
+            position = chosen
+        return None
+
+    def bottleneck_candidates(self) -> tuple[_BottleneckCandidate, ...]:
+        candidates = []
+        layer_count = len(self.layers)
+        for start in range(layer_count):
+            for end in range(start + 1, layer_count + 1):
+                stage = self.stage(start, end)
+                if (
+                    self.device_memory_bytes is not None
+                    and stage.activation + stage.persistent > self.device_memory_bytes
+                ):
+                    continue
+                prefix = self.min_segments(0, start, stage.latency, inclusive=True)
+                # k* is the rightmost bottleneck: following stages must be
+                # strictly faster, while preceding stages may tie it.
+                suffix = self.min_segments(end, layer_count, stage.latency, inclusive=False)
+                if prefix is not None and suffix is not None:
+                    candidates.append(
+                        _BottleneckCandidate(start, end, stage.latency, prefix, suffix)
+                    )
+        return tuple(candidates)
+
+    def materialize(
+        self, candidate: _BottleneckCandidate, prefix_stages: int, total_stages: int
+    ) -> _PaperPlan | None:
+        suffix_stages = total_stages - prefix_stages - 1
+        prefix = self.lexicographic_partition(
+            0,
+            candidate.start,
+            prefix_stages,
+            candidate.latency,
+            inclusive=True,
+        )
+        suffix = self.lexicographic_partition(
+            candidate.end,
+            len(self.layers),
+            suffix_stages,
+            candidate.latency,
+            inclusive=False,
+        )
+        if prefix is None or suffix is None:
+            return None
+        starts = (*prefix, candidate.start, *suffix)
+        ends = (*starts[1:], len(self.layers))
+        ranges = tuple(zip(starts, ends))
+        metrics = tuple(self.stage(start, end) for start, end in ranges)
+        bottleneck = metrics[prefix_stages]
+        stage_memory = tuple((item.activation, item.persistent) for item in metrics)
+        return _PaperPlan(
+            ranges,
+            bottleneck.forward,
+            bottleneck.backward,
+            max(item.activation for item in metrics),
+            max(item.persistent for item in metrics),
+            _max_microbatches(stage_memory, self.device_memory_bytes),
+            _sequential_sum(tuple(item.latency for item in metrics)),
+            _sequential_sum(tuple(item.latency for item in metrics[prefix_stages:])),
+            prefix_stages,
+        )
+
+
+def _paper_plans(
+    layers: Sequence[LayerExecutionResult],
+    resource_counts: Sequence[int],
+    device_memory_bytes: int | None = None,
+) -> dict[int, _PaperPlan]:
+    """Apply Section 4.1.2 Equations 1--4 for fixed-TP logical nodes.
+
+    The refactored runtime assigns one complete fixed-TP node to each stage, so
+    the paper state T(S, u, v, d) has S=d and no within-node GPU split m. The
+    shared bottleneck cache is equivalent to evaluating every feasible divide
+    and conquer result, but retains enough state to avoid the artifact's unsafe
+    single-locally-best-subproblem assumption.
+    """
+
+    requested = sorted(set(resource_counts))
+    if not requested or requested[0] < 1 or requested[-1] > len(layers):
+        raise ValueError("stage count must be between one and the number of layers")
+    workspace = _PaperWorkspace(layers, device_memory_bytes)
+    candidates = workspace.bottleneck_candidates()
+    results: dict[int, _PaperPlan] = {}
+
+    for stages in requested:
+        best: _PaperPlan | None = None
+        for candidate in candidates:
+            prefix_lower = max(
+                candidate.min_prefix_stages,
+                stages - 1 - (len(layers) - candidate.end),
+                0,
+            )
+            prefix_upper = min(
+                candidate.start,
+                stages - 1 - candidate.min_suffix_stages,
+            )
+            if prefix_lower > prefix_upper or prefix_lower >= stages:
+                continue
+            prefix_counts = (
+                range(prefix_lower, prefix_upper + 1)
+                if candidate.latency == 0.0
+                else (prefix_lower,)
+            )
+            for prefix_stages in prefix_counts:
+                predicted = (
+                    workspace.stage(0, len(layers)).latency
+                    + (3 * stages + prefix_stages - 1) * candidate.latency
+                    + workspace.stage(candidate.start, len(layers)).latency
+                )
+                if best is not None and predicted > best.planning_iteration_time:
+                    continue
+                plan = workspace.materialize(candidate, prefix_stages, stages)
+                if plan is not None and (
+                    best is None
+                    or (plan.planning_iteration_time, tuple(start for start, _ in plan.ranges))
+                    < (
+                        best.planning_iteration_time,
+                        tuple(start for start, _ in best.ranges),
+                    )
+                ):
+                    best = plan
+        if best is None:
+            raise ValueError(
+                f"pipeline template for resource count {stages} cannot fit one microbatch in device memory"
+            )
+        results[stages] = best
+    return results
+
+
 def _partitions(
     layers: Sequence[LayerExecutionResult],
     resource_counts: Sequence[int],
     device_memory_bytes: int | None = None,
 ) -> dict[int, tuple[tuple[int, int], ...]]:
-    """Return exact deterministic minimax partitions from one dynamic program."""
+    """Compatibility helper returning only the paper planner's layer ranges."""
 
-    requested = sorted(set(resource_counts))
-    if not requested or requested[0] < 1 or requested[-1] > len(layers):
-        raise ValueError("stage count must be between one and the number of layers")
-    forward = _prefix([layer.forward for layer in layers])
-    backward = _prefix([layer.backward for layer in layers])
-    activation = _prefix([_effective_activation_memory(layer) for layer in layers])
-    persistent = _prefix([layer.persistent_memory for layer in layers])
-
-    # dp[k][j] = (maximum stage work, stage start positions) for k stages
-    # covering the first j layers. Keeping the lexicographically smallest
-    # starts gives a stable answer when several partitions have equal cost.
-    max_stages = requested[-1]
-    dp: list[list[tuple[float, tuple[int, ...]] | None]] = [
-        [None] * (len(layers) + 1) for _ in range(max_stages + 1)
-    ]
-    dp[0][0] = (0.0, ())
-    for count in range(1, max_stages + 1):
-        for end in range(count, len(layers) + 1):
-            candidates = []
-            for start in range(count - 1, end):
-                previous = dp[count - 1][start]
-                if previous is None:
-                    continue
-                stage_activation = int(activation[end] - activation[start])
-                stage_persistent = int(persistent[end] - persistent[start])
-                if (
-                    device_memory_bytes is not None
-                    and stage_activation + stage_persistent > device_memory_bytes
-                ):
-                    continue
-                stage_work = float(
-                    forward[end] - forward[start] + backward[end] - backward[start]
-                )
-                candidates.append(
-                    (max(previous[0], stage_work), (*previous[1], start))
-                )
-            if candidates:
-                dp[count][end] = min(candidates)
-
-    results = {}
-    for stages in requested:
-        result = dp[stages][len(layers)]
-        if result is None:
-            raise ValueError(
-                f"pipeline template for resource count {stages} cannot fit one microbatch in device memory"
-            )
-        starts = result[1]
-        ends = (*starts[1:], len(layers))
-        results[stages] = tuple(
-            (layers[start].layer_index, layers[end - 1].layer_index + 1)
-            for start, end in zip(starts, ends)
-        )
-    return results
+    return {
+        stages: plan.ranges
+        for stages, plan in _paper_plans(layers, resource_counts, device_memory_bytes).items()
+    }
 
 
 def _partition(
@@ -92,8 +307,6 @@ def _partition(
     stages: int,
     device_memory_bytes: int | None = None,
 ) -> tuple[tuple[int, int], ...]:
-    """Return one partition; retained as the small Python oracle entry point."""
-
     return _partitions(layers, (stages,), device_memory_bytes)[stages]
 
 
@@ -112,37 +325,6 @@ def _max_microbatches(
     return min(capacities) if capacities else None
 
 
-def _summarize_partition(
-    layers: Sequence[LayerExecutionResult],
-    ranges: Sequence[tuple[int, int]],
-    device_memory_bytes: int | None,
-) -> tuple[float, float, int, int, int | None]:
-    forward_prefix = _prefix([layer.forward for layer in layers])
-    backward_prefix = _prefix([layer.backward for layer in layers])
-    activation_prefix = _prefix([_effective_activation_memory(layer) for layer in layers])
-    persistent_prefix = _prefix([layer.persistent_memory for layer in layers])
-    stage_metrics = [
-        (
-            float(forward_prefix[end] - forward_prefix[start]),
-            float(backward_prefix[end] - backward_prefix[start]),
-            int(activation_prefix[end] - activation_prefix[start]),
-            int(persistent_prefix[end] - persistent_prefix[start]),
-        )
-        for start, end in ranges
-    ]
-    bottleneck = max(
-        range(len(stage_metrics)),
-        key=lambda index: (stage_metrics[index][0] + stage_metrics[index][1], index),
-    )
-    forward, backward, _, _ = stage_metrics[bottleneck]
-    activation_memory = max(item[2] for item in stage_metrics)
-    persistent_memory = max(item[3] for item in stage_metrics)
-    max_microbatches = _max_microbatches(
-        [(item[2], item[3]) for item in stage_metrics], device_memory_bytes
-    )
-    return forward, backward, activation_memory, persistent_memory, max_microbatches
-
-
 def _create_python_templates(
     model_name: str,
     profile_data: Sequence[LayerExecutionResult],
@@ -152,21 +334,22 @@ def _create_python_templates(
     device_memory_bytes: int | None,
 ) -> dict[int, PipelineTemplate]:
     results = {}
-    partitions = _partitions(profile_data, resource_counts, device_memory_bytes)
-    for stages, ranges in partitions.items():
-        forward, backward, activation, persistent, capacity = _summarize_partition(
-            profile_data, ranges, device_memory_bytes
-        )
+    for stages, plan in _paper_plans(
+        profile_data, resource_counts, device_memory_bytes
+    ).items():
         results[stages] = PipelineTemplate(
             f"{model_name}-stages-{stages}",
-            ranges,
+            plan.ranges,
             tensor_parallel_size,
-            forward,
-            backward,
-            activation_memory=activation,
-            persistent_memory=persistent,
-            max_microbatches=capacity,
+            plan.forward,
+            plan.backward,
+            activation_memory=plan.activation,
+            persistent_memory=plan.persistent,
+            max_microbatches=plan.capacity,
             fingerprint=fingerprint,
+            paper_t1=plan.t1,
+            paper_t3=plan.t3,
+            paper_bottleneck_stage=plan.kstar,
         )
     return results
 
@@ -180,7 +363,7 @@ def create_pipeline_templates(
     fingerprint: CompatibilityFingerprint | None = None,
     device_memory_bytes: int | None = None,
 ) -> dict[int, PipelineTemplate]:
-    """Create one fixed-TP, one-stage-per-resource template for each count."""
+    """Create one paper-modeled, fixed-TP pipeline template per node count."""
 
     if not model_name or not profile_data or not num_nodes:
         raise ValueError("model_name, profile_data, and num_nodes must be non-empty")
@@ -231,6 +414,9 @@ def create_pipeline_templates(
             None if value["max_microbatches"] is None else int(value["max_microbatches"]),
             fingerprint,
             int(value["schema_version"]),
+            float(value["paper_t1"]),
+            float(value["paper_t3"]),
+            int(value["paper_bottleneck_stage"]),
         )
         for stages, value in raw.items()
     }

--- a/oobleck/planning/generator.py
+++ b/oobleck/planning/generator.py
@@ -1,54 +1,174 @@
-"""Narrow Python planner API with a deterministic fallback for the Rust extension."""
+"""Narrow Python planner API with equivalent Rust and Python backends."""
 
 from __future__ import annotations
 
+import math
 from typing import Sequence
 
 from oobleck.planning.profiler import LayerExecutionResult
 from oobleck.types import CompatibilityFingerprint, PipelineTemplate
 
 
-def _partition(layers: Sequence[LayerExecutionResult], stages: int) -> tuple[tuple[int, int], ...]:
-    if stages < 1 or stages > len(layers):
+def _effective_activation_memory(layer: LayerExecutionResult) -> int:
+    if layer.activation_memory or layer.persistent_memory:
+        return layer.activation_memory
+    return layer.mem_required
+
+
+def _prefix(values: Sequence[float | int]) -> list[float | int]:
+    result: list[float | int] = [0]
+    for value in values:
+        next_value = result[-1] + value
+        if isinstance(next_value, float) and not math.isfinite(next_value):
+            raise ValueError("aggregate profile timing overflows float")
+        result.append(next_value)
+    return result
+
+
+def _partitions(
+    layers: Sequence[LayerExecutionResult],
+    resource_counts: Sequence[int],
+    device_memory_bytes: int | None = None,
+) -> dict[int, tuple[tuple[int, int], ...]]:
+    """Return exact deterministic minimax partitions from one dynamic program."""
+
+    requested = sorted(set(resource_counts))
+    if not requested or requested[0] < 1 or requested[-1] > len(layers):
         raise ValueError("stage count must be between one and the number of layers")
-    prefix = [0.0]
-    for layer in layers:
-        prefix.append(prefix[-1] + layer.forward + layer.backward)
-    # dp[k][j] = (maximum stage work, cut positions) for k stages covering j layers.
+    forward = _prefix([layer.forward for layer in layers])
+    backward = _prefix([layer.backward for layer in layers])
+    activation = _prefix([_effective_activation_memory(layer) for layer in layers])
+    persistent = _prefix([layer.persistent_memory for layer in layers])
+
+    # dp[k][j] = (maximum stage work, stage start positions) for k stages
+    # covering the first j layers. Keeping the lexicographically smallest
+    # starts gives a stable answer when several partitions have equal cost.
+    max_stages = requested[-1]
     dp: list[list[tuple[float, tuple[int, ...]] | None]] = [
-        [None] * (len(layers) + 1) for _ in range(stages + 1)
+        [None] * (len(layers) + 1) for _ in range(max_stages + 1)
     ]
     dp[0][0] = (0.0, ())
-    for count in range(1, stages + 1):
+    for count in range(1, max_stages + 1):
         for end in range(count, len(layers) + 1):
             candidates = []
-            for cut in range(count - 1, end):
-                previous = dp[count - 1][cut]
+            for start in range(count - 1, end):
+                previous = dp[count - 1][start]
                 if previous is None:
                     continue
-                work = prefix[end] - prefix[cut]
-                candidates.append((max(previous[0], work), (*previous[1], cut)))
-            dp[count][end] = min(candidates, key=lambda item: (item[0], item[1]))
-    result = dp[stages][len(layers)]
-    assert result is not None
-    cuts = (*result[1], len(layers))
-    return tuple(
-        (layers[cuts[index]].layer_index, layers[cuts[index + 1] - 1].layer_index + 1)
-        for index in range(stages)
-    )
+                stage_activation = int(activation[end] - activation[start])
+                stage_persistent = int(persistent[end] - persistent[start])
+                if (
+                    device_memory_bytes is not None
+                    and stage_activation + stage_persistent > device_memory_bytes
+                ):
+                    continue
+                stage_work = float(
+                    forward[end] - forward[start] + backward[end] - backward[start]
+                )
+                candidates.append(
+                    (max(previous[0], stage_work), (*previous[1], start))
+                )
+            if candidates:
+                dp[count][end] = min(candidates)
+
+    results = {}
+    for stages in requested:
+        result = dp[stages][len(layers)]
+        if result is None:
+            raise ValueError(
+                f"pipeline template for resource count {stages} cannot fit one microbatch in device memory"
+            )
+        starts = result[1]
+        ends = (*starts[1:], len(layers))
+        results[stages] = tuple(
+            (layers[start].layer_index, layers[end - 1].layer_index + 1)
+            for start, end in zip(starts, ends)
+        )
+    return results
+
+
+def _partition(
+    layers: Sequence[LayerExecutionResult],
+    stages: int,
+    device_memory_bytes: int | None = None,
+) -> tuple[tuple[int, int], ...]:
+    """Return one partition; retained as the small Python oracle entry point."""
+
+    return _partitions(layers, (stages,), device_memory_bytes)[stages]
 
 
 def _max_microbatches(
-    activation_memory: int, persistent_memory: int, device_memory_bytes: int | None
+    stage_memory: Sequence[tuple[int, int]], device_memory_bytes: int | None
 ) -> int | None:
     if device_memory_bytes is None:
         return None
-    available = device_memory_bytes - persistent_memory
-    if available < 0 or (activation_memory > 0 and available < activation_memory):
-        raise ValueError("pipeline template cannot fit one microbatch in device memory")
-    if activation_memory == 0:
-        return None
-    return available // activation_memory
+    capacities = []
+    for activation_memory, persistent_memory in stage_memory:
+        available = device_memory_bytes - persistent_memory
+        if available < 0 or (activation_memory > 0 and available < activation_memory):
+            raise ValueError("pipeline template cannot fit one microbatch in device memory")
+        if activation_memory > 0:
+            capacities.append(available // activation_memory)
+    return min(capacities) if capacities else None
+
+
+def _summarize_partition(
+    layers: Sequence[LayerExecutionResult],
+    ranges: Sequence[tuple[int, int]],
+    device_memory_bytes: int | None,
+) -> tuple[float, float, int, int, int | None]:
+    forward_prefix = _prefix([layer.forward for layer in layers])
+    backward_prefix = _prefix([layer.backward for layer in layers])
+    activation_prefix = _prefix([_effective_activation_memory(layer) for layer in layers])
+    persistent_prefix = _prefix([layer.persistent_memory for layer in layers])
+    stage_metrics = [
+        (
+            float(forward_prefix[end] - forward_prefix[start]),
+            float(backward_prefix[end] - backward_prefix[start]),
+            int(activation_prefix[end] - activation_prefix[start]),
+            int(persistent_prefix[end] - persistent_prefix[start]),
+        )
+        for start, end in ranges
+    ]
+    bottleneck = max(
+        range(len(stage_metrics)),
+        key=lambda index: (stage_metrics[index][0] + stage_metrics[index][1], index),
+    )
+    forward, backward, _, _ = stage_metrics[bottleneck]
+    activation_memory = max(item[2] for item in stage_metrics)
+    persistent_memory = max(item[3] for item in stage_metrics)
+    max_microbatches = _max_microbatches(
+        [(item[2], item[3]) for item in stage_metrics], device_memory_bytes
+    )
+    return forward, backward, activation_memory, persistent_memory, max_microbatches
+
+
+def _create_python_templates(
+    model_name: str,
+    profile_data: Sequence[LayerExecutionResult],
+    resource_counts: Sequence[int],
+    tensor_parallel_size: int,
+    fingerprint: CompatibilityFingerprint | None,
+    device_memory_bytes: int | None,
+) -> dict[int, PipelineTemplate]:
+    results = {}
+    partitions = _partitions(profile_data, resource_counts, device_memory_bytes)
+    for stages, ranges in partitions.items():
+        forward, backward, activation, persistent, capacity = _summarize_partition(
+            profile_data, ranges, device_memory_bytes
+        )
+        results[stages] = PipelineTemplate(
+            f"{model_name}-stages-{stages}",
+            ranges,
+            tensor_parallel_size,
+            forward,
+            backward,
+            activation_memory=activation,
+            persistent_memory=persistent,
+            max_microbatches=capacity,
+            fingerprint=fingerprint,
+        )
+    return results
 
 
 def create_pipeline_templates(
@@ -60,10 +180,14 @@ def create_pipeline_templates(
     fingerprint: CompatibilityFingerprint | None = None,
     device_memory_bytes: int | None = None,
 ) -> dict[int, PipelineTemplate]:
+    """Create one fixed-TP, one-stage-per-resource template for each count."""
+
     if not model_name or not profile_data or not num_nodes:
         raise ValueError("model_name, profile_data, and num_nodes must be non-empty")
     if tensor_parallel_size < 1:
         raise ValueError("tensor_parallel_size must be positive")
+    if any(count < 1 for count in num_nodes):
+        raise ValueError("num_nodes must contain only positive resource counts")
     if device_memory_bytes is not None and device_memory_bytes < 1:
         raise ValueError("device_memory_bytes must be positive when supplied")
     if tuple(layer.layer_index for layer in profile_data) != tuple(range(len(profile_data))):
@@ -72,66 +196,41 @@ def create_pipeline_templates(
         from oobleck.planning import planner as rust_planner
     except ImportError:
         rust_planner = None
-    if rust_planner is not None:
+    if rust_planner is None:
+        return _create_python_templates(
+            model_name,
+            profile_data,
+            num_nodes,
+            tensor_parallel_size,
+            fingerprint,
+            device_memory_bytes,
+        )
+
+    try:
         raw = rust_planner.create_pipeline_templates(
             model_name,
             list(profile_data),
             list(num_nodes),
             tensor_parallel_size,
+            device_memory_bytes,
         )
-        return {
-            int(stages): PipelineTemplate(
-                value["template_id"],
-                tuple(tuple(item) for item in value["layer_ranges"]),
-                int(value["tensor_parallel_size"]),
-                float(value["forward_time"]),
-                float(value["backward_time"]),
-                float(value["communication_time"]),
-                int(value["activation_memory"]),
-                int(value["persistent_memory"]),
-                _max_microbatches(
-                    int(value["activation_memory"]),
-                    int(value["persistent_memory"]),
-                    device_memory_bytes,
-                ),
-                fingerprint,
-                int(value["schema_version"]),
-            )
-            for stages, value in raw.items()
-        }
-    results = {}
-    for stages in sorted(set(num_nodes)):
-        ranges = _partition(profile_data, stages)
-        forward = max(
-            sum(layer.forward for layer in profile_data[start:end]) for start, end in ranges
+    except RuntimeError as exc:
+        # Keep the supported Python API backend-independent while the direct
+        # extension preserves an explicit infeasible-planning error category.
+        raise ValueError(str(exc)) from exc
+    return {
+        int(stages): PipelineTemplate(
+            value["template_id"],
+            tuple(tuple(item) for item in value["layer_ranges"]),
+            int(value["tensor_parallel_size"]),
+            float(value["forward_time"]),
+            float(value["backward_time"]),
+            float(value["communication_time"]),
+            int(value["activation_memory"]),
+            int(value["persistent_memory"]),
+            None if value["max_microbatches"] is None else int(value["max_microbatches"]),
+            fingerprint,
+            int(value["schema_version"]),
         )
-        backward = max(
-            sum(layer.backward for layer in profile_data[start:end]) for start, end in ranges
-        )
-        activation_memory = max(
-            sum(
-                layer.activation_memory
-                if layer.activation_memory or layer.persistent_memory
-                else layer.mem_required
-                for layer in profile_data[start:end]
-            )
-            for start, end in ranges
-        )
-        persistent_memory = max(
-            sum(layer.persistent_memory for layer in profile_data[start:end])
-            for start, end in ranges
-        )
-        results[stages] = PipelineTemplate(
-            f"{model_name}-stages-{stages}",
-            ranges,
-            tensor_parallel_size,
-            forward,
-            backward,
-            activation_memory=activation_memory,
-            persistent_memory=persistent_memory,
-            max_microbatches=_max_microbatches(
-                activation_memory, persistent_memory, device_memory_bytes
-            ),
-            fingerprint=fingerprint,
-        )
-    return results
+        for stages, value in raw.items()
+    }

--- a/oobleck/planning/planner.pyi
+++ b/oobleck/planning/planner.pyi
@@ -1,8 +1,12 @@
+from typing import Any
+
 from oobleck.planning.profiler import LayerExecutionResult
+
 
 def create_pipeline_templates(
     model_name: str,
     profile_data: list[LayerExecutionResult],
-    num_nodes: list[int],
+    resource_counts: list[int],
     tensor_parallel_size: int = 1,
-) -> dict[int, dict]: ...
+    device_memory_bytes: int | None = None,
+) -> dict[int, dict[str, Any]]: ...

--- a/oobleck/planning/profiler.py
+++ b/oobleck/planning/profiler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -30,7 +31,10 @@ class LayerExecutionResult:
         if self.layer_index < 0 or not self.layer_name:
             raise ValueError("layer identity is invalid")
         if (
-            self.forward < 0
+            not math.isfinite(self.forward)
+            or not math.isfinite(self.backward)
+            or not math.isfinite(self.forward + self.backward)
+            or self.forward < 0
             or self.backward < 0
             or self.mem_required < 0
             or self.activation_memory < 0

--- a/oobleck/types.py
+++ b/oobleck/types.py
@@ -133,7 +133,12 @@ class PipelineStageSpec:
 
 @dataclass(frozen=True, slots=True)
 class PipelineTemplate:
-    """A profiled pipeline layout independent of concrete nodes and ranks."""
+    """A profiled pipeline layout independent of concrete nodes and ranks.
+
+    Generated templates store the forward and backward components of the same
+    bottleneck stage, so their sum is the minimax steady-state stage work used
+    by :meth:`iteration_time` and heterogeneous composition.
+    """
 
     template_id: str
     layer_ranges: tuple[tuple[int, int], ...]

--- a/oobleck/types.py
+++ b/oobleck/types.py
@@ -135,9 +135,9 @@ class PipelineStageSpec:
 class PipelineTemplate:
     """A profiled pipeline layout independent of concrete nodes and ranks.
 
-    Generated templates store the forward and backward components of the same
-    bottleneck stage, so their sum is the minimax steady-state stage work used
-    by :meth:`iteration_time` and heterogeneous composition.
+    Generated templates store Section 4.1.2's T1, T3, and rightmost
+    bottleneck-stage metadata. Manually constructed legacy templates may omit
+    those optional fields and retain the earlier steady-state estimate.
     """
 
     template_id: str
@@ -151,6 +151,9 @@ class PipelineTemplate:
     max_microbatches: int | None = None
     fingerprint: CompatibilityFingerprint | None = None
     schema_version: int = 1
+    paper_t1: float | None = None
+    paper_t3: float | None = None
+    paper_bottleneck_stage: int | None = None
 
     def __post_init__(self) -> None:
         if not self.template_id:
@@ -177,6 +180,22 @@ class PipelineTemplate:
             raise ValueError("memory requirements must be non-negative")
         if self.max_microbatches is not None and self.max_microbatches < 1:
             raise ValueError("max_microbatches must be >= 1 when supplied")
+        paper_fields = (self.paper_t1, self.paper_t3, self.paper_bottleneck_stage)
+        if any(value is not None for value in paper_fields) and not all(
+            value is not None for value in paper_fields
+        ):
+            raise ValueError("paper timing fields must be supplied together")
+        if self.paper_t1 is not None:
+            assert self.paper_t3 is not None and self.paper_bottleneck_stage is not None
+            if (
+                not math.isfinite(self.paper_t1)
+                or not math.isfinite(self.paper_t3)
+                or self.paper_t1 < 0
+                or self.paper_t3 < 0
+            ):
+                raise ValueError("paper T1 and T3 must be finite and non-negative")
+            if not 0 <= self.paper_bottleneck_stage < self.num_stages:
+                raise ValueError("paper bottleneck stage is outside the pipeline")
 
     @property
     def num_stages(self) -> int:
@@ -195,11 +214,39 @@ class PipelineTemplate:
             return math.inf
         if microbatches == 0:
             return 0.0
-        # Flush time plus steady-state work.  This deliberately uses only the
-        # serialized profile and is deterministic across workers.
         stage_work = self.forward_time + self.backward_time
+        if self.paper_t1 is not None:
+            assert self.paper_t3 is not None and self.paper_bottleneck_stage is not None
+            # Oobleck Section 4.1.2, Equation 2:
+            # T2 = (Nb - S + k* - 1) * (F_k* + B_k*).
+            t2 = (
+                microbatches
+                - self.num_stages
+                + self.paper_bottleneck_stage
+                - 1
+            ) * stage_work
+            return self.paper_t1 + t2 + self.paper_t3 + self.communication_time
+        # Compatibility path for hand-written/schema-v1 templates without the
+        # paper timing summary.
         bubble = max(0, self.num_stages - 1) * stage_work
         return bubble + microbatches * stage_work + self.communication_time
+
+    @property
+    def planning_iteration_time(self) -> float:
+        """Return the Section 4.1.2 objective with its temporary Nb = 4S.
+
+        This is the offline comparison value, not a runnable allocation, so the
+        concrete ``max_microbatches`` guard used by composition does not apply.
+        """
+
+        if self.paper_t1 is None:
+            return self.iteration_time(4 * self.num_stages)
+        assert self.paper_t3 is not None and self.paper_bottleneck_stage is not None
+        stage_work = self.forward_time + self.backward_time
+        t2 = (
+            3 * self.num_stages + self.paper_bottleneck_stage - 1
+        ) * stage_work
+        return self.paper_t1 + t2 + self.paper_t3 + self.communication_time
 
     def assert_compatible(self, fingerprint: CompatibilityFingerprint) -> None:
         if self.fingerprint is None:

--- a/rust/execution_result.rs
+++ b/rust/execution_result.rs
@@ -1,26 +1,14 @@
+use crate::PlannerError;
 use pyo3::conversion::FromPyObject;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
-use serde::{Deserialize, Serialize};
-use std::cmp::{Ordering, PartialEq};
-use std::sync::Arc;
 
-#[derive(Serialize, Deserialize)]
-pub struct ProfileResult {
-    model_name: String,
-    microbatch_size: u32,
-    tp_size: u32,
-    precision: String,
-    layers: Vec<LayerExecutionResult>,
-}
-
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub struct LayerExecutionResult {
     pub layer_index: u32,
     pub layer_name: String,
     pub forward: f64,
     pub backward: f64,
-    pub mem_required: u64,
     pub activation_memory: u64,
     pub persistent_memory: u64,
 }
@@ -46,127 +34,120 @@ impl<'py> FromPyObject<'py> for LayerExecutionResult {
             layer_name: ob.getattr("layer_name")?.extract()?,
             forward: ob.getattr("forward")?.extract()?,
             backward: ob.getattr("backward")?.extract()?,
-            mem_required,
             activation_memory,
             persistent_memory,
         })
     }
 }
 
+impl LayerExecutionResult {
+    pub fn validate(&self, expected_index: usize) -> Result<(), PlannerError> {
+        if self.layer_index as usize != expected_index {
+            return Err(PlannerError::invalid_input(format!(
+                "profile_data must have contiguous layer indices; expected {expected_index}, got {}",
+                self.layer_index
+            )));
+        }
+        if self.layer_name.is_empty() {
+            return Err(PlannerError::invalid_input(format!(
+                "layer {expected_index} must have a non-empty name"
+            )));
+        }
+        if !self.forward.is_finite()
+            || !self.backward.is_finite()
+            || !(self.forward + self.backward).is_finite()
+            || self.forward < 0.0
+            || self.backward < 0.0
+        {
+            return Err(PlannerError::invalid_input(format!(
+                "layer {expected_index} timings must be finite and non-negative"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct StageExecutionResult {
     pub layers: (u32, u32),
-    forward: f64,
-    backward: f64,
-    mem_required: u64,
-    activation_memory: u64,
-    persistent_memory: u64,
+    pub forward: f64,
+    pub backward: f64,
+    pub activation_memory: u64,
+    pub persistent_memory: u64,
 }
 
 impl StageExecutionResult {
-    pub fn new(layers: &[LayerExecutionResult]) -> Self {
-        Self {
-            layers: (layers[0].layer_index, layers[layers.len() - 1].layer_index + 1),
-            forward: layers.iter().map(|layer| layer.forward).sum(),
-            backward: layers.iter().map(|layer| layer.backward).sum(),
-            mem_required: layers.iter().map(|layer| layer.mem_required).sum(),
-            activation_memory: layers.iter().map(|layer| layer.activation_memory).sum(),
-            persistent_memory: layers.iter().map(|layer| layer.persistent_memory).sum(),
-        }
-    }
-
     pub fn latency(&self) -> f64 {
         self.forward + self.backward
     }
+
+    pub fn fits_one_microbatch(&self, device_memory_bytes: Option<u64>) -> bool {
+        device_memory_bytes.map_or(true, |device_memory| {
+            self.persistent_memory
+                .checked_add(self.activation_memory)
+                .is_some_and(|required| required <= device_memory)
+        })
+    }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct PipelineExecutionResult {
-    pub stages: Vec<Arc<StageExecutionResult>>,
-    pub t1: f64,
-    pub t2: f64,
-    pub t3: f64,
-    pub kstar: usize,
+    pub stages: Vec<StageExecutionResult>,
 }
 
 impl PipelineExecutionResult {
-    pub fn new(left: &Self, right: &Self) -> Self {
-        let mut stages = left.stages.clone();
-        stages.extend(right.stages.clone());
-        let t1 = left.t1 + right.t1;
-        let kstar = if left.stages[left.kstar].latency() > right.stages[right.kstar].latency() {
-            left.kstar
-        } else {
-            left.stages.len() + right.kstar
-        };
-        let num_microbatches = 4 * stages.len();
-        let t2 = (num_microbatches - stages.len() + kstar - 1) as f64 * stages[kstar].latency();
-        let t3 = if kstar == left.kstar { left.t3 + right.t1 } else { right.t3 };
-        Self {
-            stages,
-            t1,
-            t2,
-            t3,
-            kstar,
-        }
-    }
-
-    pub fn make_base_result(stage: Arc<StageExecutionResult>) -> Self {
-        let latency = stage.latency();
-        Self {
-            stages: vec![stage],
-            t1: latency,
-            t2: 2.0 * latency,
-            t3: latency,
-            kstar: 0,
-        }
-    }
-
-    pub fn latency_with_mb(&self, mb: u32) -> f64 {
-        self.t1 + self.t2 + self.t3
-            + ((mb as i32 - 4 * self.stages.len() as i32) as f64)
-                * self.stages[self.kstar].latency()
-    }
-    pub fn latency(&self) -> f64 {
-        self.t1 + self.t2 + self.t3
-    }
-    pub fn forward_time(&self) -> f64 {
-        self.stages.iter().map(|stage| stage.forward).fold(0.0, f64::max)
-    }
-    pub fn backward_time(&self) -> f64 {
-        self.stages.iter().map(|stage| stage.backward).fold(0.0, f64::max)
-    }
-    pub fn mem_required(&self) -> u64 {
+    pub fn bottleneck_stage(&self) -> &StageExecutionResult {
         self.stages
             .iter()
-            .map(|stage| stage.mem_required)
+            .enumerate()
+            .max_by(|(left_index, left), (right_index, right)| {
+                left.latency()
+                    .total_cmp(&right.latency())
+                    .then_with(|| left_index.cmp(right_index))
+            })
+            .map(|(_, stage)| stage)
+            .expect("a planned pipeline always has at least one stage")
+    }
+
+    pub fn bottleneck_latency(&self) -> f64 {
+        self.bottleneck_stage().latency()
+    }
+
+    pub fn forward_time(&self) -> f64 {
+        self.bottleneck_stage().forward
+    }
+
+    pub fn backward_time(&self) -> f64 {
+        self.bottleneck_stage().backward
+    }
+
+    pub fn activation_memory(&self) -> u64 {
+        self.stages
+            .iter()
+            .map(|stage| stage.activation_memory)
             .max()
             .unwrap_or(0)
     }
-    pub fn activation_memory(&self) -> u64 {
-        self.stages.iter().map(|stage| stage.activation_memory).max().unwrap_or(0)
-    }
-    pub fn persistent_memory(&self) -> u64 {
-        self.stages.iter().map(|stage| stage.persistent_memory).max().unwrap_or(0)
-    }
-}
 
-impl PartialEq for PipelineExecutionResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.latency_with_mb(128) == other.latency_with_mb(128)
-            && self.mem_required() == other.mem_required()
+    pub fn persistent_memory(&self) -> u64 {
+        self.stages
+            .iter()
+            .map(|stage| stage.persistent_memory)
+            .max()
+            .unwrap_or(0)
     }
-}
-impl Eq for PipelineExecutionResult {}
-impl Ord for PipelineExecutionResult {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.latency_with_mb(128)
-            .partial_cmp(&other.latency_with_mb(128))
-            .unwrap_or(Ordering::Equal)
-            .then_with(|| self.mem_required().cmp(&other.mem_required()))
-    }
-}
-impl PartialOrd for PipelineExecutionResult {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
+
+    pub fn max_microbatches(&self, device_memory_bytes: Option<u64>) -> Option<u64> {
+        let device_memory = device_memory_bytes?;
+        self.stages
+            .iter()
+            .filter(|stage| stage.activation_memory > 0)
+            .map(|stage| {
+                device_memory
+                    .checked_sub(stage.persistent_memory)
+                    .map(|available| available / stage.activation_memory)
+                    .unwrap_or(0)
+            })
+            .min()
     }
 }

--- a/rust/execution_result.rs
+++ b/rust/execution_result.rs
@@ -93,20 +93,52 @@ impl StageExecutionResult {
 #[derive(Clone, Debug, PartialEq)]
 pub struct PipelineExecutionResult {
     pub stages: Vec<StageExecutionResult>,
+    /// Section 4.1.2, Equation 1: one forward and backward pass for every stage.
+    pub t1: f64,
+    /// Section 4.1.2, Equation 3: work from the bottleneck through the last stage.
+    pub t3: f64,
+    /// Zero-based index of the rightmost stage with maximum forward + backward time.
+    pub kstar: usize,
 }
 
 impl PipelineExecutionResult {
+    /// Section 4.1.2, Equation 4 (conquer): evaluate one stage.
+    pub fn from_stage(stage: StageExecutionResult) -> Self {
+        let latency = stage.latency();
+        Self {
+            stages: vec![stage],
+            t1: latency,
+            t3: latency,
+            kstar: 0,
+        }
+    }
+
+    /// Section 4.1.2, Equations 1 and 3 (combine two subproblems).
+    ///
+    /// T2 is evaluated from the combined rightmost bottleneck by
+    /// `iteration_time`, because its coefficient depends on the concrete Nb.
+    pub fn combine(left: &Self, right: &Self) -> Self {
+        let mut stages = left.stages.clone();
+        stages.extend(right.stages.clone());
+        let right_wins = right
+            .bottleneck_latency()
+            .total_cmp(&left.bottleneck_latency())
+            != std::cmp::Ordering::Less;
+        let (kstar, t3) = if right_wins {
+            (left.stages.len() + right.kstar, right.t3)
+        } else {
+            (left.kstar, left.t3 + right.t1)
+        };
+        Self {
+            stages,
+            t1: left.t1 + right.t1,
+            t3,
+            kstar,
+        }
+    }
+
     pub fn bottleneck_stage(&self) -> &StageExecutionResult {
-        self.stages
-            .iter()
-            .enumerate()
-            .max_by(|(left_index, left), (right_index, right)| {
-                left.latency()
-                    .total_cmp(&right.latency())
-                    .then_with(|| left_index.cmp(right_index))
-            })
-            .map(|(_, stage)| stage)
-            .expect("a planned pipeline always has at least one stage")
+        &self.stages[self.kstar]
     }
 
     pub fn bottleneck_latency(&self) -> f64 {
@@ -135,6 +167,20 @@ impl PipelineExecutionResult {
             .map(|stage| stage.persistent_memory)
             .max()
             .unwrap_or(0)
+    }
+
+    /// Evaluate Section 4.1.2's T1 + T2 + T3 model.
+    pub fn iteration_time(&self, num_microbatches: u32) -> f64 {
+        // Equation 2: T2 = (Nb - S + k* - 1) * (F_k* + B_k*).
+        let t2_coefficient = num_microbatches as i64 - self.stages.len() as i64
+            + self.kstar as i64
+            - 1;
+        self.t1 + t2_coefficient as f64 * self.bottleneck_latency() + self.t3
+    }
+
+    /// The paper selects a template using the temporary planning value Nb = 4S.
+    pub fn planning_iteration_time(&self) -> f64 {
+        self.iteration_time((4 * self.stages.len()) as u32)
     }
 
     pub fn max_microbatches(&self, device_memory_bytes: Option<u64>) -> Option<u64> {

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1,66 +1,100 @@
 use crate::pipeline_template_generator::PipelineTemplateGenerator;
-mod execution_result;
-mod pipeline_template_generator;
-
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use std::fmt;
 
-#[derive(Debug)]
-struct PlannerError {
-    message: String,
+mod execution_result;
+mod pipeline_template_generator;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum PlannerError {
+    InvalidInput(String),
+    Infeasible(String),
 }
 
 impl PlannerError {
-    fn new(message: &str) -> Self {
-        Self { message: message.to_string() }
+    fn invalid_input(message: impl Into<String>) -> Self {
+        Self::InvalidInput(message.into())
+    }
+
+    fn infeasible(message: impl Into<String>) -> Self {
+        Self::Infeasible(message.into())
     }
 }
 
 impl fmt::Display for PlannerError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "PlannerError: {}", self.message)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidInput(message) => write!(f, "invalid planner input: {message}"),
+            Self::Infeasible(message) => write!(f, "pipeline planning is infeasible: {message}"),
+        }
     }
 }
 
 impl std::error::Error for PlannerError {}
 
 impl From<PlannerError> for PyErr {
-    fn from(error: PlannerError) -> PyErr {
-        PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(error.to_string())
+    fn from(error: PlannerError) -> Self {
+        match error {
+            PlannerError::InvalidInput(message) => PyValueError::new_err(message),
+            PlannerError::Infeasible(message) => PyRuntimeError::new_err(message),
+        }
     }
 }
 
-#[pyfunction(signature = (model_name, profile_data, num_nodes, tensor_parallel_size=1))]
+#[pyfunction(
+    signature = (
+        model_name,
+        profile_data,
+        resource_counts,
+        tensor_parallel_size=1,
+        device_memory_bytes=None
+    )
+)]
 fn create_pipeline_templates(
     py: Python<'_>,
     model_name: String,
     profile_data: Vec<execution_result::LayerExecutionResult>,
-    mut num_nodes: Vec<u32>,
+    mut resource_counts: Vec<u32>,
     tensor_parallel_size: u32,
+    device_memory_bytes: Option<u64>,
 ) -> PyResult<Py<PyDict>> {
-    if num_nodes.is_empty() {
-        return Err(PlannerError::new("num_nodes must not be empty").into());
+    if model_name.trim().is_empty() {
+        return Err(PlannerError::invalid_input("model_name must not be empty").into());
+    }
+    if resource_counts.is_empty() {
+        return Err(PlannerError::invalid_input("resource_counts must not be empty").into());
+    }
+    if resource_counts.contains(&0) {
+        return Err(PlannerError::invalid_input("resource counts must be positive").into());
     }
     if tensor_parallel_size == 0 {
-        return Err(PlannerError::new("tensor_parallel_size must be positive").into());
+        return Err(PlannerError::invalid_input("tensor_parallel_size must be positive").into());
     }
-    num_nodes.sort_unstable();
-    num_nodes.dedup();
+    if device_memory_bytes == Some(0) {
+        return Err(
+            PlannerError::invalid_input("device_memory_bytes must be positive when supplied").into(),
+        );
+    }
 
-    let mut generator = PipelineTemplateGenerator::new(profile_data);
-    generator.divide_and_conquer(*num_nodes.last().unwrap())?;
+    resource_counts.sort_unstable();
+    resource_counts.dedup();
+    let max_resource_count = *resource_counts
+        .last()
+        .expect("non-empty resource counts were validated");
+    let mut generator = PipelineTemplateGenerator::new(profile_data)?;
+    generator.plan(max_resource_count, device_memory_bytes)?;
     let results = PyDict::new(py);
 
-    for num_node in num_nodes {
-        let result = generator.get_pipeline_template(num_node)?;
+    for resource_count in resource_counts {
+        let result = generator.get_pipeline_template(resource_count)?;
         let template = PyDict::new(py);
-        let ranges: Vec<(u32, u32)> = result
-            .stages
-            .iter()
-            .map(|stage| stage.layers)
-            .collect();
-        template.set_item("template_id", format!("{}-stages-{}", model_name, num_node))?;
+        let ranges: Vec<(u32, u32)> = result.stages.iter().map(|stage| stage.layers).collect();
+        template.set_item(
+            "template_id",
+            format!("{model_name}-stages-{resource_count}"),
+        )?;
         template.set_item("layer_ranges", ranges)?;
         template.set_item("tensor_parallel_size", tensor_parallel_size)?;
         template.set_item("forward_time", result.forward_time())?;
@@ -68,10 +102,13 @@ fn create_pipeline_templates(
         template.set_item("communication_time", 0.0)?;
         template.set_item("activation_memory", result.activation_memory())?;
         template.set_item("persistent_memory", result.persistent_memory())?;
-        template.set_item("max_microbatches", py.None())?;
+        template.set_item(
+            "max_microbatches",
+            result.max_microbatches(device_memory_bytes),
+        )?;
         template.set_item("fingerprint", py.None())?;
         template.set_item("schema_version", 1)?;
-        results.set_item(num_node, template)?;
+        results.set_item(resource_count, template)?;
     }
 
     Ok(results.unbind())
@@ -79,7 +116,6 @@ fn create_pipeline_templates(
 
 #[pymodule]
 fn planner(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    let _ = env_logger::try_init();
     m.add_function(wrap_pyfunction!(create_pipeline_templates, m)?)?;
     Ok(())
 }

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -100,6 +100,9 @@ fn create_pipeline_templates(
         template.set_item("forward_time", result.forward_time())?;
         template.set_item("backward_time", result.backward_time())?;
         template.set_item("communication_time", 0.0)?;
+        template.set_item("paper_t1", result.t1)?;
+        template.set_item("paper_t3", result.t3)?;
+        template.set_item("paper_bottleneck_stage", result.kstar)?;
         template.set_item("activation_memory", result.activation_memory())?;
         template.set_item("persistent_memory", result.persistent_memory())?;
         template.set_item(

--- a/rust/pipeline_template_generator.rs
+++ b/rust/pipeline_template_generator.rs
@@ -1,316 +1,364 @@
-use crate::execution_result::*;
+use crate::execution_result::{
+    LayerExecutionResult, PipelineExecutionResult, StageExecutionResult,
+};
 use crate::PlannerError;
-use dashmap::DashMap;
-use log;
-use rayon::prelude::*;
 use std::cmp::Ordering;
-use std::result::Result;
-use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+struct PartitionState {
+    bottleneck_latency: f64,
+    stage_starts: Vec<usize>,
+}
+
+impl PartitionState {
+    fn compare(&self, other: &Self) -> Ordering {
+        self.bottleneck_latency
+            .total_cmp(&other.bottleneck_latency)
+            .then_with(|| self.stage_starts.cmp(&other.stage_starts))
+    }
+}
 
 pub struct PipelineTemplateGenerator {
-    pub layer_execution_results: Vec<LayerExecutionResult>,
-    // Key: (layer_start_index, layer_end_index)
-    stage_execution_results: DashMap<(usize, usize), Arc<StageExecutionResult>>,
-    // Key: (num_stages, layer_start_index, layer_end_index)
-    execution_result_cache: DashMap<(u32, usize, usize), Result<PipelineExecutionResult, String>>,
+    layer_execution_results: Vec<LayerExecutionResult>,
+    stage_execution_results: Vec<Vec<Option<StageExecutionResult>>>,
+    pipeline_execution_results: Vec<Option<PipelineExecutionResult>>,
 }
 
 impl PipelineTemplateGenerator {
-    pub fn new(profile_data: Vec<LayerExecutionResult>) -> Self {
-        PipelineTemplateGenerator {
-            layer_execution_results: profile_data,
-            stage_execution_results: DashMap::new(),
-            execution_result_cache: DashMap::new(),
+    pub fn new(profile_data: Vec<LayerExecutionResult>) -> Result<Self, PlannerError> {
+        if profile_data.is_empty() {
+            return Err(PlannerError::invalid_input(
+                "profile_data must contain at least one layer",
+            ));
         }
+        for (index, layer) in profile_data.iter().enumerate() {
+            layer.validate(index)?;
+        }
+
+        let stage_execution_results = Self::build_stage_results(&profile_data)?;
+        Ok(Self {
+            layer_execution_results: profile_data,
+            stage_execution_results,
+            pipeline_execution_results: Vec::new(),
+        })
     }
 
-    pub fn divide_and_conquer(&mut self, max_num_nodes: u32) -> Result<(), PlannerError> {
-        if !self.stage_execution_results.is_empty() {
-            return Ok(());
+    fn checked_prefix(
+        profile_data: &[LayerExecutionResult],
+        value: impl Fn(&LayerExecutionResult) -> u64,
+        name: &str,
+    ) -> Result<Vec<u64>, PlannerError> {
+        let mut prefix = Vec::with_capacity(profile_data.len() + 1);
+        prefix.push(0_u64);
+        for layer in profile_data {
+            let next = prefix
+                .last()
+                .expect("prefix contains its zero element")
+                .checked_add(value(layer))
+                .ok_or_else(|| {
+                    PlannerError::invalid_input(format!(
+                        "{name} overflows u64 while aggregating profile_data"
+                    ))
+                })?;
+            prefix.push(next);
+        }
+        Ok(prefix)
+    }
+
+    fn build_stage_results(
+        profile_data: &[LayerExecutionResult],
+    ) -> Result<Vec<Vec<Option<StageExecutionResult>>>, PlannerError> {
+        let num_layers = profile_data.len();
+        let mut forward_prefix = Vec::with_capacity(num_layers + 1);
+        let mut backward_prefix = Vec::with_capacity(num_layers + 1);
+        forward_prefix.push(0.0);
+        backward_prefix.push(0.0);
+        for layer in profile_data {
+            forward_prefix.push(
+                forward_prefix
+                    .last()
+                    .expect("prefix contains its zero element")
+                    + layer.forward,
+            );
+            backward_prefix.push(
+                backward_prefix
+                    .last()
+                    .expect("prefix contains its zero element")
+                    + layer.backward,
+            );
+        }
+        let activation_prefix = Self::checked_prefix(
+            profile_data,
+            |layer| layer.activation_memory,
+            "activation_memory",
+        )?;
+        let persistent_prefix = Self::checked_prefix(
+            profile_data,
+            |layer| layer.persistent_memory,
+            "persistent_memory",
+        )?;
+
+        if !(forward_prefix[num_layers] + backward_prefix[num_layers]).is_finite() {
+            return Err(PlannerError::invalid_input(
+                "aggregate profile timing overflows f64",
+            ));
         }
 
+        let mut results = vec![vec![None; num_layers + 1]; num_layers];
+        for start in 0..num_layers {
+            for end in (start + 1)..=num_layers {
+                results[start][end] = Some(StageExecutionResult {
+                    layers: (start as u32, end as u32),
+                    forward: forward_prefix[end] - forward_prefix[start],
+                    backward: backward_prefix[end] - backward_prefix[start],
+                    activation_memory: activation_prefix[end] - activation_prefix[start],
+                    persistent_memory: persistent_prefix[end] - persistent_prefix[start],
+                });
+            }
+        }
+        Ok(results)
+    }
+
+    fn stage(&self, start: usize, end: usize) -> &StageExecutionResult {
+        self.stage_execution_results[start][end]
+            .as_ref()
+            .expect("only non-empty contiguous stages are requested")
+    }
+
+    pub fn plan(
+        &mut self,
+        max_resource_count: u32,
+        device_memory_bytes: Option<u64>,
+    ) -> Result<(), PlannerError> {
         let num_layers = self.layer_execution_results.len();
-
-        if max_num_nodes as usize > num_layers {
-            return Err(PlannerError::new("Invalid number of nodes"));
+        let max_stages = max_resource_count as usize;
+        if max_stages == 0 {
+            return Err(PlannerError::invalid_input(
+                "resource counts must be positive",
+            ));
+        }
+        if max_stages > num_layers {
+            return Err(PlannerError::invalid_input(format!(
+                "resource count {max_stages} exceeds the number of profiled layers {num_layers}"
+            )));
         }
 
-        // Put all base cases in the cache
-        (0..num_layers).into_par_iter().for_each(|i| {
-            ((i + 1)..=num_layers).into_par_iter().for_each(|j| {
-                let stage_execution_result = Arc::new(StageExecutionResult::new(
-                    &self.layer_execution_results[i..j],
-                ));
-                log::debug!(
-                    "StageExecutionResult({}, {})  -> {}",
-                    stage_execution_result.layers.0,
-                    stage_execution_result.layers.1,
-                    stage_execution_result.latency()
-                );
-                self.stage_execution_results
-                    .insert((i, j), stage_execution_result.clone());
-
-                let pipeline_execution_result =
-                    PipelineExecutionResult::make_base_result(stage_execution_result);
-                log::debug!(
-                    "PipelineExecutionResult({}, {}, {}) -> {}",
-                    1,
-                    i,
-                    j,
-                    pipeline_execution_result.latency()
-                );
-                self.execution_result_cache
-                    .insert((1, i, j), Ok(pipeline_execution_result));
-            });
+        let mut states = vec![vec![None::<PartitionState>; num_layers + 1]; max_stages + 1];
+        states[0][0] = Some(PartitionState {
+            bottleneck_latency: 0.0,
+            stage_starts: Vec::new(),
         });
 
-        log::debug!("Base cases inserted into the cache");
-
-        // Compute the rest of the results, gradually increasing the number of stages
-        // Number of stages can increase from 2 up to the number of nodes
-        // (currently more than two stages cannot be assigned to a node)
-        // Each number of stages all computations should be done before moving on to the next number of stages
-        for num_stages in 2..=max_num_nodes as u32 {
-            (0..num_layers).into_par_iter().for_each(|i| {
-                ((i + 1)..=num_layers).into_par_iter().for_each(|j| {
-                    let key = (num_stages, i, j);
-
-                    // If number of layers is less than number of stages, skip it
-                    // Cannot create specified number of stages with the given number of layers
-                    if j - i < num_stages as usize {
-                        self.execution_result_cache
-                            .insert(key, Err("Infeasible case".to_string()));
-                        return;
+        for num_stages in 1..=max_stages {
+            for end in num_stages..=num_layers {
+                let mut best: Option<PartitionState> = None;
+                for start in (num_stages - 1)..end {
+                    let Some(previous) = states[num_stages - 1][start].as_ref() else {
+                        continue;
+                    };
+                    let stage = self.stage(start, end);
+                    if !stage.fits_one_microbatch(device_memory_bytes) {
+                        continue;
                     }
+                    let mut stage_starts = previous.stage_starts.clone();
+                    stage_starts.push(start);
+                    let candidate = PartitionState {
+                        bottleneck_latency: previous.bottleneck_latency.max(stage.latency()),
+                        stage_starts,
+                    };
+                    if best
+                        .as_ref()
+                        .map_or(true, |current| candidate.compare(current) == Ordering::Less)
+                    {
+                        best = Some(candidate);
+                    }
+                }
+                states[num_stages][end] = best;
+            }
+        }
 
-                    // Spawn a task to compute the result for this subproblem.
-                    let best_result = (i..j)
-                        .into_par_iter()
-                        .map(|num_layers_left| {
-                            let mut result: Result<PipelineExecutionResult, String> =
-                                Err("Error in subproblem".to_string());
-
-                            for num_stages_left in 1..num_stages {
-                                let num_stages_right = num_stages - num_stages_left;
-
-                                if num_layers_left - i == 0 || j - num_layers_left == 0 {
-                                    continue;
-                                }
-
-                                // As we gradually increase the number of stages from 1,
-                                // we must have already computed the results for the subproblems
-                                let left = self
-                                    .execution_result_cache
-                                    .get(&(num_stages_left, i, num_layers_left))
-                                    .unwrap();
-                                let right = self
-                                    .execution_result_cache
-                                    .get(&(num_stages_right, num_layers_left, j))
-                                    .unwrap();
-
-                                if left.is_err() || right.is_err() {
-                                    continue;
-                                }
-
-                                // Merge two subproblems into a bigger PipelineExecutionResult
-                                let local_result = PipelineExecutionResult::new(
-                                    left.as_ref().unwrap(),
-                                    right.as_ref().unwrap(),
-                                );
-                                if result.is_err()
-                                    || local_result.cmp(result.as_ref().unwrap()) == Ordering::Less
-                                {
-                                    result = Ok(local_result);
-                                }
-                            }
-
-                            result
-                        })
-                        .reduce(
-                            || Err("Error in subproblem".to_string()),
-                            |acc, result| {
-                                if result.is_err() {
-                                    return acc;
-                                } else if acc.is_err() {
-                                    return result;
-                                } else if result.as_ref().unwrap() < acc.as_ref().unwrap() {
-                                    return result;
-                                } else {
-                                    return acc;
-                                }
-                            },
-                        );
-
-                    log::debug!(
-                        "PipelineExecutionResult({}, {}, {}) -> {}",
-                        num_stages,
-                        i,
-                        j,
-                        if best_result.is_ok() {
-                            best_result.as_ref().unwrap().latency()
-                        } else {
-                            0.0
-                        }
-                    );
-                    self.execution_result_cache.insert(key, best_result);
-                })
-            });
+        self.pipeline_execution_results = vec![None; max_stages + 1];
+        for num_stages in 1..=max_stages {
+            let Some(state) = states[num_stages][num_layers].as_ref() else {
+                continue;
+            };
+            let mut stages = Vec::with_capacity(num_stages);
+            for (index, start) in state.stage_starts.iter().copied().enumerate() {
+                let end = state
+                    .stage_starts
+                    .get(index + 1)
+                    .copied()
+                    .unwrap_or(num_layers);
+                stages.push(self.stage(start, end).clone());
+            }
+            self.pipeline_execution_results[num_stages] =
+                Some(PipelineExecutionResult { stages });
         }
         Ok(())
     }
 
     pub fn get_pipeline_template(
         &self,
-        num_nodes: u32,
+        resource_count: u32,
     ) -> Result<PipelineExecutionResult, PlannerError> {
-        log::debug!(
-            "get_pipeline_template({}, {}, {})",
-            num_nodes,
-            0,
-            self.layer_execution_results.len()
-        );
-
-        let result =
-            self.execution_result_cache
-                .get(&(num_nodes, 0, self.layer_execution_results.len()));
-
-        match result {
-            Some(result) => Ok(result.value().clone().unwrap()),
-            None => Err(PlannerError::new(
-                format!("No pipeline template for {} nodes", num_nodes).as_str(),
-            ))?,
-        }
+        self.pipeline_execution_results
+            .get(resource_count as usize)
+            .and_then(Option::as_ref)
+            .cloned()
+            .ok_or_else(|| {
+                PlannerError::infeasible(format!(
+                    "pipeline template for resource count {resource_count} cannot fit one microbatch in device memory"
+                ))
+            })
     }
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
-    fn prepare(
-        num_layers: u32,
-        same_latency: bool,
-        mut num_nodes: Vec<u32>,
-    ) -> Result<PipelineTemplateGenerator, PlannerError> {
-        let mut layer_results = vec![];
-        for i in 0..num_layers {
-            layer_results.push(LayerExecutionResult {
-                layer_index: i,
-                layer_name: format!("layer{}", i),
-                forward: if same_latency {
-                    1 as f64
-                } else {
-                    (i + 1) as f64
-                },
-                backward: if same_latency {
-                    1 as f64
-                } else {
-                    (i + 1) as f64
-                },
-                mem_required: if same_latency {
-                    1 as u64
-                } else {
-                    (i + 1) as u64
-                },
-                activation_memory: (i + 1) as u64,
-                persistent_memory: (i + 1) as u64 * 2,
-            });
+    fn layer(index: u32, latency: f64, activation_memory: u64) -> LayerExecutionResult {
+        LayerExecutionResult {
+            layer_index: index,
+            layer_name: format!("layer{index}"),
+            forward: latency,
+            backward: 0.0,
+            activation_memory,
+            persistent_memory: 0,
         }
+    }
 
-        num_nodes.sort();
-
-        let mut generator = PipelineTemplateGenerator::new(layer_results);
-        generator.divide_and_conquer(num_nodes[num_nodes.len() - 1])?;
+    fn prepare(
+        latencies: &[f64],
+        max_resource_count: u32,
+        device_memory_bytes: Option<u64>,
+    ) -> Result<PipelineTemplateGenerator, PlannerError> {
+        let profile = latencies
+            .iter()
+            .enumerate()
+            .map(|(index, latency)| layer(index as u32, *latency, 1))
+            .collect();
+        let mut generator = PipelineTemplateGenerator::new(profile)?;
+        generator.plan(max_resource_count, device_memory_bytes)?;
         Ok(generator)
     }
 
-    #[test]
-    fn test_return_no_template_for_too_large_num_nodes() {
-        let generator = prepare(6, true, vec![7]);
-        assert!(generator.is_err());
+    fn ranges(result: &PipelineExecutionResult) -> Vec<(u32, u32)> {
+        result.stages.iter().map(|stage| stage.layers).collect()
+    }
 
-        let generator = prepare(6, true, vec![6]);
-        assert!(generator.is_ok());
-        assert!(generator.unwrap().get_pipeline_template(7).is_err());
+    fn brute_force_bottleneck(
+        latencies: &[f64],
+        stages: usize,
+        start: usize,
+    ) -> Option<f64> {
+        if stages == 1 {
+            return Some(latencies[start..].iter().sum());
+        }
+        let mut best: Option<f64> = None;
+        for end in (start + 1)..=(latencies.len() - stages + 1) {
+            let first: f64 = latencies[start..end].iter().sum();
+            let suffix = brute_force_bottleneck(latencies, stages - 1, end)?;
+            let candidate = first.max(suffix);
+            best = Some(best.map_or(candidate, |current| current.min(candidate)));
+        }
+        best
     }
 
     #[test]
-    fn test_all_layers_covered() {
-        let generator = prepare(6, false, vec![1, 2, 3, 4, 5, 6]).unwrap();
-        let expected_layers: Vec<u32> = (0..6).map(|i| i).collect();
+    fn rejects_invalid_profiles_and_resource_counts() {
+        assert!(PipelineTemplateGenerator::new(Vec::new()).is_err());
+        let mut invalid = layer(1, 1.0, 1);
+        assert!(PipelineTemplateGenerator::new(vec![invalid.clone()]).is_err());
+        invalid.layer_index = 0;
+        invalid.forward = f64::NAN;
+        assert!(PipelineTemplateGenerator::new(vec![invalid]).is_err());
 
-        for i in 1..=6 {
-            let template = generator.get_pipeline_template(i).unwrap();
-            let mut covered_layers: Vec<u32> = Vec::new();
-            for stage in template.stages.iter() {
-                for layer in stage.layers.0..stage.layers.1 {
-                    covered_layers.push(layer);
-                }
+        let mut generator = prepare(&[1.0, 2.0], 2, None).unwrap();
+        assert!(generator.plan(0, None).is_err());
+        assert!(generator.plan(3, None).is_err());
+    }
+
+    #[test]
+    fn returns_contiguous_globally_optimal_partitions() {
+        let generator = prepare(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 4, None).unwrap();
+        for stage_count in 1..=4 {
+            let result = generator.get_pipeline_template(stage_count).unwrap();
+            assert_eq!(result.stages.len(), stage_count as usize);
+            assert_eq!(result.stages.first().unwrap().layers.0, 0);
+            assert_eq!(result.stages.last().unwrap().layers.1, 6);
+            for adjacent in result.stages.windows(2) {
+                assert_eq!(adjacent[0].layers.1, adjacent[1].layers.0);
             }
-            assert_eq!(covered_layers, expected_layers);
+            assert_eq!(
+                result.bottleneck_latency(),
+                brute_force_bottleneck(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], stage_count as usize, 0)
+                    .unwrap()
+            );
+        }
+        assert_eq!(
+            ranges(&generator.get_pipeline_template(2).unwrap()),
+            vec![(0, 4), (4, 6)]
+        );
+    }
+
+    #[test]
+    fn fixes_the_legacy_non_optimal_subproblem_counterexample() {
+        let latencies = [91.0, 45.0, 29.0, 75.0, 73.0, 66.0, 99.0, 81.0, 83.0, 83.0];
+        let generator = prepare(&latencies, 6, None).unwrap();
+        let result = generator.get_pipeline_template(6).unwrap();
+        assert_eq!(
+            ranges(&result),
+            vec![(0, 2), (2, 4), (4, 6), (6, 7), (7, 9), (9, 10)]
+        );
+        assert_eq!(
+            result.bottleneck_latency(),
+            brute_force_bottleneck(&latencies, 6, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn uses_lexicographically_smallest_cuts_for_equal_costs() {
+        let generator = prepare(&[1.0, 1.0, 1.0], 2, None).unwrap();
+        assert_eq!(
+            ranges(&generator.get_pipeline_template(2).unwrap()),
+            vec![(0, 1), (1, 3)]
+        );
+    }
+
+    #[test]
+    fn excludes_fast_partitions_that_do_not_fit_memory() {
+        let profile = vec![layer(0, 1.0, 8), layer(1, 5.0, 5), layer(2, 6.0, 1)];
+        let mut generator = PipelineTemplateGenerator::new(profile).unwrap();
+        generator.plan(2, Some(10)).unwrap();
+        let result = generator.get_pipeline_template(2).unwrap();
+        assert_eq!(ranges(&result), vec![(0, 1), (1, 3)]);
+        assert_eq!(result.bottleneck_latency(), 11.0);
+        assert_eq!(result.max_microbatches(Some(10)), Some(1));
+    }
+
+    #[test]
+    fn plans_realistic_layer_and_resource_counts() {
+        let latencies: Vec<f64> = (1..=96).map(f64::from).collect();
+        let generator = prepare(&latencies, 64, None).unwrap();
+        for resource_count in 1..=64 {
+            let result = generator.get_pipeline_template(resource_count).unwrap();
+            assert_eq!(result.stages.len(), resource_count as usize);
         }
     }
 
     #[test]
-    fn test_divide_and_conquer_base_only() {
-        let generator = prepare(6, false, vec![1]).unwrap();
-        let template = generator.get_pipeline_template(1).unwrap();
-
-        assert_eq!(template.stages.len(), 1);
-        assert_eq!(template.stages[0].layers, (0, 6));
+    fn rejects_aggregate_timing_overflow() {
+        let profile = vec![layer(0, 1.0e308, 1), layer(1, 1.0e308, 1)];
+        assert!(PipelineTemplateGenerator::new(profile).is_err());
     }
 
     #[test]
-    fn test_divide_and_conquer_divide() {
-        // Uneven distribution test
-        let generator = prepare(6, false, vec![1, 2]).unwrap();
-
-        // Template for 1 node
-        let template = generator.get_pipeline_template(1).unwrap();
-        assert_eq!(template.stages.len(), 1);
-        assert_eq!(template.stages[0].layers, (0, 6));
-
-        let template = generator.get_pipeline_template(2).unwrap();
-        assert_eq!(template.stages.len(), 2);
-        assert_eq!(template.stages[0].layers, (0, 4));
-        assert_eq!(template.stages[1].layers, (4, 6));
-
-        let generator = prepare(6, true, vec![1, 2]).unwrap();
-        let template = generator.get_pipeline_template(2).unwrap();
-        assert_eq!(template.stages.len(), 2);
-        assert_eq!(template.stages[0].layers, (0, 3));
-        assert_eq!(template.stages[1].layers, (3, 6));
-    }
-
-    #[test]
-    fn test_divide_and_conquer_divide2() {
-        let generator = prepare(6, false, vec![2, 3, 4]).unwrap();
-        let template = generator.get_pipeline_template(2).unwrap();
-        assert_eq!(template.stages.len(), 2);
-        assert_eq!(template.stages[0].layers, (0, 4));
-        assert_eq!(template.stages[1].layers, (4, 6));
-
-        let template = generator.get_pipeline_template(3).unwrap();
-        assert_eq!(template.stages.len(), 3);
-        assert_eq!(template.stages[0].layers, (0, 3));
-        assert_eq!(template.stages[1].layers, (3, 5));
-        assert_eq!(template.stages[2].layers, (5, 6));
-
-        let template = generator.get_pipeline_template(4).unwrap();
-        assert_eq!(template.stages.len(), 4);
-        assert_eq!(template.stages[0].layers, (0, 3));
-        assert_eq!(template.stages[1].layers, (3, 4));
-        assert_eq!(template.stages[2].layers, (4, 5));
-        assert_eq!(template.stages[3].layers, (5, 6));
-    }
-
-    #[test]
-    fn test_measure_time_of_large_model() {
-        let generator = prepare(96, false, vec![64]).unwrap();
-        for i in 1..=64 {
-            let template_result = generator.get_pipeline_template(i);
-            assert!(template_result.is_ok());
-            assert_eq!(template_result.unwrap().stages.len(), i as usize);
-        }
+    fn reports_infeasible_memory_with_context() {
+        let profile = vec![layer(0, 1.0, 11), layer(1, 1.0, 1)];
+        let mut generator = PipelineTemplateGenerator::new(profile).unwrap();
+        generator.plan(1, Some(10)).unwrap();
+        let error = generator.get_pipeline_template(1).unwrap_err();
+        assert!(error.to_string().contains("resource count 1"));
     }
 }

--- a/rust/pipeline_template_generator.rs
+++ b/rust/pipeline_template_generator.rs
@@ -4,18 +4,13 @@ use crate::execution_result::{
 use crate::PlannerError;
 use std::cmp::Ordering;
 
-#[derive(Clone, Debug)]
-struct PartitionState {
-    bottleneck_latency: f64,
-    stage_starts: Vec<usize>,
-}
-
-impl PartitionState {
-    fn compare(&self, other: &Self) -> Ordering {
-        self.bottleneck_latency
-            .total_cmp(&other.bottleneck_latency)
-            .then_with(|| self.stage_starts.cmp(&other.stage_starts))
-    }
+#[derive(Clone, Copy, Debug)]
+struct BottleneckCandidate {
+    start: usize,
+    end: usize,
+    latency: f64,
+    min_prefix_stages: usize,
+    min_suffix_stages: usize,
 }
 
 pub struct PipelineTemplateGenerator {
@@ -125,6 +120,230 @@ impl PipelineTemplateGenerator {
             .expect("only non-empty contiguous stages are requested")
     }
 
+    fn latency_within(&self, start: usize, end: usize, threshold: f64, inclusive: bool) -> bool {
+        let ordering = self.stage(start, end).latency().total_cmp(&threshold);
+        ordering == Ordering::Less || (inclusive && ordering == Ordering::Equal)
+    }
+
+    fn stage_allowed(
+        &self,
+        start: usize,
+        end: usize,
+        threshold: f64,
+        inclusive: bool,
+        device_memory_bytes: Option<u64>,
+    ) -> bool {
+        self.stage(start, end).fits_one_microbatch(device_memory_bytes)
+            && self.latency_within(start, end, threshold, inclusive)
+    }
+
+    /// Minimum number of contiguous stages needed for [start, end) under a
+    /// bottleneck bound. Non-negative additive time and memory make the greedy
+    /// longest-feasible-stage choice optimal. Any count up to the number of
+    /// layers is then reachable by splitting stages.
+    fn min_segments(
+        &self,
+        start: usize,
+        end: usize,
+        threshold: f64,
+        inclusive: bool,
+        device_memory_bytes: Option<u64>,
+    ) -> Option<usize> {
+        let mut position = start;
+        let mut count = 0;
+        while position < end {
+            let mut farthest = None;
+            for next in (position + 1)..=end {
+                if self.stage_allowed(
+                    position,
+                    next,
+                    threshold,
+                    inclusive,
+                    device_memory_bytes,
+                ) {
+                    farthest = Some(next);
+                } else {
+                    break;
+                }
+            }
+            position = farthest?;
+            count += 1;
+        }
+        Some(count)
+    }
+
+    /// Return the lexicographically smallest exact partition under a latency
+    /// bound. This is used only to materialize a winning paper candidate; the
+    /// feasibility bounds are shared by every requested template size.
+    fn lexicographic_partition(
+        &self,
+        start: usize,
+        end: usize,
+        count: usize,
+        threshold: f64,
+        inclusive: bool,
+        device_memory_bytes: Option<u64>,
+    ) -> Option<Vec<usize>> {
+        if count == 0 {
+            return (start == end).then(Vec::new);
+        }
+        if count > end - start {
+            return None;
+        }
+
+        let mut starts = Vec::with_capacity(count);
+        let mut position = start;
+        for stage_index in 0..count {
+            starts.push(position);
+            let remaining = count - stage_index - 1;
+            if remaining == 0 {
+                return self
+                    .stage_allowed(
+                        position,
+                        end,
+                        threshold,
+                        inclusive,
+                        device_memory_bytes,
+                    )
+                    .then_some(starts);
+            }
+
+            let latest = end - remaining;
+            let mut chosen = None;
+            for next in (position + 1)..=latest {
+                if !self.stage_allowed(
+                    position,
+                    next,
+                    threshold,
+                    inclusive,
+                    device_memory_bytes,
+                ) {
+                    break;
+                }
+                let minimum = self.min_segments(
+                    next,
+                    end,
+                    threshold,
+                    inclusive,
+                    device_memory_bytes,
+                );
+                if minimum.is_some_and(|minimum| minimum <= remaining)
+                    && remaining <= end - next
+                {
+                    chosen = Some(next);
+                    break;
+                }
+            }
+            position = chosen?;
+        }
+        None
+    }
+
+    fn bottleneck_candidates(
+        &self,
+        device_memory_bytes: Option<u64>,
+    ) -> Vec<BottleneckCandidate> {
+        let num_layers = self.layer_execution_results.len();
+        let mut candidates = Vec::new();
+        for start in 0..num_layers {
+            for end in (start + 1)..=num_layers {
+                let stage = self.stage(start, end);
+                if !stage.fits_one_microbatch(device_memory_bytes) {
+                    continue;
+                }
+                let latency = stage.latency();
+                let Some(min_prefix_stages) = self.min_segments(
+                    0,
+                    start,
+                    latency,
+                    true,
+                    device_memory_bytes,
+                ) else {
+                    continue;
+                };
+                // k* is the rightmost bottleneck, so following stages must be
+                // strictly faster while preceding stages may tie it.
+                let Some(min_suffix_stages) = self.min_segments(
+                    end,
+                    num_layers,
+                    latency,
+                    false,
+                    device_memory_bytes,
+                ) else {
+                    continue;
+                };
+                candidates.push(BottleneckCandidate {
+                    start,
+                    end,
+                    latency,
+                    min_prefix_stages,
+                    min_suffix_stages,
+                });
+            }
+        }
+        candidates
+    }
+
+    fn materialize_candidate(
+        &self,
+        candidate: BottleneckCandidate,
+        prefix_stages: usize,
+        total_stages: usize,
+        device_memory_bytes: Option<u64>,
+    ) -> Option<PipelineExecutionResult> {
+        let suffix_stages = total_stages - prefix_stages - 1;
+        let mut starts = self.lexicographic_partition(
+            0,
+            candidate.start,
+            prefix_stages,
+            candidate.latency,
+            true,
+            device_memory_bytes,
+        )?;
+        starts.push(candidate.start);
+        starts.extend(self.lexicographic_partition(
+            candidate.end,
+            self.layer_execution_results.len(),
+            suffix_stages,
+            candidate.latency,
+            false,
+            device_memory_bytes,
+        )?);
+
+        let ends = starts
+            .iter()
+            .copied()
+            .skip(1)
+            .chain(std::iter::once(self.layer_execution_results.len()));
+        let mut stages = starts
+            .iter()
+            .copied()
+            .zip(ends)
+            .map(|(start, end)| self.stage(start, end).clone());
+        let first = stages
+            .next()
+            .expect("a materialized candidate always contains its bottleneck stage");
+        let mut result = PipelineExecutionResult::from_stage(first);
+        for stage in stages {
+            let right = PipelineExecutionResult::from_stage(stage);
+            result = PipelineExecutionResult::combine(&result, &right);
+        }
+        debug_assert_eq!(result.kstar, prefix_stages);
+        Some(result)
+    }
+
+    /// Generate fixed-TP templates using Oobleck Section 4.1.2, Equations 1--4.
+    ///
+    /// The paper jointly divides layers and devices. The refactored runtime
+    /// treats one complete fixed-TP node as an indivisible logical device, so
+    /// S=d=n and the within-node GPU split m disappears. For every possible
+    /// rightmost bottleneck stage this method derives T1, T2, and T3 exactly,
+    /// checks whether its left and right subproblems can be conquered, and
+    /// chooses the minimum paper iteration time with Nb=4S.
+    ///
+    /// Stage metrics and bottleneck feasibility summaries are built once and
+    /// reused for every resource count in this invocation, preserving the
+    /// cross-template cache reuse of the artifact implementation.
     pub fn plan(
         &mut self,
         max_resource_count: u32,
@@ -143,56 +362,70 @@ impl PipelineTemplateGenerator {
             )));
         }
 
-        let mut states = vec![vec![None::<PartitionState>; num_layers + 1]; max_stages + 1];
-        states[0][0] = Some(PartitionState {
-            bottleneck_latency: 0.0,
-            stage_starts: Vec::new(),
-        });
+        let candidates = self.bottleneck_candidates(device_memory_bytes);
+        let total_work = self.stage(0, num_layers).latency();
+        self.pipeline_execution_results = vec![None; max_stages + 1];
 
-        for num_stages in 1..=max_stages {
-            for end in num_stages..=num_layers {
-                let mut best: Option<PartitionState> = None;
-                for start in (num_stages - 1)..end {
-                    let Some(previous) = states[num_stages - 1][start].as_ref() else {
-                        continue;
-                    };
-                    let stage = self.stage(start, end);
-                    if !stage.fits_one_microbatch(device_memory_bytes) {
+        for total_stages in 1..=max_stages {
+            let mut best: Option<PipelineExecutionResult> = None;
+            for candidate in candidates.iter().copied() {
+                let prefix_lower = candidate
+                    .min_prefix_stages
+                    .max(total_stages.saturating_sub(1 + (num_layers - candidate.end)));
+                let prefix_upper = candidate.start.min(
+                    total_stages
+                        .saturating_sub(1 + candidate.min_suffix_stages),
+                );
+                if prefix_lower > prefix_upper || prefix_lower >= total_stages {
+                    continue;
+                }
+
+                // Increasing k* adds one bottleneck latency to Equation 2.
+                // Only a zero-latency bottleneck can tie across several k*s.
+                let prefix_range = if candidate.latency == 0.0 {
+                    prefix_lower..=prefix_upper
+                } else {
+                    prefix_lower..=prefix_lower
+                };
+                for prefix_stages in prefix_range {
+                    let t3 = self.stage(candidate.start, num_layers).latency();
+                    let predicted = total_work
+                        + (3 * total_stages + prefix_stages - 1) as f64
+                            * candidate.latency
+                        + t3;
+                    if best.as_ref().is_some_and(|current| {
+                        predicted.total_cmp(&current.planning_iteration_time())
+                            == Ordering::Greater
+                    }) {
                         continue;
                     }
-                    let mut stage_starts = previous.stage_starts.clone();
-                    stage_starts.push(start);
-                    let candidate = PartitionState {
-                        bottleneck_latency: previous.bottleneck_latency.max(stage.latency()),
-                        stage_starts,
+                    let Some(result) = self.materialize_candidate(
+                        candidate,
+                        prefix_stages,
+                        total_stages,
+                        device_memory_bytes,
+                    ) else {
+                        continue;
                     };
-                    if best
-                        .as_ref()
-                        .map_or(true, |current| candidate.compare(current) == Ordering::Less)
-                    {
-                        best = Some(candidate);
+                    let replace = best.as_ref().map_or(true, |current| {
+                        result
+                            .planning_iteration_time()
+                            .total_cmp(&current.planning_iteration_time())
+                            .then_with(|| {
+                                result
+                                    .stages
+                                    .iter()
+                                    .map(|stage| stage.layers.0)
+                                    .cmp(current.stages.iter().map(|stage| stage.layers.0))
+                            })
+                            == Ordering::Less
+                    });
+                    if replace {
+                        best = Some(result);
                     }
                 }
-                states[num_stages][end] = best;
             }
-        }
-
-        self.pipeline_execution_results = vec![None; max_stages + 1];
-        for num_stages in 1..=max_stages {
-            let Some(state) = states[num_stages][num_layers].as_ref() else {
-                continue;
-            };
-            let mut stages = Vec::with_capacity(num_stages);
-            for (index, start) in state.stage_starts.iter().copied().enumerate() {
-                let end = state
-                    .stage_starts
-                    .get(index + 1)
-                    .copied()
-                    .unwrap_or(num_layers);
-                stages.push(self.stage(start, end).clone());
-            }
-            self.pipeline_execution_results[num_stages] =
-                Some(PipelineExecutionResult { stages });
+            self.pipeline_execution_results[total_stages] = best;
         }
         Ok(())
     }
@@ -247,22 +480,68 @@ mod tests {
         result.stages.iter().map(|stage| stage.layers).collect()
     }
 
-    fn brute_force_bottleneck(
-        latencies: &[f64],
-        stages: usize,
-        start: usize,
-    ) -> Option<f64> {
-        if stages == 1 {
-            return Some(latencies[start..].iter().sum());
+    fn paper_time(latencies: &[f64], starts: &[usize]) -> f64 {
+        let ends = starts
+            .iter()
+            .copied()
+            .skip(1)
+            .chain(std::iter::once(latencies.len()));
+        let work: Vec<f64> = starts
+            .iter()
+            .copied()
+            .zip(ends)
+            .map(|(start, end)| latencies[start..end].iter().sum())
+            .collect();
+        let kstar = work
+            .iter()
+            .enumerate()
+            .max_by(|left, right| {
+                left.1
+                    .total_cmp(right.1)
+                    .then_with(|| left.0.cmp(&right.0))
+            })
+            .unwrap()
+            .0;
+        let t1: f64 = work.iter().sum();
+        let t3: f64 = work[kstar..].iter().sum();
+        let t2 = (3 * starts.len() + kstar - 1) as f64 * work[kstar];
+        t1 + t2 + t3
+    }
+
+    fn brute_force(latencies: &[f64], stages: usize) -> (f64, Vec<usize>) {
+        fn visit(
+            latencies: &[f64],
+            stages: usize,
+            next: usize,
+            starts: &mut Vec<usize>,
+            best: &mut Option<(f64, Vec<usize>)>,
+        ) {
+            if starts.len() == stages {
+                let candidate = (paper_time(latencies, starts), starts.clone());
+                if best.as_ref().map_or(true, |current| {
+                    candidate
+                        .0
+                        .total_cmp(&current.0)
+                        .then_with(|| candidate.1.cmp(&current.1))
+                        == Ordering::Less
+                }) {
+                    *best = Some(candidate);
+                }
+                return;
+            }
+            let remaining_starts = stages - starts.len();
+            let last = latencies.len() - remaining_starts;
+            for start in next..=last {
+                starts.push(start);
+                visit(latencies, stages, start + 1, starts, best);
+                starts.pop();
+            }
         }
-        let mut best: Option<f64> = None;
-        for end in (start + 1)..=(latencies.len() - stages + 1) {
-            let first: f64 = latencies[start..end].iter().sum();
-            let suffix = brute_force_bottleneck(latencies, stages - 1, end)?;
-            let candidate = first.max(suffix);
-            best = Some(best.map_or(candidate, |current| current.min(candidate)));
-        }
-        best
+
+        let mut best = None;
+        let mut starts = vec![0];
+        visit(latencies, stages, 1, &mut starts, &mut best);
+        best.unwrap()
     }
 
     #[test]
@@ -280,46 +559,51 @@ mod tests {
     }
 
     #[test]
-    fn returns_contiguous_globally_optimal_partitions() {
-        let generator = prepare(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], 4, None).unwrap();
+    fn matches_an_exhaustive_paper_objective_oracle() {
+        let latencies = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let generator = prepare(&latencies, 4, None).unwrap();
         for stage_count in 1..=4 {
             let result = generator.get_pipeline_template(stage_count).unwrap();
-            assert_eq!(result.stages.len(), stage_count as usize);
-            assert_eq!(result.stages.first().unwrap().layers.0, 0);
-            assert_eq!(result.stages.last().unwrap().layers.1, 6);
-            for adjacent in result.stages.windows(2) {
-                assert_eq!(adjacent[0].layers.1, adjacent[1].layers.0);
-            }
+            let expected = brute_force(&latencies, stage_count as usize);
             assert_eq!(
-                result.bottleneck_latency(),
-                brute_force_bottleneck(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0], stage_count as usize, 0)
-                    .unwrap()
+                result.stages.iter().map(|stage| stage.layers.0 as usize).collect::<Vec<_>>(),
+                expected.1
             );
+            assert_eq!(result.planning_iteration_time(), expected.0);
         }
-        assert_eq!(
-            ranges(&generator.get_pipeline_template(2).unwrap()),
-            vec![(0, 4), (4, 6)]
-        );
     }
 
     #[test]
-    fn fixes_the_legacy_non_optimal_subproblem_counterexample() {
+    fn fixes_the_legacy_single_result_cache_counterexample() {
         let latencies = [91.0, 45.0, 29.0, 75.0, 73.0, 66.0, 99.0, 81.0, 83.0, 83.0];
         let generator = prepare(&latencies, 6, None).unwrap();
         let result = generator.get_pipeline_template(6).unwrap();
+        let expected = brute_force(&latencies, 6);
         assert_eq!(
-            ranges(&result),
-            vec![(0, 2), (2, 4), (4, 6), (6, 7), (7, 9), (9, 10)]
+            result.stages.iter().map(|stage| stage.layers.0 as usize).collect::<Vec<_>>(),
+            expected.1
         );
-        assert_eq!(
-            result.bottleneck_latency(),
-            brute_force_bottleneck(&latencies, 6, 0).unwrap()
-        );
+        assert_eq!(result.planning_iteration_time(), expected.0);
     }
 
     #[test]
-    fn uses_lexicographically_smallest_cuts_for_equal_costs() {
-        let generator = prepare(&[1.0, 1.0, 1.0], 2, None).unwrap();
+    fn follows_equations_one_through_four() {
+        let generator = prepare(&[2.0, 3.0, 4.0], 2, None).unwrap();
+        let result = generator.get_pipeline_template(2).unwrap();
+        assert_eq!(result.t1, 9.0);
+        assert_eq!(
+            result.t3,
+            result.stages[result.kstar..]
+                .iter()
+                .map(StageExecutionResult::latency)
+                .sum::<f64>()
+        );
+        assert_eq!(result.planning_iteration_time(), result.iteration_time(8));
+    }
+
+    #[test]
+    fn uses_lexicographically_smallest_cuts_for_equal_paper_costs() {
+        let generator = prepare(&[0.0, 0.0, 0.0], 2, None).unwrap();
         assert_eq!(
             ranges(&generator.get_pipeline_template(2).unwrap()),
             vec![(0, 1), (1, 3)]
@@ -327,18 +611,17 @@ mod tests {
     }
 
     #[test]
-    fn excludes_fast_partitions_that_do_not_fit_memory() {
+    fn excludes_paper_candidates_that_do_not_fit_memory() {
         let profile = vec![layer(0, 1.0, 8), layer(1, 5.0, 5), layer(2, 6.0, 1)];
         let mut generator = PipelineTemplateGenerator::new(profile).unwrap();
         generator.plan(2, Some(10)).unwrap();
         let result = generator.get_pipeline_template(2).unwrap();
         assert_eq!(ranges(&result), vec![(0, 1), (1, 3)]);
-        assert_eq!(result.bottleneck_latency(), 11.0);
         assert_eq!(result.max_microbatches(Some(10)), Some(1));
     }
 
     #[test]
-    fn plans_realistic_layer_and_resource_counts() {
+    fn one_shared_cache_produces_every_requested_template_size() {
         let latencies: Vec<f64> = (1..=96).map(f64::from).collect();
         let generator = prepare(&latencies, 64, None).unwrap();
         for resource_count in 1..=64 {

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -2,12 +2,6 @@
 
 These items are intentionally deferred until the DP/PP/TP elastic runtime and its recovery path are complete.
 
-## Refactor the Rust pipeline planner
-
-The initial Oobleck refactor will reuse the current Rust pipeline-template planner behind a narrow, versioned Python API. It will receive correctness fixes, tests, and the required PyO3 upgrade, but its internal design will not be substantially rewritten in the first implementation.
-
-Later work should simplify the planner's data model, separate enumeration from optimization, replace legacy assumptions and naming, improve error reporting, benchmark a pure-Python or alternative solver where useful, and document the Rust/Python boundary. Preserve behavioral fixtures for template generation and simple/borrow/merge decisions before changing the implementation.
-
 ## Add context and expert parallelism
 
 The first implementation supports LLM DP/PP/TP with fixed per-node TP width. Add Cornstarch context parallelism (CP) and expert parallelism (EP) after that path is stable.

--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -7,3 +7,14 @@ These items are intentionally deferred until the DP/PP/TP elastic runtime and it
 The first implementation supports LLM DP/PP/TP with fixed per-node TP width. Add Cornstarch context parallelism (CP) and expert parallelism (EP) after that path is stable.
 
 This work must extend template resource modeling, heterogeneous mesh construction, logical state manifests, gradient synchronization, all-to-all state redistribution, replay determinism, and the single-GPU distributed tests. EP also needs expert ownership/migration policy; CP needs sequence-shard and dataloader semantics across a reconfiguration. Cover CP and EP independently before testing their composition with heterogeneous PP and elastic recovery.
+
+## Generalize paper GPU--stage mapping beyond fixed per-node TP
+
+The Rust planner now implements Section 4.1.2's `T1 + T2 + T3` objective for
+the refactored runtime's supported `S = d = n` case: one complete fixed-TP node
+per pipeline stage. Restore the paper's remaining `S > n` search and within-node
+GPU split `m` only after Cornstarch can instantiate multiple pipeline stages in
+one node with stage-specific TP widths. That work must extend template ownership,
+rank-grid construction, profile data indexed by GPU width, heterogeneous meshes,
+and state synchronization together; planner-only output that the runtime cannot
+instantiate is not acceptable.

--- a/tests/refactor/test_benchmark.py
+++ b/tests/refactor/test_benchmark.py
@@ -1,3 +1,4 @@
+from benchmarks.pipeline_planner import run as run_pipeline_planner
 from benchmarks.recovery_schedule import run
 from benchmarks.transaction_overhead import run as run_transaction_overhead
 
@@ -24,3 +25,11 @@ def test_transaction_overhead_benchmark_replays_once_and_matches_reference():
     assert result["committed_step"] == 3
     assert result["numerically_equivalent"] is True
     assert len(result["replayed_sample_indices"]) == 4
+
+
+def test_pipeline_planner_benchmark_matches_backends():
+    result = run_pipeline_planner(layers=12, max_resources=6, repeats=1)
+    assert result["backends_match"] is True
+    assert result["scenario"]["template_count"] == 6
+    assert result["rust_seconds"] >= 0
+    assert result["python_seconds"] >= 0

--- a/tests/refactor/test_generator.py
+++ b/tests/refactor/test_generator.py
@@ -1,3 +1,6 @@
+from itertools import combinations
+import math
+
 import pytest
 
 from oobleck.planning import LayerExecutionResult, create_pipeline_templates
@@ -14,6 +17,23 @@ def _profile(
     ]
 
 
+def _paper_oracle(latencies: tuple[float, ...], stages: int) -> tuple[float, tuple[int, ...]]:
+    best: tuple[float, tuple[int, ...]] | None = None
+    for cuts in combinations(range(1, len(latencies)), stages - 1):
+        starts = (0, *cuts)
+        ends = (*cuts, len(latencies))
+        work = tuple(sum(latencies[start:end]) for start, end in zip(starts, ends))
+        kstar = max(range(stages), key=lambda index: (work[index], index))
+        t1 = sum(work)
+        t2 = (3 * stages + kstar - 1) * work[kstar]
+        t3 = sum(work[kstar:])
+        candidate = (t1 + t2 + t3, starts)
+        if best is None or candidate < best:
+            best = candidate
+    assert best is not None
+    return best
+
+
 def test_template_generator_covers_uneven_global_ranges():
     layers = [
         LayerExecutionResult(index, f"layer.{index}", index + 1, index + 1, 10)
@@ -28,21 +48,21 @@ def test_template_generator_covers_uneven_global_ranges():
     assert templates[2].layer_ranges == ((0, 4), (4, 6))
 
 
-def test_rust_and_python_backends_return_identical_templates():
-    layers = _profile((91, 45, 29, 75, 73, 66, 99, 81, 83, 83))
+def test_rust_and_python_backends_match_the_paper_objective():
+    latencies = (91, 45, 29, 75, 73, 66, 99, 81, 83, 83)
+    layers = _profile(latencies)
     rust = create_pipeline_templates("counterexample", layers, [1, 2, 3, 4, 5, 6])
-    python = _create_python_templates("counterexample", layers, [1, 2, 3, 4, 5, 6], 1, None, None)
+    python = _create_python_templates(
+        "counterexample", layers, [1, 2, 3, 4, 5, 6], 1, None, None
+    )
 
     assert rust == python
-    assert rust[6].layer_ranges == (
-        (0, 2),
-        (2, 4),
-        (4, 6),
-        (6, 7),
-        (7, 9),
-        (9, 10),
-    )
-    assert rust[6].forward_time + rust[6].backward_time == 164
+    expected_time, expected_starts = _paper_oracle(latencies, 6)
+    assert tuple(start for start, _ in rust[6].layer_ranges) == expected_starts
+    assert rust[6].planning_iteration_time == expected_time
+    assert rust[6].paper_t1 == sum(latencies)
+    assert rust[6].paper_t3 is not None
+    assert rust[6].paper_bottleneck_stage is not None
 
 
 def test_memory_feasibility_is_part_of_partition_selection():
@@ -55,6 +75,7 @@ def test_memory_feasibility_is_part_of_partition_selection():
     assert rust == python
     assert rust[2].layer_ranges == ((0, 1), (1, 3))
     assert rust[2].max_microbatches == 1
+    assert math.isfinite(rust[2].planning_iteration_time)
 
 
 def test_memory_infeasibility_reports_requested_resource_count():

--- a/tests/refactor/test_generator.py
+++ b/tests/refactor/test_generator.py
@@ -1,4 +1,17 @@
+import pytest
+
 from oobleck.planning import LayerExecutionResult, create_pipeline_templates
+from oobleck.planning.generator import _create_python_templates
+
+
+def _profile(
+    latencies: tuple[float, ...], activation: tuple[int, ...] | None = None
+) -> list[LayerExecutionResult]:
+    memory = activation or (1,) * len(latencies)
+    return [
+        LayerExecutionResult(index, f"layer.{index}", latency, 0.0, memory[index], memory[index], 0)
+        for index, latency in enumerate(latencies)
+    ]
 
 
 def test_template_generator_covers_uneven_global_ranges():
@@ -12,4 +25,64 @@ def test_template_generator_covers_uneven_global_ranges():
         assert template.num_stages == stages
         covered = [index for start, end in template.layer_ranges for index in range(start, end)]
         assert covered == list(range(6))
-    assert templates[2].layer_ranges[0] != (0, 3)
+    assert templates[2].layer_ranges == ((0, 4), (4, 6))
+
+
+def test_rust_and_python_backends_return_identical_templates():
+    layers = _profile((91, 45, 29, 75, 73, 66, 99, 81, 83, 83))
+    rust = create_pipeline_templates("counterexample", layers, [1, 2, 3, 4, 5, 6])
+    python = _create_python_templates("counterexample", layers, [1, 2, 3, 4, 5, 6], 1, None, None)
+
+    assert rust == python
+    assert rust[6].layer_ranges == (
+        (0, 2),
+        (2, 4),
+        (4, 6),
+        (6, 7),
+        (7, 9),
+        (9, 10),
+    )
+    assert rust[6].forward_time + rust[6].backward_time == 164
+
+
+def test_memory_feasibility_is_part_of_partition_selection():
+    layers = _profile((1, 5, 6), (8, 5, 1))
+    rust = create_pipeline_templates(
+        "memory", layers, [2], device_memory_bytes=10
+    )
+    python = _create_python_templates("memory", layers, [2], 1, None, 10)
+
+    assert rust == python
+    assert rust[2].layer_ranges == ((0, 1), (1, 3))
+    assert rust[2].max_microbatches == 1
+
+
+def test_memory_infeasibility_reports_requested_resource_count():
+    layers = _profile((1, 1), (11, 1))
+    with pytest.raises(ValueError, match="resource count 1"):
+        create_pipeline_templates("memory", layers, [1], device_memory_bytes=10)
+
+    from oobleck.planning import planner as rust_planner
+
+    with pytest.raises(RuntimeError, match="resource count 1"):
+        rust_planner.create_pipeline_templates("memory", layers, [1], 1, 10)
+
+
+def test_profile_timings_must_be_finite():
+    with pytest.raises(ValueError, match="non-negative"):
+        LayerExecutionResult(0, "bad", float("nan"), 1.0, 1)
+    with pytest.raises(ValueError, match="non-negative"):
+        LayerExecutionResult(0, "bad", 1.0, float("inf"), 1)
+    with pytest.raises(ValueError, match="non-negative"):
+        LayerExecutionResult(0, "bad", 1.0e308, 1.0e308, 1)
+
+    overflowing = _profile((1.0e308, 1.0e308))
+    with pytest.raises(ValueError, match="overflows"):
+        create_pipeline_templates("overflow", overflowing, [1])
+    with pytest.raises(ValueError, match="overflows"):
+        _create_python_templates("overflow", overflowing, [1], 1, None, None)
+
+
+def test_resource_counts_must_be_positive():
+    with pytest.raises(ValueError, match="positive"):
+        create_pipeline_templates("toy", _profile((1, 1)), [0])

--- a/tests/refactor/test_planning.py
+++ b/tests/refactor/test_planning.py
@@ -71,6 +71,31 @@ def test_profiler_measures_and_records_materialized_layers(tmp_path):
     assert all(item.activation_memory >= 0 for item in templates.values())
 
 
+def test_generated_template_serializes_the_section_4_timing_model():
+    layers = (
+        LayerExecutionResult(0, "l0", 2.0, 0.0, 1),
+        LayerExecutionResult(1, "l1", 3.0, 0.0, 1),
+        LayerExecutionResult(2, "l2", 4.0, 0.0, 1),
+    )
+    item = create_pipeline_templates("paper", layers, (2,))[2]
+    assert item.paper_t1 == 9.0
+    assert item.paper_t3 is not None
+    assert item.paper_bottleneck_stage is not None
+    stage_work = item.forward_time + item.backward_time
+    expected = (
+        item.paper_t1
+        + (8 - item.num_stages + item.paper_bottleneck_stage - 1) * stage_work
+        + item.paper_t3
+    )
+    assert item.planning_iteration_time == expected
+    assert PipelineTemplate.from_dict(item.to_dict()) == item
+
+
+def test_hand_written_template_keeps_legacy_iteration_estimate():
+    item = PipelineTemplate("legacy", ((0, 1), (1, 2)), 1, 2.0, 1.0)
+    assert item.iteration_time(4) == 15.0
+
+
 def test_template_capacity_uses_device_memory_budget():
     layers = (
         LayerExecutionResult(0, "l0", 1.0, 1.0, 300, 100, 200),


### PR DESCRIPTION
## Summary
- Replace the legacy nested Rayon/DashMap cache with a deterministic Rust planner for the fixed-TP runtime specialization of Section 4.1.2 (`S = d = n`).
- Implement the paper's Equations 1–4, including `T1`, `T2`, `T3`, the rightmost bottleneck stage `k*`, and `N_b = 4S`; serialize the paper timing terms.
- Retain exact, optimized bottleneck-feasibility summaries shared across requested template sizes, with memory validation, deterministic tie-breaking, and Rust/Python parity.
- Document the supported paper boundary; the full `S > n`/within-node GPU split `m` remains deferred until the runtime can instantiate variable-TP stages.

## Algorithm correspondence
The optimized solver enumerates the possible latency/range of the paper's rightmost bottleneck stage. Prefix stages must be no slower than that bottleneck, while suffix stages must be strictly faster. Because latency and memory are nonnegative and additive, greedy minimum-segment feasibility is exact for each candidate. These summaries are reused across template sizes without discarding state required by `k*` and `T3`.

## Validation
- `cargo test --lib`: 9 passed
- `cargo test --release --lib`: 9 passed
- `pytest -q`: 81 passed (4 unrelated multiprocessing warnings)
- `ruff check .`
- `pyright`: 0 errors, 0 warnings
- `git diff --check`
- 200 randomized profiles matched the exhaustive oracle
- 96-layer/64-node benchmark: Rust/Python parity; Rust ~0.212 s, Python ~1.662 s (7.85x)
