### PR TITLE
Document Oobleck runtime behavior

### DIFF
--- a/oobleck/acceptance.py
+++ b/oobleck/acceptance.py
@@ -16,6 +16,8 @@ _METRIC_LOCK = threading.Lock()
 
 
 def _metric_int(record: Mapping[str, object], field: str) -> int:
+    """Read an integer metric without accepting bool's integer subclass."""
+
     value = record[field]
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValueError(f"metric {field} must be an integer")
@@ -23,6 +25,8 @@ def _metric_int(record: Mapping[str, object], field: str) -> int:
 
 
 def _metric_float(record: Mapping[str, object], field: str) -> float:
+    """Read a numeric metric and normalize it for aggregation."""
+
     value = record[field]
     if not isinstance(value, (int, float)) or isinstance(value, bool):
         raise ValueError(f"metric {field} must be a number")
@@ -30,6 +34,8 @@ def _metric_float(record: Mapping[str, object], field: str) -> float:
 
 
 def resolve_metrics_path(template: str | Path, *, node_id: str, worker_id: str) -> Path:
+    """Expand worker/node/PID placeholders into a collision-resistant output path."""
+
     value = str(template).format(
         node_id=node_id,
         worker_id=worker_id.replace(":", "-"),
@@ -39,6 +45,8 @@ def resolve_metrics_path(template: str | Path, *, node_id: str, worker_id: str) 
 
 
 def _process_group_count() -> int:
+    """Best-effort count live private c10d handles for leak detection."""
+
     try:
         from torch.distributed import distributed_c10d as c10d
 
@@ -57,6 +65,8 @@ def runtime_metric(
     result: Any = None,
     step_seconds: float = 0.0,
 ) -> dict[str, object]:
+    """Snapshot transaction, recovery, CUDA, and process-group health as JSON data."""
+
     if not event or step_seconds < 0:
         raise ValueError("metric event and non-negative step duration are required")
     device = getattr(context, "device", torch.device("cpu"))
@@ -107,6 +117,8 @@ def runtime_metric(
 
 
 def append_metric(path: str | Path, metric: Mapping[str, object]) -> None:
+    """Append and flush one canonical JSONL record under a process-local lock."""
+
     destination = Path(path)
     destination.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(dict(metric), sort_keys=True, separators=(",", ":")) + "\n"
@@ -117,6 +129,8 @@ def append_metric(path: str | Path, metric: Mapping[str, object]) -> None:
 
 
 def load_metrics(paths: Iterable[str | Path]) -> list[dict[str, object]]:
+    """Load JSONL records from every worker output with source-aware validation."""
+
     records: list[dict[str, object]] = []
     for path in paths:
         source = Path(path)
@@ -140,6 +154,8 @@ def verify_churn_metrics(
     max_cuda_reserved_growth_bytes: int = 256 * 1024 * 1024,
     max_process_group_growth: int = 16,
 ) -> dict[str, object]:
+    """Verify monotonic generations/steps, replay, strategy, and leak bounds."""
+
     if not records:
         raise ValueError("at least one worker metric is required")
     if max_cuda_reserved_growth_bytes < 0 or max_process_group_growth < 0:

--- a/oobleck/acceptance.py
+++ b/oobleck/acceptance.py
@@ -65,7 +65,14 @@ def runtime_metric(
     result: Any = None,
     step_seconds: float = 0.0,
 ) -> dict[str, object]:
-    """Snapshot transaction, recovery, CUDA, and process-group health as JSON data."""
+    """Build one machine-readable observation of runtime and recovery health.
+
+    The record binds worker identity to generation, committed transaction progress, plan and
+    compatibility checksums, retry count, CUDA allocation, and live process-group count. When
+    the current generation has transition metrics, its detection, planning, transfer, activation,
+    and balancing measurements are nested into the same record. The function only snapshots
+    state; durable JSONL ordering and flushing belong to :func:`append_metric`.
+    """
 
     if not event or step_seconds < 0:
         raise ValueError("metric event and non-negative step duration are required")
@@ -154,7 +161,14 @@ def verify_churn_metrics(
     max_cuda_reserved_growth_bytes: int = 256 * 1024 * 1024,
     max_process_group_growth: int = 16,
 ) -> dict[str, object]:
-    """Verify monotonic generations/steps, replay, strategy, and leak bounds."""
+    """Validate a multi-worker churn run against transactional and resource invariants.
+
+    Records are grouped by stable worker identity and ordered by timestamp. Each worker must
+    observe nondecreasing generations and strictly consecutive committed steps, while retries
+    prove interrupted-batch replay when required. Recovery-strategy coverage, CUDA-reserved
+    growth, process-group growth, step latency, and optional clean shutdown are checked against
+    caller bounds. The returned summary is suitable for CI artifacts and benchmark comparison.
+    """
 
     if not records:
         raise ValueError("at least one worker metric is required")

--- a/oobleck/cli.py
+++ b/oobleck/cli.py
@@ -92,7 +92,13 @@ async def _agent(config: AgentConfig) -> None:
 
 
 def _launch(config: TrainingLaunchConfig) -> int:
-    """Run locally or bootstrap initial remote agents and supervise their exits."""
+    """Launch training locally or bootstrap the initial cluster over explicit SSH.
+
+    Local mode directly returns the training process exit code. Hostfile mode validates node and
+    fixed-TP capacity, constructs one explicit agent command per host, and supervises them as a
+    cohort. The first nonzero exit terminates remaining agents; normal completion requires all
+    agents to exit successfully. Later elastic joins bypass this bootstrap-only hostfile path.
+    """
 
     if not config.training_script.is_file():
         raise FileNotFoundError(f"training script does not exist: {config.training_script}")
@@ -150,7 +156,13 @@ def _launch(config: TrainingLaunchConfig) -> int:
 
 
 def _profile(config: ProfileCommandConfig) -> None:
-    """Measure or load a profile, validate compatibility, and save templates."""
+    """Produce a versioned template cache from measured or precomputed layer profiles.
+
+    Measurement mode loads a user factory, derives hardware/Cornstarch identity, profiles warmup
+    and timed steps, and persists the raw profile. Cached mode decodes an existing profile. Both
+    paths require exact model, dtype, TP width, and microbatch compatibility before the planner
+    generates every requested resource-count template under the device-memory budget.
+    """
 
     if config.profile is None and config.measurement_factory is None:
         raise ValueError(

--- a/oobleck/cli.py
+++ b/oobleck/cli.py
@@ -54,6 +54,8 @@ Command = Union[
 
 
 async def _master(config: MasterServiceConfig) -> None:
+    """Run the membership master until cancellation, then close every stream."""
+
     service = MasterControlService(
         AsyncioTcpControlTransport(max_frame_bytes=config.max_frame_bytes),
         lease_timeout_s=config.lease_timeout_s,
@@ -69,7 +71,11 @@ async def _master(config: MasterServiceConfig) -> None:
 
 
 async def _agent(config: AgentConfig) -> None:
+    """Run a node agent and emit machine-readable membership changes."""
+
     async def announce(message: MessageEnvelope) -> None:
+        """Print a compact generation notice for operators and launch scripts."""
+
         print(
             json.dumps(
                 {
@@ -86,6 +92,8 @@ async def _agent(config: AgentConfig) -> None:
 
 
 def _launch(config: TrainingLaunchConfig) -> int:
+    """Run locally or bootstrap initial remote agents and supervise their exits."""
+
     if not config.training_script.is_file():
         raise FileNotFoundError(f"training script does not exist: {config.training_script}")
     if config.initial_hostfile is None:
@@ -142,6 +150,8 @@ def _launch(config: TrainingLaunchConfig) -> int:
 
 
 def _profile(config: ProfileCommandConfig) -> None:
+    """Measure or load a profile, validate compatibility, and save templates."""
+
     if config.profile is None and config.measurement_factory is None:
         raise ValueError(
             "provide --profile with a versioned ModelProfile JSON or "
@@ -225,16 +235,22 @@ def _profile(config: ProfileCommandConfig) -> None:
 
 
 async def _inspect(config: InspectMembershipConfig) -> None:
+    """Print the master's current checksummed membership as JSON."""
+
     snapshot = await inspect_membership(config.master_host, config.master_port)
     print(json.dumps(asdict(snapshot), sort_keys=True))
 
 
 async def _drain(config: DrainConfig) -> None:
+    """Request graceful removal of a live stable node identity."""
+
     generation = await request_drain(config.master_host, config.master_port, config.node_id)
     print(f"drain accepted at generation {generation}")
 
 
 def _chaos(config: ChaosConfig) -> None:
+    """Kill only a PID proven to be the confirmed disposable example agent."""
+
     path = f"/proc/{config.pid}/cmdline"
     try:
         command = open(path, "rb").read().decode(errors="replace")
@@ -246,6 +262,8 @@ def _chaos(config: ChaosConfig) -> None:
 
 
 def dispatch(command: Command) -> object:
+    """Route a validated Tyro dataclass to its synchronous or async handler."""
+
     if isinstance(command, MasterServiceConfig):
         return asyncio.run(_master(command))
     if isinstance(command, AgentConfig):
@@ -264,6 +282,8 @@ def dispatch(command: Command) -> object:
 
 
 def main() -> object:
+    """Parse the command union with Tyro and dispatch the selected operation."""
+
     import tyro
 
     return dispatch(tyro.cli(Command))

--- a/oobleck/compatibility.py
+++ b/oobleck/compatibility.py
@@ -17,6 +17,8 @@ from oobleck.types import RuntimeCompatibility, checksum
 
 
 def _package_revision(distribution: str, module_name: str) -> str:
+    """Find the strongest available package identity: VCS commit, then version."""
+
     try:
         direct_url = importlib.metadata.distribution(distribution).read_text("direct_url.json")
         if direct_url:
@@ -45,6 +47,8 @@ def _package_revision(distribution: str, module_name: str) -> str:
 
 
 def model_fingerprint(model: torch.nn.Module, *, model_identity: str = "structure-only") -> str:
+    """Hash model type and state layout without reading mutable tensor contents."""
+
     if not model_identity:
         raise ValueError("model_identity must not be empty")
     state = [
@@ -70,6 +74,13 @@ def dataset_fingerprint(
     explicit: str | None = None,
     preprocessing: str = "identity",
 ) -> str:
+    """Hash a stable indexed dataset identity together with preprocessing semantics.
+
+    The fingerprint deliberately rejects iterable datasets and anonymous
+    map-style datasets: generation consensus must not equate workers whose
+    sample ordering or preprocessing may differ.
+    """
+
     if isinstance(dataset, IterableDataset) or not (
         hasattr(dataset, "__len__") and hasattr(dataset, "__getitem__")
     ):
@@ -97,6 +108,8 @@ def dataset_fingerprint(
 
 
 def _hardware_fingerprint() -> str:
+    """Hash the local accelerator model or CPU platform used for this worker."""
+
     if torch.cuda.is_available():
         device = torch.cuda.current_device()
         properties = torch.cuda.get_device_properties(device)
@@ -125,6 +138,8 @@ def build_runtime_compatibility(
     oobleck_revision: str | None = None,
     cornstarch_revision: str | None = None,
 ) -> RuntimeCompatibility:
+    """Assemble the checksummed contract workers compare before activation."""
+
     cuda_version = torch.version.cuda
     nccl_version = None
     if torch.cuda.is_available() and torch.distributed.is_nccl_available():

--- a/oobleck/compatibility.py
+++ b/oobleck/compatibility.py
@@ -138,7 +138,13 @@ def build_runtime_compatibility(
     oobleck_revision: str | None = None,
     cornstarch_revision: str | None = None,
 ) -> RuntimeCompatibility:
-    """Assemble the checksummed contract workers compare before activation."""
+    """Assemble the exact software, model, dataset, and hardware generation contract.
+
+    Package revisions prefer source commits, while Torch/CUDA/NCCL and datasets versions describe
+    the executable environment. Model structure, stable dataset/preprocessing identity, schema
+    versions, and local hardware are fingerprinted independently. The resulting immutable digest
+    is embedded in execution plans and must agree across workers before rendezvous.
+    """
 
     cuda_version = torch.version.cuda
     nccl_version = None

--- a/oobleck/config.py
+++ b/oobleck/config.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 @dataclass(frozen=True, slots=True)
 class MasterServiceConfig:
+    """Serializable settings for the central membership/control service."""
+
     host: str = "127.0.0.1"
     port: int = 0
     heartbeat_interval_s: float = 1.0
@@ -16,6 +18,8 @@ class MasterServiceConfig:
     max_nodes: int = 16
 
     def __post_init__(self) -> None:
+        """Reject endpoints and timing bounds that cannot maintain valid leases."""
+
         if not self.host or not 0 <= self.port <= 65535:
             raise ValueError("master host/port is invalid")
         if self.heartbeat_interval_s <= 0 or self.lease_timeout_s <= self.heartbeat_interval_s:
@@ -26,6 +30,8 @@ class MasterServiceConfig:
 
 @dataclass(frozen=True, slots=True)
 class AgentConfig:
+    """Connection, inventory, and optional worker-launch settings for one node."""
+
     node_id: str
     master_host: str = "127.0.0.1"
     master_port: int = 0
@@ -37,6 +43,8 @@ class AgentConfig:
     heartbeat_interval_s: float = 1.0
 
     def __post_init__(self) -> None:
+        """Validate stable identity, GPU ownership, and worker IPC dependencies."""
+
         if not self.node_id or not self.master_host or not 1 <= self.master_port <= 65535:
             raise ValueError("agent identity and master address are required")
         if not self.gpu_ids or len(set(self.gpu_ids)) != len(self.gpu_ids):
@@ -53,6 +61,8 @@ class AgentConfig:
 
 @dataclass(frozen=True, slots=True)
 class TrainingLaunchConfig:
+    """Inputs for a local launch and optional SSH bootstrap of initial agents."""
+
     training_script: Path
     script_args: tuple[str, ...] = ()
     max_nodes: int = 1
@@ -66,6 +76,8 @@ class TrainingLaunchConfig:
     socket_directory: Path = Path("/tmp")
 
     def __post_init__(self) -> None:
+        """Require complete remote-bootstrap information when a hostfile is used."""
+
         if self.max_nodes < 1 or self.tensor_parallel_size < 1:
             raise ValueError("max_nodes and tensor_parallel_size must be positive")
         if self.initial_hostfile is not None and (
@@ -76,6 +88,8 @@ class TrainingLaunchConfig:
 
 @dataclass(frozen=True, slots=True)
 class ProfileCommandConfig:
+    """Offline profiling/template-generation inputs accepted by the CLI."""
+
     output: Path
     model: str
     profile: Path | None = None
@@ -92,6 +106,8 @@ class ProfileCommandConfig:
     device_memory_bytes: int | None = None
 
     def __post_init__(self) -> None:
+        """Keep measured and precomputed profile modes mutually consistent."""
+
         if not self.model or self.tensor_parallel_size < 1 or self.microbatch_size < 1:
             raise ValueError("profile model and parallel sizes are required")
         if not self.resource_counts or any(item < 1 for item in self.resource_counts):
@@ -106,31 +122,43 @@ class ProfileCommandConfig:
 
 @dataclass(frozen=True, slots=True)
 class DrainConfig:
+    """Identify the live node and master involved in a graceful drain."""
+
     node_id: str
     master_host: str = "127.0.0.1"
     master_port: int = 0
 
     def __post_init__(self) -> None:
+        """Require a routable master endpoint and non-empty stable node ID."""
+
         if not self.node_id or not self.master_host or not 1 <= self.master_port <= 65535:
             raise ValueError("drain requires a node identity and master address")
 
 
 @dataclass(frozen=True, slots=True)
 class InspectMembershipConfig:
+    """Address of the master whose current membership should be inspected."""
+
     master_host: str = "127.0.0.1"
     master_port: int = 0
 
     def __post_init__(self) -> None:
+        """Reject incomplete or non-routable inspection endpoints."""
+
         if not self.master_host or not 1 <= self.master_port <= 65535:
             raise ValueError("membership inspection requires a master address")
 
 
 @dataclass(frozen=True, slots=True)
 class ChaosConfig:
+    """Explicitly confirmed process target for the guarded failure helper."""
+
     target_node_id: str
     pid: int = 0
     confirmation: str = ""
 
     def __post_init__(self) -> None:
+        """Require the target-specific confirmation token before signaling a PID."""
+
         if self.pid < 1 or self.confirmation != f"FAIL:{self.target_node_id}":
             raise ValueError("pid must be positive and confirmation must be FAIL:<node-id>")

--- a/oobleck/cornstarch.py
+++ b/oobleck/cornstarch.py
@@ -13,6 +13,8 @@ from oobleck.types import OobleckExecutionPlan, PipelineStageSpec
 
 
 def _fallback_manifest(model: torch.nn.Module, rank: int, committed_step: int = 0) -> StateManifest:
+    """Describe an unsharded local model when Cornstarch provides no manifest."""
+
     entries = []
     for kind, values in (
         ("parameter", model.named_parameters(recurse=True)),
@@ -36,6 +38,8 @@ def _fallback_manifest(model: torch.nn.Module, rank: int, committed_step: int = 
 
 
 def _external_manifest(value: Any, rank: int, committed_step: int = 0) -> StateManifest:
+    """Normalize a Cornstarch manifest into Oobleck's versioned state schema."""
+
     entries = []
     for item in value.entries:
         entries.append(
@@ -58,6 +62,8 @@ def _external_manifest(value: Any, rank: int, committed_step: int = 0) -> StateM
 
 @dataclass(frozen=True, slots=True)
 class CompiledLocalPartition:
+    """Process-group-free ownership plus the execution plan needed at activation."""
+
     root_model: torch.nn.Module
     rank: int
     world_size: int
@@ -73,6 +79,12 @@ class CompiledLocalPartition:
         *,
         mesh: Any = None,
     ) -> "ActivatedPartition":
+        """Materialize local storage only after replacement WORLD exists.
+
+        External Cornstarch partitions receive the rank-local heterogeneous mesh;
+        the fallback path initializes meta tensors or moves an ordinary model.
+        """
+
         if self.external_compiled is not None:
             all_meshes = None
             if mesh is None and self.world_size > 1:
@@ -102,6 +114,8 @@ class CompiledLocalPartition:
 
 
 class ActivatedPartition:
+    """Materialized rank-local model and external resources for one generation."""
+
     def __init__(
         self,
         compiled: CompiledLocalPartition,
@@ -110,6 +124,8 @@ class ActivatedPartition:
         manifest: StateManifest | None = None,
         all_meshes: dict[str, Any] | None = None,
     ) -> None:
+        """Retain the compiled identity, materialized model, manifest, and meshes."""
+
         self.compiled = compiled
         self.model = model
         self.external_context = external_context
@@ -119,9 +135,13 @@ class ActivatedPartition:
 
     @property
     def closed(self) -> bool:
+        """Report whether generation-local external resources were retired."""
+
         return self._closed
 
     def close(self) -> None:
+        """Idempotently release the external context and mesh references."""
+
         if self._closed:
             return
         if self.external_context is not None:

--- a/oobleck/cornstarch.py
+++ b/oobleck/cornstarch.py
@@ -81,8 +81,12 @@ class CompiledLocalPartition:
     ) -> "ActivatedPartition":
         """Materialize local storage only after replacement WORLD exists.
 
-        External Cornstarch partitions receive the rank-local heterogeneous mesh;
-        the fallback path initializes meta tensors or moves an ordinary model.
+        External Cornstarch partitions receive the rank-local heterogeneous mesh,
+        which every rank creates in identical pipeline order to avoid collective
+        mismatches. The fallback path either allocates meta parameters and invokes the
+        checkpoint initializer or moves an ordinary model to the target device/dtype.
+        The resulting manifest is the authoritative ownership description for state
+        recovery and heterogeneous gradient-group construction.
         """
 
         if self.external_compiled is not None:
@@ -161,7 +165,14 @@ def compile_local_partition(
     *,
     cornstarch_plan: object | None = None,
 ) -> CompiledLocalPartition:
-    """Compile ownership without touching ``torch.distributed`` or real storage."""
+    """Compile rank-local ownership without touching distributed state or storage.
+
+    The execution plan selects one global stage for ``rank`` and supplies its total
+    world size to the pinned Cornstarch compiler. When Cornstarch exposes a local
+    manifest, it is normalized into Oobleck's logical recovery schema; otherwise a
+    replicated fallback manifest is built from the model blueprint. The returned
+    object is safe to exchange and validate before replacement WORLD exists.
+    """
 
     stage = execution_plan.rank_local_stage(rank)
     external = None

--- a/oobleck/cornstarch_base.py
+++ b/oobleck/cornstarch_base.py
@@ -12,6 +12,8 @@ from oobleck.types import OobleckExecutionPlan, PipelineStageSpec
 
 
 def _local_manifest(model: torch.nn.Module, rank: int, committed_step: int = 0) -> StateManifest:
+    """Describe every local parameter and buffer as replicated fallback state."""
+
     entries = []
     for kind, values in (
         ("parameter", model.named_parameters(recurse=True)),
@@ -52,6 +54,8 @@ class CompiledLocalPartition:
         *,
         mesh: Any = None,
     ) -> "ActivatedPartition":
+        """Materialize an external partition or initialize the fallback model."""
+
         if self.external_compiled is not None:
             external = self.external_compiled.activate(device=device, dtype=dtype, mesh=mesh)
             model = getattr(external, "model", self.root_model)
@@ -69,12 +73,16 @@ class CompiledLocalPartition:
 
 
 class ActivatedPartition:
+    """Lower-level materialized model wrapper retained for compatibility."""
+
     def __init__(
         self,
         compiled: CompiledLocalPartition,
         model: torch.nn.Module,
         external_context: Any = None,
     ) -> None:
+        """Bind compiled ownership to its model and optional external context."""
+
         self.compiled = compiled
         self.model = model
         self.external_context = external_context
@@ -82,9 +90,13 @@ class ActivatedPartition:
 
     @property
     def closed(self) -> bool:
+        """Report whether the materialized context has been retired."""
+
         return self._closed
 
     def close(self) -> None:
+        """Idempotently close an external context and mark this wrapper retired."""
+
         if self._closed:
             return
         if self.external_context is not None:

--- a/oobleck/data.py
+++ b/oobleck/data.py
@@ -16,6 +16,8 @@ from oobleck.data_base import prepare_dataloader as _prepare_dataloader
 
 
 def prepare_dataloader(dataloader: DataLoader) -> PreparedDataLoader:
+    """Attach replay semantics only when sampler and loader share one dataset."""
+
     sampler = getattr(dataloader, "batch_sampler", None)
     if isinstance(sampler, OobleckBatchSampler) and sampler.dataset is not dataloader.dataset:
         raise ValueError(

--- a/oobleck/data_base.py
+++ b/oobleck/data_base.py
@@ -74,7 +74,13 @@ class OobleckBatchSampler(BatchSampler):
         shuffle: bool,
         drop_last: bool = True,
     ) -> None:
-        """Validate the replay contract and initialize an uncommitted cursor."""
+        """Validate the deterministic replay contract and initialize its cursor.
+
+        A logical global batch is independent of physical rank assignment. The
+        sampler therefore stores the pipeline allocation separately, derives sample
+        order only from ``seed`` and ``epoch``, and advances progress exclusively
+        through :meth:`commit` rather than DataLoader iteration or prefetch.
+        """
 
         _validate_dataset(dataset)
         if global_batch_size < 1 or microbatch_size < 1:
@@ -128,7 +134,13 @@ class OobleckBatchSampler(BatchSampler):
         return torch.randperm(size, generator=generator).tolist()
 
     def descriptor_at(self, batch_index: int) -> OobleckBatchDescriptor:
-        """Build and cache the deterministic routing descriptor for an index."""
+        """Build the replay-stable sample and pipeline routing for one batch.
+
+        Global microbatch IDs are assigned before physical pipeline routing, so the
+        same descriptor can be retried after reconfiguration. Issued descriptors are
+        cached to make an eventual commit validate the exact batch that was exposed
+        to the training loop, even when DataLoader prefetched later batches.
+        """
 
         if batch_index < 0 or batch_index >= len(self):
             raise IndexError(batch_index)
@@ -184,7 +196,13 @@ class OobleckBatchSampler(BatchSampler):
         return (size + self.global_batch_size - 1) // self.global_batch_size
 
     def commit(self, descriptor: OobleckBatchDescriptor) -> None:
-        """Advance exactly one position after validating an in-order successful step."""
+        """Atomically advance the logical cursor after one successful transaction.
+
+        Commits must match the active epoch, the next cursor position, and the exact
+        previously issued descriptor. This prevents duplicate, skipped, or stale
+        batches from advancing sample progress; uncommitted prefetched descriptors
+        remain replayable if the generation changes before optimizer commit.
+        """
 
         if descriptor.epoch != self.epoch:
             raise RuntimeError("cannot commit a batch from a stale epoch")
@@ -298,7 +316,12 @@ class PreparedDataLoader:
         self.sampler.reconfigure(instances)
 
     def __iter__(self) -> Iterator[OobleckBatch]:
-        """Pair each collated result with the still-uncommitted logical descriptor."""
+        """Pair DataLoader output with descriptors beginning at committed progress.
+
+        Enumeration starts from the sampler cursor rather than from prefetched state.
+        Invalidation stops the iterator immediately, allowing a replacement iterator
+        to reproduce the same uncommitted batch under a new pipeline allocation.
+        """
 
         self._invalidated = False
         start = self.sampler.committed_cursor

--- a/oobleck/data_base.py
+++ b/oobleck/data_base.py
@@ -23,6 +23,8 @@ def logical_seed(seed: int, *keys: object) -> int:
 
 @dataclass(frozen=True, slots=True)
 class PipelineBatchAssignment:
+    """The samples and global microbatch IDs routed to one pipeline."""
+
     pipeline_id: str
     sample_indices: tuple[int, ...]
     global_microbatch_ids: tuple[int, ...]
@@ -30,6 +32,8 @@ class PipelineBatchAssignment:
 
 @dataclass(frozen=True, slots=True)
 class OobleckBatchDescriptor:
+    """Replay-stable logical identity and routing for one global batch."""
+
     epoch: int
     logical_batch_id: int
     sample_indices: tuple[int, ...]
@@ -38,15 +42,21 @@ class OobleckBatchDescriptor:
 
 @dataclass(frozen=True, slots=True)
 class OobleckBatch:
+    """Collated microbatches paired with the descriptor used for commit/replay."""
+
     descriptor: OobleckBatchDescriptor
     microbatches: tuple[Any, ...]
 
     @property
     def sample_indices(self) -> tuple[int, ...]:
+        """Return dataset indices in deterministic global-batch order."""
+
         return self.descriptor.sample_indices
 
     @property
     def logical_batch_id(self) -> int:
+        """Return the commit cursor position represented by this batch."""
+
         return self.descriptor.logical_batch_id
 
 
@@ -64,6 +74,8 @@ class OobleckBatchSampler(BatchSampler):
         shuffle: bool,
         drop_last: bool = True,
     ) -> None:
+        """Validate the replay contract and initialize an uncommitted cursor."""
+
         _validate_dataset(dataset)
         if global_batch_size < 1 or microbatch_size < 1:
             raise ValueError("batch sizes must be positive")
@@ -90,9 +102,13 @@ class OobleckBatchSampler(BatchSampler):
 
     @property
     def committed_cursor(self) -> int:
+        """Return the next logical batch that may be committed."""
+
         return self._committed_cursor
 
     def set_epoch(self, epoch: int) -> None:
+        """Reset deterministic ordering, refusing to abandon consumed progress."""
+
         if epoch < 0:
             raise ValueError("epoch must be non-negative")
         if self._committed_cursor and epoch != self.epoch:
@@ -102,6 +118,8 @@ class OobleckBatchSampler(BatchSampler):
         self._issued.clear()
 
     def _permutation(self) -> list[int]:
+        """Derive the epoch sample order without consulting physical rank state."""
+
         size = len(self.dataset)  # type: ignore[arg-type]
         if not self.shuffle:
             return list(range(size))
@@ -110,6 +128,8 @@ class OobleckBatchSampler(BatchSampler):
         return torch.randperm(size, generator=generator).tolist()
 
     def descriptor_at(self, batch_index: int) -> OobleckBatchDescriptor:
+        """Build and cache the deterministic routing descriptor for an index."""
+
         if batch_index < 0 or batch_index >= len(self):
             raise IndexError(batch_index)
         logical_id = batch_index
@@ -148,18 +168,24 @@ class OobleckBatchSampler(BatchSampler):
         return descriptor
 
     def __iter__(self) -> Iterator[list[int]]:
+        """Issue batches from the committed cursor without advancing it."""
+
         # Prefetch may advance this iterator arbitrarily far.  The committed
         # cursor is deliberately untouched and a fresh iterator starts there.
         for index in range(self._committed_cursor, len(self)):
             yield list(self.descriptor_at(index).sample_indices)
 
     def __len__(self) -> int:
+        """Return complete batches, or include the final partial batch when requested."""
+
         size = len(self.dataset)  # type: ignore[arg-type]
         if self.drop_last:
             return size // self.global_batch_size
         return (size + self.global_batch_size - 1) // self.global_batch_size
 
     def commit(self, descriptor: OobleckBatchDescriptor) -> None:
+        """Advance exactly one position after validating an in-order successful step."""
+
         if descriptor.epoch != self.epoch:
             raise RuntimeError("cannot commit a batch from a stale epoch")
         if descriptor.logical_batch_id != self._committed_cursor:
@@ -174,11 +200,15 @@ class OobleckBatchSampler(BatchSampler):
         self._issued.pop(descriptor.logical_batch_id, None)
 
     def rewind_uncommitted(self) -> None:
+        """Forget descriptors produced only by DataLoader prefetch."""
+
         self._issued = {
             key: value for key, value in self._issued.items() if key < self._committed_cursor
         }
 
     def reconfigure(self, instances: Sequence[PipelineInstance]) -> None:
+        """Replace physical routing while preserving the logical commit cursor."""
+
         selected = tuple(instances)
         allocated = sum(item.microbatches for item in selected)
         expected = self.global_batch_size // self.microbatch_size
@@ -191,6 +221,8 @@ class OobleckBatchSampler(BatchSampler):
 
 
 def _validate_dataset(dataset: object) -> None:
+    """Enforce the stable indexed-dataset requirement needed for replay."""
+
     if isinstance(dataset, IterableDataset):
         raise TypeError(
             "Oobleck requires a stable map-style Dataset; streaming and other "
@@ -210,6 +242,8 @@ def _validate_dataset(dataset: object) -> None:
 
 
 def _slice_collated(value: Any, start: int, end: int, total: int) -> Any:
+    """Slice batch-shaped leaves while retaining shared metadata unchanged."""
+
     if isinstance(value, Mapping):
         return {key: _slice_collated(item, start, end, total) for key, item in value.items()}
     if isinstance(value, tuple) and len(value) == total:
@@ -224,6 +258,8 @@ def _slice_collated(value: Any, start: int, end: int, total: int) -> Any:
 def _normalize_microbatches(
     collated: Any, descriptor: OobleckBatchDescriptor, microbatch_size: int
 ) -> tuple[Any, ...]:
+    """Accept pre-split input or split a collated global batch into microbatches."""
+
     count = sum(len(item.global_microbatch_ids) for item in descriptor.assignments)
     if isinstance(collated, list) and len(collated) == count:
         return tuple(collated)
@@ -243,19 +279,27 @@ class PreparedDataLoader:
     """Ordered adapter that pairs DataLoader results with logical descriptors."""
 
     def __init__(self, dataloader: DataLoader, sampler: OobleckBatchSampler) -> None:
+        """Bind DataLoader output order to the sampler's logical descriptors."""
+
         self.dataloader = dataloader
         self.sampler = sampler
         self._invalidated = False
 
     def invalidate_prefetch(self) -> None:
+        """Stop the active iterator and discard work fetched beyond commit."""
+
         self._invalidated = True
         self.sampler.rewind_uncommitted()
 
     def reconfigure(self, instances: Sequence[PipelineInstance]) -> None:
+        """Invalidate prefetched data before changing pipeline assignments."""
+
         self.invalidate_prefetch()
         self.sampler.reconfigure(instances)
 
     def __iter__(self) -> Iterator[OobleckBatch]:
+        """Pair each collated result with the still-uncommitted logical descriptor."""
+
         self._invalidated = False
         start = self.sampler.committed_cursor
         for offset, collated in enumerate(iter(self.dataloader)):
@@ -268,10 +312,14 @@ class PreparedDataLoader:
             )
 
     def __len__(self) -> int:
+        """Return the number of logical batches remaining after commit."""
+
         return max(0, len(self.sampler) - self.sampler.committed_cursor)
 
 
 def prepare_dataloader(dataloader: DataLoader) -> PreparedDataLoader:
+    """Validate and seed a standard DataLoader for deterministic replay."""
+
     if not isinstance(dataloader, DataLoader):
         raise TypeError("prepare_dataloader expects torch.utils.data.DataLoader")
     _validate_dataset(dataloader.dataset)

--- a/oobleck/distributed/lifecycle.py
+++ b/oobleck/distributed/lifecycle.py
@@ -9,7 +9,7 @@ from typing import Iterable
 
 
 class ProcessGroupLayoutError(RuntimeError):
-    pass
+    """The installed PyTorch private c10d layout is outside the audited contract."""
 
 
 def initialize_process_group(
@@ -61,6 +61,8 @@ _OPTIONAL = ("_pg_coalesce_state", "pg_default_device")
 
 
 def _shutdown(group: object) -> None:
+    """Best-effort stop one backend before global registry teardown."""
+
     shutdown = getattr(group, "_shutdown", None)
     if callable(shutdown):
         shutdown()

--- a/oobleck/distributed/lifecycle.py
+++ b/oobleck/distributed/lifecycle.py
@@ -21,7 +21,13 @@ def initialize_process_group(
     world_size: int,
     timeout_s: float,
 ) -> None:
-    """Create one validated replacement WORLD from deterministic rendezvous data."""
+    """Create one replacement WORLD from deterministic generation metadata.
+
+    Initialization is forbidden while an older WORLD remains live. Endpoint, rank,
+    world size, and timeout are validated before constructing the TCP rendezvous URL;
+    afterward the observed rank map is checked against the plan. Any mismatch triggers
+    complete teardown so callers never continue with a partially valid universe.
+    """
 
     import torch.distributed as dist
 
@@ -69,7 +75,15 @@ def _shutdown(group: object) -> None:
 
 
 def destroy_process_group_universe(extra_handles: Iterable[object] = ()) -> None:
-    """Concurrently stop all groups, destroy WORLD, and clear known registries."""
+    """Retire the complete process-group universe before generation replacement.
+
+    Oobleck audits the installed PyTorch version and private c10d registry layout before
+    touching them. Every known backend handle, including caller-supplied topology groups,
+    is shut down concurrently; default WORLD is destroyed and all audited registries are
+    cleared. Unknown layouts fail loudly because retaining a communicator across rank-map
+    changes is less safe than refusing recovery. The final initialized-state check makes
+    teardown completeness part of the generation invariant.
+    """
 
     import torch
     import torch.distributed as dist

--- a/oobleck/distributed/lifecycle_base.py
+++ b/oobleck/distributed/lifecycle_base.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 
 class ProcessGroupLayoutError(RuntimeError):
-    pass
+    """The retained teardown path cannot recognize private c10d registries."""
 
 
 _WORLD_REGISTRIES = (
@@ -23,6 +23,8 @@ _WORLD_REGISTRIES = (
 
 
 def _shutdown_backend(group: object) -> None:
+    """Ask one backend handle to stop without assuming a concrete backend type."""
+
     shutdown = getattr(group, "_shutdown", None)
     if callable(shutdown):
         shutdown()

--- a/oobleck/elastic/hostfile.py
+++ b/oobleck/elastic/hostfile.py
@@ -9,11 +9,15 @@ from typing import Sequence
 
 @dataclass(frozen=True, slots=True)
 class InitialHost:
+    """Stable bootstrap node identity, SSH address, and fixed local GPU set."""
+
     node_id: str
     address: str
     gpu_ids: tuple[str, ...]
 
     def __post_init__(self) -> None:
+        """Require complete identity and unique GPU identifiers."""
+
         if not self.node_id or not self.address or not self.gpu_ids:
             raise ValueError("hostfile node_id, address, and gpu_ids are required")
         if len(self.gpu_ids) != len(set(self.gpu_ids)):

--- a/oobleck/elastic/hostfile.py
+++ b/oobleck/elastic/hostfile.py
@@ -60,7 +60,13 @@ def ssh_agent_command(
     socket_directory: str | Path = "/tmp",
     ssh_command: str = "ssh",
 ) -> tuple[str, ...]:
-    """Build one explicit remote agent command without executing it."""
+    """Construct the complete SSH command for one bootstrap agent without side effects.
+
+    The command carries stable node identity, master endpoint, GPU inventory, local-worker socket,
+    worker entrypoint, and optional training arguments. Returning argv rather than a shell string
+    preserves quoting and lets the launcher supervise processes directly. This is intentionally
+    limited to initial bootstrap; membership controls later joins.
+    """
 
     if not 1 <= master_port <= 65535:
         raise ValueError("master_port must be reachable and nonzero for SSH bootstrap")

--- a/oobleck/elastic/local_ipc.py
+++ b/oobleck/elastic/local_ipc.py
@@ -130,7 +130,15 @@ class LocalWorkerRelay:
         self._server = await asyncio.start_unix_server(accept, path=self.path)
 
     async def _handle(self, connection: ControlConnection) -> None:
-        """Register one worker incarnation and aggregate its phase acknowledgements."""
+        """Register one local worker incarnation and aggregate generation consensus.
+
+        A reconnecting stable worker replaces its prior Unix stream and receives the latest
+        membership/rendezvous/active phases in order. Acknowledgements must belong to that
+        incarnation and current snapshot. Preparation records checksum/plan/compatibility;
+        readiness additionally requires a matching relayed rendezvous. Callbacks fire once
+        only after all configured GPU workers report identical metadata, while disconnects
+        remove that worker from both phase counts.
+        """
 
         worker_id: str | None = None
         try:
@@ -229,7 +237,13 @@ class LocalWorkerRelay:
                 await connection.close()
 
     async def publish(self, message: MessageEnvelope) -> None:
-        """Validate, retain, and fan out a master generation phase locally."""
+        """Validate, retain, and fan out one master generation phase to GPU workers.
+
+        New membership clears all preparation/readiness state. Rendezvous is accepted only
+        after unanimous local preparation, and active only after unanimous readiness for
+        the same identities. Messages are sent concurrently; failed worker streams are
+        removed from consensus instead of blocking the node indefinitely.
+        """
 
         allowed = {"membership", "generation_rendezvous", "generation_active"}
         if message.message_type not in allowed:
@@ -437,7 +451,14 @@ class LocalWorkerClient:
         )
 
     async def activate_prepared(self, prepared: Any, snapshot: MembershipSnapshot) -> Any:
-        """Activate initial ownership only after both CPU control-plane barriers."""
+        """Activate initial ownership through prepared, rendezvous, ready, and active.
+
+        The worker recompiles if its prepared plan predates the latest membership, then
+        acknowledges plan and compatibility metadata. A superseding snapshot before
+        rendezvous restarts preparation; one arriving after local WORLD creation closes the
+        partial context and starts over. Only matching master activation enables transaction
+        barriers and returns the context to application code.
+        """
 
         if self.connection is None:
             raise RuntimeError("local worker is not connected")
@@ -483,7 +504,14 @@ class LocalWorkerClient:
         on_snapshot: Callable[[MembershipSnapshot], Awaitable[None]] | None = None,
         on_active: Callable[[int], Awaitable[None]] | None = None,
     ) -> None:
-        """Drive reconfiguration barriers, restarting whenever membership supersedes."""
+        """Drive the active context through every future generation barrier.
+
+        Complete snapshots are applied to plan replacement ownership, after which local
+        preparation metadata is acknowledged. Rendezvous authorizes WORLD activation and
+        local readiness; master activation releases transactional steps. Membership at
+        either nested phase supersedes the attempt and restarts from the newest snapshot,
+        ensuring workers never combine topology or state from different generations.
+        """
 
         if self.connection is None:
             raise RuntimeError("local worker is not connected")

--- a/oobleck/elastic/local_ipc.py
+++ b/oobleck/elastic/local_ipc.py
@@ -36,6 +36,8 @@ class LocalWorkerRelay:
         on_generation_ready: WorkerPhaseCallback | None = None,
         max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
     ) -> None:
+        """Initialize the Unix listener and per-generation local consensus state."""
+
         if expected_workers < 1:
             raise ValueError("expected_workers must be positive")
         self.path = Path(path)
@@ -57,9 +59,13 @@ class LocalWorkerRelay:
 
     @property
     def worker_ids(self) -> tuple[str, ...]:
+        """Return registered stable worker identities in deterministic order."""
+
         return tuple(sorted(self._workers))
 
     def _phase_complete(self, generation: int, values: dict[str, tuple[str, str, str]]) -> bool:
+        """Require every configured worker to report against current membership."""
+
         latest = self._latest_membership
         return (
             latest is not None
@@ -69,9 +75,13 @@ class LocalWorkerRelay:
         )
 
     def generation_prepared(self, generation: int) -> bool:
+        """Report whether all local workers compiled the proposed generation."""
+
         return self._phase_complete(generation, self._prepared)
 
     def generation_ready(self, generation: int) -> bool:
+        """Report whether all local workers initialized replacement WORLD."""
+
         return self._phase_complete(generation, self._acknowledged)
 
     def _phase_metadata(
@@ -80,6 +90,8 @@ class LocalWorkerRelay:
         values: dict[str, tuple[str, str, str]],
         phase: str,
     ) -> tuple[str, str, str]:
+        """Return unanimous snapshot, plan, and compatibility identities."""
+
         if not self._phase_complete(generation, values):
             raise RuntimeError(f"local generation is not {phase}")
         agreed = set(values.values())
@@ -88,12 +100,18 @@ class LocalWorkerRelay:
         return next(iter(agreed))
 
     def preparation_metadata(self, generation: int) -> tuple[str, str, str]:
+        """Return agreed metadata for completed local preparation."""
+
         return self._phase_metadata(generation, self._prepared, "prepared")
 
     def readiness_metadata(self, generation: int) -> tuple[str, str, str]:
+        """Return agreed metadata for completed local readiness."""
+
         return self._phase_metadata(generation, self._acknowledged, "ready")
 
     async def start(self) -> None:
+        """Safely replace a stale socket and begin accepting local workers."""
+
         if self._server is not None:
             raise RuntimeError("local worker relay is already running")
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -104,12 +122,16 @@ class LocalWorkerRelay:
             self.path.unlink()
 
         async def accept(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            """Wrap one Unix stream in the same framed control protocol."""
+
             connection = ControlConnection(reader, writer, max_frame_bytes=self.max_frame_bytes)
             await self._handle(connection)
 
         self._server = await asyncio.start_unix_server(accept, path=self.path)
 
     async def _handle(self, connection: ControlConnection) -> None:
+        """Register one worker incarnation and aggregate its phase acknowledgements."""
+
         worker_id: str | None = None
         try:
             registration = await connection.receive()
@@ -207,6 +229,8 @@ class LocalWorkerRelay:
                 await connection.close()
 
     async def publish(self, message: MessageEnvelope) -> None:
+        """Validate, retain, and fan out a master generation phase locally."""
+
         allowed = {"membership", "generation_rendezvous", "generation_active"}
         if message.message_type not in allowed:
             raise ValueError(f"local relay accepts only {sorted(allowed)} messages")
@@ -262,6 +286,8 @@ class LocalWorkerRelay:
                     self._acknowledged.pop(worker_id, None)
 
     async def close(self) -> None:
+        """Close workers and listener, then remove only the owned socket path."""
+
         if self._server is not None:
             self._server.close()
             await self._server.wait_closed()
@@ -280,6 +306,8 @@ class LocalWorkerClient:
     """Execute the prepared/rendezvous/ready/active generation protocol."""
 
     def __init__(self, path: str | Path, node_id: str, worker_id: str) -> None:
+        """Assign a fresh local incarnation and initialize phase cursors."""
+
         if not node_id or not worker_id:
             raise ValueError("node_id and worker_id are required")
         self.path = Path(path)
@@ -292,6 +320,8 @@ class LocalWorkerClient:
         self.sequence = 0
 
     async def connect(self) -> None:
+        """Open the Unix stream and register the stable worker identity."""
+
         reader, writer = await asyncio.open_unix_connection(self.path)
         self.connection = ControlConnection(reader, writer)
         await self.connection.send(
@@ -307,6 +337,8 @@ class LocalWorkerClient:
         )
 
     def _parse_membership(self, message: MessageEnvelope) -> MembershipSnapshot:
+        """Verify and install a strictly newer checksummed membership."""
+
         if message.message_type != "membership":
             raise ProtocolError("local agent sent a non-membership message")
         snapshot = membership_snapshot_from_payload(message.generation, message.payload)
@@ -316,6 +348,8 @@ class LocalWorkerClient:
         return snapshot
 
     async def receive(self) -> MembershipSnapshot:
+        """Wait for membership while consuming informational phase messages."""
+
         if self.connection is None:
             raise RuntimeError("local worker is not connected")
         while True:
@@ -330,6 +364,8 @@ class LocalWorkerClient:
 
     @staticmethod
     def _metadata(execution_plan: Any, snapshot: MembershipSnapshot) -> tuple[str, str, str]:
+        """Bind phase acknowledgements to membership, plan, and compatibility."""
+
         return (
             snapshot.snapshot_hash,
             str(getattr(execution_plan, "plan_checksum", snapshot.snapshot_hash)),
@@ -342,6 +378,8 @@ class LocalWorkerClient:
         snapshot: MembershipSnapshot,
         metadata: tuple[str, str, str],
     ) -> None:
+        """Send one sequenced worker phase acknowledgement to the local relay."""
+
         assert self.connection is not None
         self.sequence += 1
         await self.connection.send(
@@ -368,6 +406,8 @@ class LocalWorkerClient:
         snapshot: MembershipSnapshot,
         metadata: tuple[str, str, str],
     ) -> None:
+        """Require the expected phase and exact locally prepared identities."""
+
         if message.message_type != expected_type:
             raise ProtocolError(
                 f"local agent sent {message.message_type!r}; expected {expected_type}"
@@ -381,6 +421,8 @@ class LocalWorkerClient:
 
     @staticmethod
     def _reprepare(prepared: Any, snapshot: MembershipSnapshot) -> Any:
+        """Recompile ownership from a superseding snapshot without building WORLD."""
+
         owner = prepared.owner_plan
         tp = int(getattr(owner.parallel_config, "tensor_parallel_size"))
         if any(len(node.gpu_ids) != tp for node in snapshot.nodes):
@@ -441,6 +483,8 @@ class LocalWorkerClient:
         on_snapshot: Callable[[MembershipSnapshot], Awaitable[None]] | None = None,
         on_active: Callable[[int], Awaitable[None]] | None = None,
     ) -> None:
+        """Drive reconfiguration barriers, restarting whenever membership supersedes."""
+
         if self.connection is None:
             raise RuntimeError("local worker is not connected")
         enable_barrier = getattr(context, "enable_control_plane_barrier", None)
@@ -486,6 +530,8 @@ class LocalWorkerClient:
                 break
 
     async def close(self) -> None:
+        """Close the worker-to-agent stream idempotently."""
+
         if self.connection is not None:
             await self.connection.close()
             self.connection = None

--- a/oobleck/elastic/membership.py
+++ b/oobleck/elastic/membership.py
@@ -76,7 +76,13 @@ class MembershipSnapshot:
 def membership_snapshot_from_payload(
     generation: int, payload: Mapping[str, object]
 ) -> MembershipSnapshot:
-    """Strictly reconstruct a checksummed snapshot from a control payload."""
+    """Reconstruct a membership snapshot only from the exact wire representation.
+
+    The decoder rejects unknown/missing fields, invalid container types, malformed identities,
+    empty resource inventories, and non-string values before creating ``NodeIdentity`` objects.
+    ``MembershipSnapshot`` then recomputes and verifies the supplied hash, so downstream planning
+    consumes a complete, typed, checksummed generation rather than partially trusted JSON.
+    """
 
     if set(payload) != {"nodes", "reasons", "snapshot_hash"}:
         raise ValueError("membership payload fields are invalid")
@@ -175,8 +181,12 @@ class MembershipStateMachine:
     def register(self, identity: NodeIdentity, sequence_number: int) -> None:
         """Add, refresh, or replace a node while enforcing fixed TP width.
 
-        A new incarnation for an existing stable ID supersedes the old one and
-        contributes a replacement event to the next coalesced generation.
+        Registration is scoped to a stable agent ID plus a process incarnation. A
+        repeated live incarnation must advance its sequence and only renews its lease;
+        a fresh incarnation atomically supersedes the old connection. New nodes respect
+        ``max_nodes`` and all nodes contribute the same GPU count required by fixed TP.
+        Join/replacement reasons are queued but do not advance generation until publish,
+        allowing concurrent membership events to coalesce into one complete snapshot.
         """
 
         if sequence_number < 0:
@@ -284,7 +294,13 @@ class MembershipStateMachine:
         return expired
 
     def publish(self) -> MembershipSnapshot | None:
-        """Coalesce pending events into one monotonically newer snapshot."""
+        """Publish all queued membership events as one immutable generation.
+
+        Generation advances once regardless of how many joins, disconnects, drains, or
+        lease expirations accumulated. Nodes and reasons are sorted before checksumming,
+        so master and workers share a deterministic full-membership identity. Consuming
+        the pending reasons ensures a later event produces a strictly newer proposal.
+        """
 
         if not self._pending_reasons:
             return None

--- a/oobleck/elastic/membership.py
+++ b/oobleck/elastic/membership.py
@@ -10,25 +10,29 @@ from typing import Callable, Mapping
 
 
 class StaleGeneration(RuntimeError):
-    pass
+    """A control message refers to a generation that is no longer active."""
 
 
 class StaleSequence(RuntimeError):
-    pass
+    """An incarnation repeated or reordered a control-plane message."""
 
 
 class IncarnationMismatch(RuntimeError):
-    pass
+    """A connection no longer owns the live incarnation for its stable node ID."""
 
 
 @dataclass(frozen=True, slots=True)
 class NodeIdentity:
+    """Stable node identity plus one process incarnation and its resources."""
+
     agent_id: str
     incarnation_id: str
     addresses: tuple[str, ...]
     gpu_ids: tuple[str, ...]
 
     def __post_init__(self) -> None:
+        """Require routable identity and at least one GPU contribution."""
+
         if not self.agent_id or not self.incarnation_id:
             raise ValueError("agent_id and incarnation_id are required")
         if not self.addresses or not self.gpu_ids:
@@ -37,6 +41,8 @@ class NodeIdentity:
 
 @dataclass(slots=True)
 class _LiveNode:
+    """Mutable lease and sequence state for the currently authorized incarnation."""
+
     identity: NodeIdentity
     last_sequence: int
     lease_deadline: float
@@ -44,12 +50,16 @@ class _LiveNode:
 
 @dataclass(frozen=True, slots=True)
 class MembershipSnapshot:
+    """Immutable, checksummed membership view published as one generation."""
+
     generation: int
     nodes: tuple[NodeIdentity, ...]
     reasons: tuple[str, ...]
     snapshot_hash: str = field(default="", compare=False)
 
     def __post_init__(self) -> None:
+        """Compute or verify the hash used for worker consensus."""
+
         payload = {
             "generation": self.generation,
             "nodes": [asdict(item) for item in self.nodes],
@@ -126,6 +136,8 @@ class MembershipStateMachine:
         gpu_ids_per_node: int | None = None,
         clock: Callable[[], float] = time.monotonic,
     ) -> None:
+        """Initialize an empty membership with injectable time for lease tests."""
+
         if lease_timeout_s <= 0:
             raise ValueError("lease_timeout_s must be positive")
         self.lease_timeout_s = lease_timeout_s
@@ -142,19 +154,31 @@ class MembershipStateMachine:
 
     @property
     def agent_ids(self) -> tuple[str, ...]:
+        """Return live stable identities in deterministic order."""
+
         return tuple(sorted(self._nodes))
 
     @property
     def has_pending_generation(self) -> bool:
+        """Report whether coalesced events still need to be published."""
+
         return bool(self._pending_reasons)
 
     def _check_generation(self, generation: int) -> None:
+        """Prevent commands from mixing membership generations."""
+
         if generation != self.generation:
             raise StaleGeneration(
                 f"message generation {generation} does not match active {self.generation}"
             )
 
     def register(self, identity: NodeIdentity, sequence_number: int) -> None:
+        """Add, refresh, or replace a node while enforcing fixed TP width.
+
+        A new incarnation for an existing stable ID supersedes the old one and
+        contributes a replacement event to the next coalesced generation.
+        """
+
         if sequence_number < 0:
             raise ValueError("sequence_number must be non-negative")
         existing = self._nodes.get(identity.agent_id)
@@ -202,6 +226,8 @@ class MembershipStateMachine:
         sequence_number: int,
         generation: int,
     ) -> None:
+        """Renew the live incarnation lease after generation and sequence checks."""
+
         self._check_generation(generation)
         node = self._require_incarnation(agent_id, incarnation_id)
         if sequence_number <= node.last_sequence:
@@ -210,12 +236,16 @@ class MembershipStateMachine:
         node.lease_deadline = self.clock() + self.lease_timeout_s
 
     def _require_incarnation(self, agent_id: str, incarnation_id: str) -> _LiveNode:
+        """Resolve only the connection currently authorized for a stable node ID."""
+
         node = self._nodes.get(agent_id)
         if node is None or node.identity.incarnation_id != incarnation_id:
             raise IncarnationMismatch(f"connection does not own active incarnation for {agent_id}")
         return node
 
     def disconnect(self, agent_id: str, incarnation_id: str) -> bool:
+        """Remove the matching incarnation; ignore closure of superseded sockets."""
+
         node = self._nodes.get(agent_id)
         if node is None or node.identity.incarnation_id != incarnation_id:
             return False
@@ -230,6 +260,8 @@ class MembershipStateMachine:
         sequence_number: int,
         generation: int,
     ) -> None:
+        """Remove a node gracefully and queue a drain membership event."""
+
         self._check_generation(generation)
         node = self._require_incarnation(agent_id, incarnation_id)
         if sequence_number <= node.last_sequence:
@@ -238,6 +270,8 @@ class MembershipStateMachine:
         self._pending_reasons.add(f"drain:{agent_id}")
 
     def expire_leases(self, now: float | None = None) -> tuple[str, ...]:
+        """Remove all expired nodes atomically and return their stable IDs."""
+
         current = self.clock() if now is None else now
         expired = tuple(
             sorted(
@@ -250,6 +284,8 @@ class MembershipStateMachine:
         return expired
 
     def publish(self) -> MembershipSnapshot | None:
+        """Coalesce pending events into one monotonically newer snapshot."""
+
         if not self._pending_reasons:
             return None
         self.generation += 1
@@ -262,6 +298,8 @@ class MembershipStateMachine:
         return snapshot
 
     def snapshot(self) -> MembershipSnapshot:
+        """Return the current live view without consuming or advancing events."""
+
         return MembershipSnapshot(
             self.generation,
             tuple(self._nodes[agent_id].identity for agent_id in sorted(self._nodes)),

--- a/oobleck/elastic/service.py
+++ b/oobleck/elastic/service.py
@@ -16,7 +16,11 @@ from oobleck.elastic.transport import MessageEnvelope
 
 
 class MasterControlService(_MasterControlService):
+    """Master variant that bounds broadcasts to failed or stalled peers."""
+
     async def _broadcast_message(self, message: MessageEnvelope) -> None:
+        """Treat a stalled writer as failure detection, never a recovery barrier."""
+
         # A peer can close during a proposal or activation broadcast. That
         # failed writer is a detection input, not permission to stall the
         # membership state machine indefinitely.

--- a/oobleck/elastic/service_base.py
+++ b/oobleck/elastic/service_base.py
@@ -20,6 +20,8 @@ from oobleck.elastic.transport import (
 
 
 class MasterControlService:
+    """Serialize membership changes and two-phase generation activation."""
+
     def __init__(
         self,
         transport: ControlTransport | None = None,
@@ -29,6 +31,8 @@ class MasterControlService:
         max_nodes: int | None = None,
         gpu_ids_per_node: int | None = None,
     ) -> None:
+        """Create empty membership, consensus, connection, and lease state."""
+
         self.transport = transport or AsyncioTcpControlTransport()
         self.membership = MembershipStateMachine(
             lease_timeout_s=lease_timeout_s,
@@ -48,6 +52,8 @@ class MasterControlService:
         self.active_generation = 0
 
     async def start(self, host: str, port: int) -> asyncio.AbstractServer:
+        """Start accepting agent streams and monitoring their renewable leases."""
+
         if self._server is not None:
             raise RuntimeError("master service is already running")
         self._server = await self.transport.start_server(host, port, self._handle)
@@ -55,6 +61,8 @@ class MasterControlService:
         return self._server
 
     async def close(self) -> None:
+        """Stop lease monitoring, close listeners, then retire every agent stream."""
+
         if self._lease_task is not None:
             self._lease_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -81,6 +89,8 @@ class MasterControlService:
             self.active_generation = snapshot.generation
 
     async def _expire_leases(self) -> None:
+        """Convert expired leases into coalesced membership proposals."""
+
         while True:
             await asyncio.sleep(self.lease_check_interval_s)
             async with self._lock:
@@ -94,6 +104,13 @@ class MasterControlService:
                 await self._broadcast(snapshot)
 
     async def _handle(self, connection: ControlConnection) -> None:
+        """Serve one operator request or one registered agent incarnation.
+
+        Registration installs the stream under a stable node ID. Subsequent
+        heartbeats and phase acknowledgements are serialized with membership;
+        stream loss feeds the same removal path as lease expiration.
+        """
+
         identity: NodeIdentity | None = None
         try:
             first = await connection.receive()
@@ -280,10 +297,14 @@ class MasterControlService:
                     await self._broadcast(snapshot)
 
     async def _broadcast(self, snapshot: MembershipSnapshot) -> None:
+        """Encode and publish one immutable membership snapshot."""
+
         message = self._membership_message(snapshot)
         await self._broadcast_message(message)
 
     async def _broadcast_message(self, message: MessageEnvelope) -> None:
+        """Send a phase message concurrently without hiding task cancellation."""
+
         connections = [item[1] for item in self._connections.values()]
         results = await asyncio.gather(
             *(connection.send(message) for connection in connections),
@@ -294,6 +315,8 @@ class MasterControlService:
                 raise result
 
     def _membership_message(self, snapshot: MembershipSnapshot) -> MessageEnvelope:
+        """Create a sequenced membership envelope from a checksummed snapshot."""
+
         self._master_sequence += 1
         return MessageEnvelope(
             1,
@@ -310,6 +333,8 @@ class MasterControlService:
         )
 
     def _status_message(self, snapshot: MembershipSnapshot) -> MessageEnvelope:
+        """Expose proposed, prepared, ready, and active generation progress."""
+
         self._master_sequence += 1
         return MessageEnvelope(
             1,
@@ -334,6 +359,8 @@ class MasterControlService:
         plan_checksum: str,
         compatibility_digest: str,
     ) -> MessageEnvelope:
+        """Authorize workers with matching preparation metadata to build WORLD."""
+
         self._master_sequence += 1
         return MessageEnvelope(
             1,
@@ -355,6 +382,8 @@ class MasterControlService:
         plan_checksum: str,
         compatibility_digest: str,
     ) -> MessageEnvelope:
+        """Publish activation after every live agent reports local readiness."""
+
         self._master_sequence += 1
         return MessageEnvelope(
             1,
@@ -372,6 +401,8 @@ class MasterControlService:
 
 
 class NodeAgentClient:
+    """Retained basic agent client for registration, leases, and graceful drain."""
+
     def __init__(
         self,
         node_id: str,
@@ -381,6 +412,8 @@ class NodeAgentClient:
         heartbeat_interval_s: float = 1.0,
         on_membership: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
     ) -> None:
+        """Assign a fresh process incarnation and initialize stream counters."""
+
         if not node_id or not gpu_ids:
             raise ValueError("node_id and gpu_ids are required")
         self.node_id = node_id
@@ -394,6 +427,8 @@ class NodeAgentClient:
         self.connection: ControlConnection | None = None
 
     async def connect(self, host: str, port: int) -> MessageEnvelope:
+        """Register inventory on a new stream and receive its first membership."""
+
         self.connection = await self.transport.connect(host, port)
         await self.connection.send(
             MessageEnvelope(
@@ -414,6 +449,8 @@ class NodeAgentClient:
         return membership
 
     async def run(self) -> None:
+        """Renew the lease and opportunistically consume membership updates."""
+
         if self.connection is None:
             raise RuntimeError("connect() must be called before run()")
         while True:
@@ -438,6 +475,8 @@ class NodeAgentClient:
                         await self.on_membership(message)
 
     async def drain(self) -> None:
+        """Submit an incarnation-owned graceful removal to the master."""
+
         if self.connection is None:
             raise RuntimeError("agent is not connected")
         self.sequence += 1

--- a/oobleck/elastic/service_base.py
+++ b/oobleck/elastic/service_base.py
@@ -106,9 +106,13 @@ class MasterControlService:
     async def _handle(self, connection: ControlConnection) -> None:
         """Serve one operator request or one registered agent incarnation.
 
-        Registration installs the stream under a stable node ID. Subsequent
-        heartbeats and phase acknowledgements are serialized with membership;
-        stream loss feeds the same removal path as lease expiration.
+        Operator inspection and drain requests are short-lived and never join membership.
+        Agent streams must register first; their heartbeats, drains, and prepared/ready
+        acknowledgements are serialized under the membership lock. Prepared metadata must
+        agree across every live agent before rendezvous, and ready metadata must agree
+        again before activation. A newer membership proposal clears both barriers. EOF,
+        reset, malformed protocol, and lease expiry all converge on incarnation-aware
+        removal so closure of a superseded socket cannot evict its replacement.
         """
 
         identity: NodeIdentity | None = None

--- a/oobleck/elastic/service_public_base.py
+++ b/oobleck/elastic/service_public_base.py
@@ -62,7 +62,14 @@ class NodeAgentClient:
         on_generation_active: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
         local_worker_socket: str | Path | None = None,
     ) -> None:
-        """Validate advertised resources and initialize per-incarnation phase state."""
+        """Initialize one reconnectable node incarnation and its generation state machine.
+
+        Advertised GPU inventory and heartbeat cadence are validated, while addresses are either
+        supplied explicitly or discovered and checked for resolvability. Independent cursors track
+        master sequencing, membership, preparation, rendezvous, readiness, and activation. Optional
+        local IPC aggregates exactly one worker per GPU before node-level acknowledgements, and send
+        locks preserve the incarnation sequence across heartbeat and phase tasks.
+        """
 
         if not node_id or not gpu_ids or heartbeat_interval_s <= 0:
             raise ValueError("node_id, gpu_ids, and a positive heartbeat interval are required")
@@ -172,7 +179,13 @@ class NodeAgentClient:
             await self._send_ready_if_possible(generation)
 
     async def _send_prepared_if_possible(self, generation: int) -> None:
-        """Acknowledge preparation once per generation after every local worker."""
+        """Send node-level preparation exactly once when all prerequisites agree.
+
+        The current connection, snapshot, local preparation cursor, and generation must match. With
+        local workers, unanimous snapshot/plan/compatibility metadata is required; without them, the
+        snapshot hash supplies the compatibility fallback. The sent cursor is rolled back if writing
+        fails so a reconnected incarnation may safely acknowledge again.
+        """
 
         async with self._ready_lock:
             snapshot = self.snapshot
@@ -209,7 +222,12 @@ class NodeAgentClient:
                 raise
 
     async def _send_ready_if_possible(self, generation: int) -> None:
-        """Acknowledge readiness once local workers match master rendezvous."""
+        """Send node-level readiness exactly once after matching rendezvous and local WORLD.
+
+        Readiness is gated by the current snapshot, the rendezvous cursor, retained preparation
+        metadata, and unanimous local-worker ready state. As with preparation, failure resets the sent
+        marker so reconnect can retry without treating a dropped frame as consensus.
+        """
 
         async with self._ready_lock:
             snapshot = self.snapshot
@@ -252,7 +270,13 @@ class NodeAgentClient:
         self._last_master_sequence = message.sequence_number
 
     async def _consume_membership(self, message: MessageEnvelope) -> MembershipSnapshot:
-        """Install a newer snapshot and invalidate all phase work derived before it."""
+        """Install membership and invalidate every phase derived from its predecessor.
+
+        Master sequence and snapshot checksum are validated before local state changes.
+        Preparation/rendezvous/readiness cursors and compatibility metadata reset together,
+        then the complete snapshot is relayed to GPU workers and optional callbacks. The
+        agent acknowledges preparation only after every configured local worker agrees.
+        """
 
         if message.message_type != "membership":
             raise ValueError("expected a membership message from the master")
@@ -276,7 +300,12 @@ class NodeAgentClient:
         return snapshot
 
     async def _consume_rendezvous(self, message: MessageEnvelope) -> None:
-        """Accept rendezvous only when it exactly matches local preparation."""
+        """Accept rendezvous only for the locally prepared generation and metadata.
+
+        Stale rendezvous is harmlessly ignored; a future or mismatched checksum, plan, or
+        compatibility digest is a protocol error. Matching rendezvous is relayed to local
+        workers, and the agent reports ready only after their second barrier completes.
+        """
 
         if message.message_type != "generation_rendezvous":
             raise ValueError("expected a generation_rendezvous message")
@@ -298,7 +327,12 @@ class NodeAgentClient:
         await self._send_ready_if_possible(message.generation)
 
     async def _consume_active(self, message: MessageEnvelope) -> None:
-        """Mark and relay activation only for the locally readied generation."""
+        """Complete activation only for the generation this node prepared and readied.
+
+        The master sequence, membership hash, plan checksum, and compatibility digest must
+        all match local phase state. Once accepted, activation is broadcast to GPU workers
+        before the optional application callback observes the new active generation.
+        """
 
         if message.message_type != "generation_active":
             raise ValueError("expected a generation_active message")
@@ -390,7 +424,12 @@ class NodeAgentClient:
             task.result()
 
     async def run_reconnecting(self, *, retry_delay_s: float = 0.1) -> None:
-        """Maintain one incarnation at a time and reconnect after stream loss."""
+        """Reconnect after transport loss without reusing incarnation ordering state.
+
+        Ordinary protocol/application errors still escape. Recoverable stream errors close the old
+        connection, allocate a fresh incarnation ID, reset sequence numbering, wait the configured
+        retry delay, and register again. A graceful stop suppresses reconnection entirely.
+        """
 
         if self._host is None or self._port is None:
             raise RuntimeError("connect() must be called before run_reconnecting()")

--- a/oobleck/elastic/service_public_base.py
+++ b/oobleck/elastic/service_public_base.py
@@ -27,6 +27,8 @@ from oobleck.elastic.transport import (
 
 @dataclass(frozen=True, slots=True)
 class ControlStatus:
+    """Operator view of proposal membership and activation barrier progress."""
+
     snapshot: MembershipSnapshot
     active_generation: int
     prepared_agents: tuple[str, ...]
@@ -34,14 +36,20 @@ class ControlStatus:
 
     @property
     def generation(self) -> int:
+        """Return the newest proposed membership generation."""
+
         return self.snapshot.generation
 
     @property
     def active(self) -> bool:
+        """Report whether the proposal has completed both activation barriers."""
+
         return self.active_generation == self.snapshot.generation
 
 
 class NodeAgentClient:
+    """Reconnectable node stream plus local GPU-worker barrier aggregation."""
+
     def __init__(
         self,
         node_id: str,
@@ -54,6 +62,8 @@ class NodeAgentClient:
         on_generation_active: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
         local_worker_socket: str | Path | None = None,
     ) -> None:
+        """Validate advertised resources and initialize per-incarnation phase state."""
+
         if not node_id or not gpu_ids or heartbeat_interval_s <= 0:
             raise ValueError("node_id, gpu_ids, and a positive heartbeat interval are required")
         self.node_id = node_id
@@ -106,6 +116,8 @@ class NodeAgentClient:
         generation: int,
         payload: Mapping[str, object],
     ) -> None:
+        """Serialize one sequenced agent message on the current incarnation."""
+
         if self.connection is None:
             raise RuntimeError("agent is not connected")
         async with self._send_lock:
@@ -129,6 +141,8 @@ class NodeAgentClient:
         plan_checksum: str,
         compatibility_digest: str,
     ) -> None:
+        """Record unanimous local preparation and attempt the master acknowledgement."""
+
         snapshot = self.snapshot
         if (
             snapshot is not None
@@ -145,6 +159,8 @@ class NodeAgentClient:
         plan_checksum: str,
         compatibility_digest: str,
     ) -> None:
+        """Forward unanimous local readiness only when it matches preparation."""
+
         snapshot = self.snapshot
         if (
             snapshot is not None
@@ -156,6 +172,8 @@ class NodeAgentClient:
             await self._send_ready_if_possible(generation)
 
     async def _send_prepared_if_possible(self, generation: int) -> None:
+        """Acknowledge preparation once per generation after every local worker."""
+
         async with self._ready_lock:
             snapshot = self.snapshot
             if (
@@ -191,6 +209,8 @@ class NodeAgentClient:
                 raise
 
     async def _send_ready_if_possible(self, generation: int) -> None:
+        """Acknowledge readiness once local workers match master rendezvous."""
+
         async with self._ready_lock:
             snapshot = self.snapshot
             if (
@@ -223,6 +243,8 @@ class NodeAgentClient:
                 raise
 
     def _validate_master_sequence(self, message: MessageEnvelope) -> None:
+        """Reject messages not owned by the master or replayed out of order."""
+
         if message.agent_id != "master":
             raise ValueError("expected a control message from the master")
         if message.sequence_number <= self._last_master_sequence:
@@ -230,6 +252,8 @@ class NodeAgentClient:
         self._last_master_sequence = message.sequence_number
 
     async def _consume_membership(self, message: MessageEnvelope) -> MembershipSnapshot:
+        """Install a newer snapshot and invalidate all phase work derived before it."""
+
         if message.message_type != "membership":
             raise ValueError("expected a membership message from the master")
         self._validate_master_sequence(message)
@@ -252,6 +276,8 @@ class NodeAgentClient:
         return snapshot
 
     async def _consume_rendezvous(self, message: MessageEnvelope) -> None:
+        """Accept rendezvous only when it exactly matches local preparation."""
+
         if message.message_type != "generation_rendezvous":
             raise ValueError("expected a generation_rendezvous message")
         self._validate_master_sequence(message)
@@ -272,6 +298,8 @@ class NodeAgentClient:
         await self._send_ready_if_possible(message.generation)
 
     async def _consume_active(self, message: MessageEnvelope) -> None:
+        """Mark and relay activation only for the locally readied generation."""
+
         if message.message_type != "generation_active":
             raise ValueError("expected a generation_active message")
         self._validate_master_sequence(message)
@@ -294,6 +322,8 @@ class NodeAgentClient:
             await self.on_generation_active(message)
 
     async def connect(self, host: str, port: int) -> MessageEnvelope:
+        """Start local IPC, register this incarnation, and consume membership."""
+
         self._host, self._port = host, port
         if self.local_worker_relay is not None and self.local_worker_relay._server is None:
             await self.local_worker_relay.start()
@@ -317,11 +347,15 @@ class NodeAgentClient:
         return membership
 
     async def _heartbeat_loop(self) -> None:
+        """Renew the master lease on an independent send cadence."""
+
         while True:
             await asyncio.sleep(self.heartbeat_interval_s)
             await self._send_agent_message("heartbeat", self.generation, {})
 
     async def _receive_loop(self) -> None:
+        """Continuously dispatch master phases and targeted drain commands."""
+
         assert self.connection is not None
         while True:
             message = await self.connection.receive()
@@ -340,6 +374,8 @@ class NodeAgentClient:
                 raise ValueError(f"unsupported master message {message.message_type!r}")
 
     async def run(self) -> None:
+        """Run heartbeat and receive loops until either stream task fails."""
+
         if self.connection is None:
             raise RuntimeError("connect() must be called before run()")
         tasks = {
@@ -376,12 +412,16 @@ class NodeAgentClient:
                 await self.connect(self._host, self._port)
 
     async def drain(self) -> None:
+        """Stop reconnecting and request graceful incarnation removal."""
+
         if self.connection is None:
             raise RuntimeError("agent is not connected")
         self._stopping = True
         await self._send_agent_message("drain", self.generation, {})
 
     async def close(self, *, graceful: bool = False) -> None:
+        """Optionally drain, then close master and local-worker transports."""
+
         self._stopping = True
         if self.connection is not None:
             if graceful:
@@ -398,6 +438,8 @@ async def inspect_membership(
     *,
     transport: ControlTransport | None = None,
 ) -> MembershipSnapshot:
+    """Fetch one immutable membership snapshot over a short-lived operator stream."""
+
     selected = transport or AsyncioTcpControlTransport()
     connection = await selected.connect(host, port)
     try:
@@ -416,6 +458,8 @@ async def inspect_status(
     *,
     transport: ControlTransport | None = None,
 ) -> ControlStatus:
+    """Fetch membership together with prepared/ready/active barrier progress."""
+
     selected = transport or AsyncioTcpControlTransport()
     connection = await selected.connect(host, port)
     try:

--- a/oobleck/elastic/transport.py
+++ b/oobleck/elastic/transport.py
@@ -48,14 +48,16 @@ _PAYLOAD_FIELDS = {
 
 
 class ProtocolError(ValueError):
-    pass
+    """A frame or envelope violates the versioned control protocol."""
 
 
 class FrameTooLarge(ProtocolError):
-    pass
+    """A peer declared or encoded a frame beyond the configured bound."""
 
 
 def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
+    """Enforce the exact payload schema for a versioned message type."""
+
     expected = _PAYLOAD_FIELDS.get(message_type)
     if expected is None:
         raise ProtocolError(f"unsupported message_type {message_type!r}")
@@ -113,6 +115,8 @@ def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
 
 @dataclass(frozen=True, slots=True)
 class MessageEnvelope:
+    """Strictly validated metadata and payload for one control-plane message."""
+
     protocol_version: int
     message_type: str
     agent_id: str
@@ -122,6 +126,8 @@ class MessageEnvelope:
     payload: Mapping[str, object]
 
     def __post_init__(self) -> None:
+        """Reject unknown versions, missing identities, and malformed payloads."""
+
         if self.protocol_version != PROTOCOL_VERSION:
             raise ProtocolError(
                 f"unsupported protocol version {self.protocol_version}; expected {PROTOCOL_VERSION}"
@@ -136,6 +142,8 @@ class MessageEnvelope:
 
     @classmethod
     def from_dict(cls, value: object) -> "MessageEnvelope":
+        """Decode only an exact envelope shape; unknown fields are protocol errors."""
+
         if not isinstance(value, dict):
             raise ProtocolError("control envelope must be a JSON object")
         if set(value) != _FIELDS:
@@ -158,6 +166,8 @@ class MessageEnvelope:
 
 
 def encode_frame(message: MessageEnvelope, max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES) -> bytes:
+    """Serialize an envelope as bounded big-endian-length-prefixed JSON."""
+
     body = json.dumps(
         asdict(message), sort_keys=True, separators=(",", ":"), ensure_ascii=True
     ).encode("utf-8")
@@ -169,6 +179,8 @@ def encode_frame(message: MessageEnvelope, max_frame_bytes: int = DEFAULT_MAX_FR
 async def read_frame(
     reader: asyncio.StreamReader, max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES
 ) -> MessageEnvelope:
+    """Read exactly one frame, preserving fragmentation and coalescing semantics."""
+
     header = await reader.readexactly(4)
     size = struct.unpack(">I", header)[0]
     if size == 0:
@@ -188,6 +200,8 @@ async def write_frame(
     message: MessageEnvelope,
     max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
 ) -> None:
+    """Write one complete frame and wait for stream backpressure."""
+
     writer.write(encode_frame(message, max_frame_bytes))
     await writer.drain()
 
@@ -202,6 +216,8 @@ class SerializedWriter:
         max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
         queue_size: int = 64,
     ) -> None:
+        """Start the sole writer task for this stream and bound queued sends."""
+
         self._writer = writer
         self._max_frame_bytes = max_frame_bytes
         self._queue: asyncio.Queue[tuple[MessageEnvelope | None, asyncio.Future[None]]] = (
@@ -210,6 +226,8 @@ class SerializedWriter:
         self._task = asyncio.create_task(self._run())
 
     async def send(self, message: MessageEnvelope) -> None:
+        """Queue a message and return only after it has drained to the stream."""
+
         if self._task.done():
             await self._task
         future = asyncio.get_running_loop().create_future()
@@ -217,6 +235,8 @@ class SerializedWriter:
         await future
 
     async def _run(self) -> None:
+        """Serialize writes and propagate the first failure to every queued sender."""
+
         try:
             while True:
                 message, completion = await self._queue.get()
@@ -239,6 +259,8 @@ class SerializedWriter:
             raise
 
     async def close(self) -> None:
+        """Flush queued frames, stop the writer task, and close the stream."""
+
         if not self._task.done():
             completion = asyncio.get_running_loop().create_future()
             await self._queue.put((None, completion))
@@ -249,6 +271,8 @@ class SerializedWriter:
 
 
 class ControlConnection:
+    """Bidirectional framed connection with one serialized writer."""
+
     def __init__(
         self,
         reader: asyncio.StreamReader,
@@ -257,6 +281,8 @@ class ControlConnection:
         max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
         writer_queue_size: int = 64,
     ) -> None:
+        """Wrap the stream pair with shared frame and queue limits."""
+
         self.reader = reader
         self.writer = SerializedWriter(
             writer,
@@ -266,33 +292,51 @@ class ControlConnection:
         self.max_frame_bytes = max_frame_bytes
 
     async def receive(self) -> MessageEnvelope:
+        """Receive the next validated envelope from the peer."""
+
         return await read_frame(self.reader, self.max_frame_bytes)
 
     async def send(self, message: MessageEnvelope) -> None:
+        """Send through the connection's ordered, backpressured queue."""
+
         await self.writer.send(message)
 
     async def close(self) -> None:
+        """Close the serialized writer and its underlying stream."""
+
         await self.writer.close()
 
 
 class ControlTransport(Protocol):
-    async def connect(self, host: str, port: int) -> ControlConnection: ...
+    """Transport boundary consumed by membership services and local IPC."""
+
+    async def connect(self, host: str, port: int) -> ControlConnection:
+        """Open one persistent client connection using the transport backend."""
+
+        ...
 
     async def start_server(
         self,
         host: str,
         port: int,
         handler: Callable[[ControlConnection], Awaitable[None]],
-    ) -> asyncio.AbstractServer: ...
+    ) -> asyncio.AbstractServer:
+        """Listen for framed connections and dispatch each to ``handler``."""
+
+        ...
 
 
 class AsyncioTcpControlTransport:
+    """Asyncio stream implementation of the control transport contract."""
+
     def __init__(
         self,
         *,
         max_frame_bytes: int = DEFAULT_MAX_FRAME_BYTES,
         writer_queue_size: int = 64,
     ) -> None:
+        """Configure identical frame and writer bounds for clients and servers."""
+
         if max_frame_bytes < 256 or writer_queue_size < 1:
             raise ValueError("invalid control transport limits")
         self.max_frame_bytes = max_frame_bytes
@@ -301,6 +345,8 @@ class AsyncioTcpControlTransport:
     def _connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> ControlConnection:
+        """Apply this transport's limits to a newly opened stream pair."""
+
         return ControlConnection(
             reader,
             writer,
@@ -309,6 +355,8 @@ class AsyncioTcpControlTransport:
         )
 
     async def connect(self, host: str, port: int) -> ControlConnection:
+        """Open a persistent full-duplex TCP control connection."""
+
         reader, writer = await asyncio.open_connection(host, port)
         return self._connection(reader, writer)
 
@@ -318,7 +366,11 @@ class AsyncioTcpControlTransport:
         port: int,
         handler: Callable[[ControlConnection], Awaitable[None]],
     ) -> asyncio.AbstractServer:
+        """Start a server that always closes each accepted connection after handling."""
+
         async def accept(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            """Adapt an asyncio stream pair and guarantee connection retirement."""
+
             connection = self._connection(reader, writer)
             try:
                 await handler(connection)

--- a/oobleck/elastic/transport.py
+++ b/oobleck/elastic/transport.py
@@ -56,7 +56,13 @@ class FrameTooLarge(ProtocolError):
 
 
 def _validate_payload(message_type: str, payload: Mapping[str, object]) -> None:
-    """Enforce the exact payload schema for a versioned message type."""
+    """Enforce the exact field set and runtime types for each protocol message.
+
+    Validation is intentionally closed-world: unknown message types, extra fields, bools
+    masquerading as integers, malformed node inventories, or invalid phase metadata are
+    rejected before service state machines see them. This keeps transport decoding from
+    smuggling partially interpreted control state across generation boundaries.
+    """
 
     expected = _PAYLOAD_FIELDS.get(message_type)
     if expected is None:
@@ -235,7 +241,13 @@ class SerializedWriter:
         await future
 
     async def _run(self) -> None:
-        """Serialize writes and propagate the first failure to every queued sender."""
+        """Own the stream writer, preserving frame order and bounded backpressure.
+
+        Exactly one task dequeues frames and awaits ``drain()``, preventing concurrent
+        coroutines from interleaving bytes. A close sentinel flushes preceding messages.
+        Any write failure is copied to its sender and every still-queued completion before
+        the task terminates, so callers cannot mistake dropped control messages for success.
+        """
 
         try:
             while True:

--- a/oobleck/elastic/workers.py
+++ b/oobleck/elastic/workers.py
@@ -26,6 +26,8 @@ class LocalWorkerSupervisor:
         gpu_ids: Sequence[str],
         socket_path: str | Path,
     ) -> None:
+        """Capture worker entrypoint, stable node identity, GPUs, and relay path."""
+
         self.script = Path(script)
         self.script_args = tuple(script_args)
         self.node_id = node_id
@@ -34,6 +36,8 @@ class LocalWorkerSupervisor:
         self.processes: list[asyncio.subprocess.Process] = []
 
     async def start(self) -> None:
+        """Spawn one isolated process per GPU with deterministic worker metadata."""
+
         if self.processes:
             raise RuntimeError("local workers are already running")
         if not self.script.is_file():
@@ -62,6 +66,8 @@ class LocalWorkerSupervisor:
             self.processes.append(process)
 
     async def wait(self) -> tuple[int, ...]:
+        """Wait for every worker and fail the node service if any exits nonzero."""
+
         if not self.processes:
             raise RuntimeError("local workers have not been started")
         codes = tuple(await asyncio.gather(*(item.wait() for item in self.processes)))
@@ -71,6 +77,8 @@ class LocalWorkerSupervisor:
         return codes
 
     async def close(self) -> None:
+        """Terminate workers, escalate to kill after a bound, and forget handles."""
+
         running = [item for item in self.processes if item.returncode is None]
         for process in running:
             process.terminate()

--- a/oobleck/elastic/workers.py
+++ b/oobleck/elastic/workers.py
@@ -101,7 +101,14 @@ async def run_agent_service(
     on_membership: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
     on_generation_active: Callable[[MessageEnvelope], Awaitable[None]] | None = None,
 ) -> None:
-    """Run an agent lease and, when configured, its local training workers."""
+    """Own the complete node-agent and optional GPU-worker process lifetime.
+
+    The agent registers before workers start so membership and local IPC are available. Without a
+    worker script it simply maintains the reconnecting lease. With workers, the agent stream and
+    process cohort run concurrently; unsuccessful workers fail the node, while clean worker completion
+    requests a graceful drain. The ``finally`` path always retires processes, closes transports, and
+    cancels the remaining agent task.
+    """
 
     client = NodeAgentClient(
         config.node_id,

--- a/oobleck/optimization.py
+++ b/oobleck/optimization.py
@@ -114,7 +114,14 @@ def optimizer_schema_for_partition(
     owner_rank: int,
     committed_step: int,
 ) -> OptimizerStateSchema:
-    """Merge replica schemas and retain state belonging to one new partition."""
+    """Derive optimizer metadata and slots owned by one replacement partition.
+
+    Surviving schemas must agree on optimizer class, schema version, parameter-group count,
+    group metadata, and each parameter's group assignment. The new model manifest selects
+    only locally owned parameters and matching TP-lane tensor slots; scalar slots are copied
+    by logical parameter key. Owners and committed versions are rewritten for the new rank,
+    producing a schema that can be planned alongside model state without unstable object IDs.
+    """
 
     if not schemas:
         raise OptimizerSchemaError("no surviving optimizer schema is available")
@@ -208,7 +215,14 @@ def restore_optimizer_state(
     tensors: Mapping[str, torch.Tensor],
     named_parameters: Mapping[str, torch.nn.Parameter],
 ) -> None:
-    """Rebuild a compatible optimizer from logical parameter and slot identities."""
+    """Rebuild optimizer groups and state using stable logical parameter identities.
+
+    Class/schema and group-count checks prevent recovery into a semantically different
+    optimizer. Parameter lists are rebound to the replacement model, group options and scalar
+    slots are restored, and every declared tensor slot must be present. Sharded parameters
+    rewrap matching local storage as DTensor when possible; ordinary slots remain local tensors
+    on the parameter device.
+    """
 
     actual = f"{optimizer.__class__.__module__}.{optimizer.__class__.__qualname__}"
     if schema.schema_version != 1 or actual != schema.optimizer_class:

--- a/oobleck/optimization.py
+++ b/oobleck/optimization.py
@@ -16,6 +16,8 @@ class OptimizerSchemaError(TypeError):
 
 @dataclass(frozen=True, slots=True)
 class OptimizerStateSchema:
+    """Portable optimizer metadata and versioned logical tensor entries."""
+
     optimizer_class: str
     parameter_groups: tuple[dict[str, Any], ...]
     scalar_slots: tuple[tuple[str, str, Any], ...]
@@ -24,6 +26,8 @@ class OptimizerStateSchema:
 
 
 def _local_tensor(value: torch.Tensor) -> torch.Tensor:
+    """Extract detached rank-local storage from a Tensor or DTensor slot."""
+
     local = value.to_local() if hasattr(value, "to_local") else value
     return local.detach()
 
@@ -176,6 +180,8 @@ def _restore_tensor_for_parameter(
     tensor: torch.Tensor,
     parameter: torch.nn.Parameter,
 ) -> torch.Tensor:
+    """Restore local storage and rewrap it as DTensor when the parameter is sharded."""
+
     local = tensor.to(parameter.device).clone()
     if not hasattr(parameter, "device_mesh") or tuple(local.shape) != tuple(
         getattr(parameter, "_local_tensor", local).shape
@@ -202,6 +208,8 @@ def restore_optimizer_state(
     tensors: Mapping[str, torch.Tensor],
     named_parameters: Mapping[str, torch.nn.Parameter],
 ) -> None:
+    """Rebuild a compatible optimizer from logical parameter and slot identities."""
+
     actual = f"{optimizer.__class__.__module__}.{optimizer.__class__.__qualname__}"
     if schema.schema_version != 1 or actual != schema.optimizer_class:
         raise OptimizerSchemaError(

--- a/oobleck/optimization_base.py
+++ b/oobleck/optimization_base.py
@@ -11,11 +11,13 @@ from oobleck.state import LogicalStateEntry
 
 
 class OptimizerSchemaError(TypeError):
-    pass
+    """An optimizer cannot be represented by the retained logical-key schema."""
 
 
 @dataclass(frozen=True, slots=True)
 class OptimizerStateSchema:
+    """Optimizer class, parameter groups, scalar slots, and tensor manifests."""
+
     optimizer_class: str
     parameter_groups: tuple[dict[str, Any], ...]
     scalar_slots: tuple[tuple[str, str, Any], ...]
@@ -30,6 +32,8 @@ def serialize_optimizer_state(
     owner_rank: int,
     committed_step: int,
 ) -> tuple[OptimizerStateSchema, dict[str, torch.Tensor]]:
+    """Replace unstable parameter IDs with logical keys and versioned slot tensors."""
+
     by_identity = {id(parameter): name for name, parameter in named_parameters.items()}
     groups = []
     for group in optimizer.param_groups:
@@ -91,6 +95,8 @@ def restore_optimizer_state(
     tensors: Mapping[str, torch.Tensor],
     named_parameters: Mapping[str, torch.nn.Parameter],
 ) -> None:
+    """Reconstruct parameter groups and slots into a compatible optimizer."""
+
     actual = f"{optimizer.__class__.__module__}.{optimizer.__class__.__qualname__}"
     if schema.schema_version != 1 or actual != schema.optimizer_class:
         raise OptimizerSchemaError(

--- a/oobleck/optimization_base.py
+++ b/oobleck/optimization_base.py
@@ -32,7 +32,13 @@ def serialize_optimizer_state(
     owner_rank: int,
     committed_step: int,
 ) -> tuple[OptimizerStateSchema, dict[str, torch.Tensor]]:
-    """Replace unstable parameter IDs with logical keys and versioned slot tensors."""
+    """Serialize the retained homogeneous optimizer schema using logical model keys.
+
+    Parameter groups preserve options but replace object identities with stable names. Per-parameter
+    state is split into primitive scalar slots and tensor slots represented by versioned manifest
+    entries at the committed step. Parameters or slot types that lack a portable representation fail
+    explicitly rather than producing recovery data tied to transient Python IDs.
+    """
 
     by_identity = {id(parameter): name for name, parameter in named_parameters.items()}
     groups = []

--- a/oobleck/planning/cache.py
+++ b/oobleck/planning/cache.py
@@ -17,6 +17,8 @@ def save_templates(
     templates: Sequence[PipelineTemplate],
     fingerprint: CompatibilityFingerprint,
 ) -> None:
+    """Persist templates with the exact fingerprint that produced them."""
+
     target = Path(path)
     target.parent.mkdir(parents=True, exist_ok=True)
     payload = {
@@ -39,6 +41,8 @@ def save_templates(
 def load_templates(
     path: str | Path, fingerprint: CompatibilityFingerprint
 ) -> tuple[PipelineTemplate, ...]:
+    """Load a cache only when both its schema and runtime fingerprint match."""
+
     target = Path(path)
     try:
         payload = json.loads(target.read_text())

--- a/oobleck/planning/composer.py
+++ b/oobleck/planning/composer.py
@@ -78,11 +78,15 @@ def allocate_microbatches(
 def _resource_compositions(
     templates: Sequence[PipelineTemplate], resources: int, minimum_replicas: int
 ) -> Iterable[tuple[PipelineTemplate, ...]]:
+    """Enumerate stable template multisets that consume every available node."""
+
     ordered = sorted(templates, key=lambda item: (item.resource_count, item.template_id))
 
     def visit(
         start: int, remaining: int, selected: tuple[PipelineTemplate, ...]
     ) -> Iterable[tuple[PipelineTemplate, ...]]:
+        """Backtrack through nondecreasing templates to avoid duplicates."""
+
         if remaining == 0:
             if len(selected) >= minimum_replicas:
                 yield selected
@@ -131,6 +135,8 @@ def _assign_composition(
 
     @lru_cache(maxsize=None)
     def choose(slot: int, used: int) -> tuple[int, tuple[int, ...]]:
+        """Match old identities to new slots while maximizing retained state."""
+
         if slot == len(composition):
             return 0, ()
         options: list[tuple[int, tuple[int, ...]]] = []

--- a/oobleck/planning/composer.py
+++ b/oobleck/planning/composer.py
@@ -13,7 +13,14 @@ from oobleck.types import PipelineInstance, PipelineTemplate, RecoveryUnavailabl
 def allocate_microbatches(
     instances: Sequence[PipelineInstance], total_microbatches: int
 ) -> tuple[PipelineInstance, ...]:
-    """Minimize the predicted maximum iteration time with integer allocations."""
+    """Allocate integer microbatches to minimize predicted iteration makespan.
+
+    The search first finds the smallest feasible iteration-time threshold under
+    each template's memory capacity. Every replica receives one microbatch, then
+    remaining work is assigned greedily by its next completion time with stable
+    instance-ID tie breaks. The returned allocation always consumes the complete
+    fixed global batch without silently disabling a pipeline.
+    """
 
     if not instances:
         raise RecoveryUnavailable("cannot allocate a batch without a pipeline")
@@ -105,7 +112,14 @@ def _assign_composition(
     previous: Sequence[PipelineInstance],
     state_bytes: Mapping[str, int],
 ) -> tuple[tuple[PipelineInstance, ...], int, int]:
-    """Assign identities/nodes to a composition with maximum in-place state."""
+    """Map a template composition to nodes while preserving maximum local state.
+
+    A dynamic-programming match pairs new composition slots with surviving old
+    pipeline identities using retained-state bytes as the primary score. Reserved
+    survivors stay with the winning identity; remaining nodes fill deficits in
+    stable order. The result also reports retained bytes and survivor movement so
+    higher-level composition can apply deterministic recovery tie breaks.
+    """
 
     surviving = set(nodes)
     old = tuple(
@@ -207,7 +221,14 @@ def compose_templates(
     previous_instances: Sequence[PipelineInstance] = (),
     state_bytes_by_node: Mapping[str, int] | None = None,
 ) -> tuple[PipelineInstance, ...]:
-    """Choose throughput first, then retained state, movement, and stable IDs."""
+    """Choose a complete heterogeneous composition with deterministic objectives.
+
+    Every multiset of templates that exactly consumes membership and satisfies the
+    replica threshold is considered. Feasible candidates receive an integer batch
+    allocation, then compare by predicted makespan, retained state, moved nodes,
+    template IDs, and concrete ownership. This ordering lets all workers derive an
+    identical plan while preferring throughput before recovery convenience.
+    """
 
     if not templates:
         raise RecoveryUnavailable("no pipeline templates are available")

--- a/oobleck/planning/generator.py
+++ b/oobleck/planning/generator.py
@@ -9,6 +9,8 @@ from oobleck.types import CompatibilityFingerprint, PipelineTemplate
 
 
 def _partition(layers: Sequence[LayerExecutionResult], stages: int) -> tuple[tuple[int, int], ...]:
+    """Minimax-partition contiguous layers with deterministic cut-position ties."""
+
     if stages < 1 or stages > len(layers):
         raise ValueError("stage count must be between one and the number of layers")
     prefix = [0.0]
@@ -41,6 +43,8 @@ def _partition(layers: Sequence[LayerExecutionResult], stages: int) -> tuple[tup
 def _max_microbatches(
     activation_memory: int, persistent_memory: int, device_memory_bytes: int | None
 ) -> int | None:
+    """Convert a device-memory budget into a pipeline activation capacity."""
+
     if device_memory_bytes is None:
         return None
     available = device_memory_bytes - persistent_memory
@@ -60,6 +64,13 @@ def create_pipeline_templates(
     fingerprint: CompatibilityFingerprint | None = None,
     device_memory_bytes: int | None = None,
 ) -> dict[int, PipelineTemplate]:
+    """Generate templates via the Rust planner or deterministic Python fallback.
+
+    Profiles use global contiguous layer IDs. Each requested node count becomes
+    a stage count; optional memory capacity lets composition reject globally
+    infeasible microbatch allocations.
+    """
+
     if not model_name or not profile_data or not num_nodes:
         raise ValueError("model_name, profile_data, and num_nodes must be non-empty")
     if tensor_parallel_size < 1:

--- a/oobleck/planning/profiler.py
+++ b/oobleck/planning/profiler.py
@@ -18,6 +18,8 @@ PROFILE_SCHEMA_VERSION = 2
 
 @dataclass(frozen=True, slots=True)
 class LayerExecutionResult:
+    """Timing and memory measurements for one globally indexed model layer."""
+
     layer_index: int
     layer_name: str
     forward: float
@@ -27,6 +29,8 @@ class LayerExecutionResult:
     persistent_memory: int = 0
 
     def __post_init__(self) -> None:
+        """Require a valid global identity and non-negative measurements."""
+
         if self.layer_index < 0 or not self.layer_name:
             raise ValueError("layer identity is invalid")
         if (
@@ -40,7 +44,11 @@ class LayerExecutionResult:
 
 
 class JsonEncoder(json.JSONEncoder):
+    """Encode profile value objects through their dataclass representation."""
+
     def default(self, obj: object) -> object:
+        """Delegate unknown objects after handling profile dataclasses."""
+
         if isinstance(obj, (LayerExecutionResult, CompatibilityFingerprint)):
             return asdict(obj)
         return super().default(obj)
@@ -48,12 +56,16 @@ class JsonEncoder(json.JSONEncoder):
 
 @dataclass(frozen=True, slots=True)
 class ModelProfile:
+    """Versioned, compatibility-bound collection of per-layer measurements."""
+
     fingerprint: CompatibilityFingerprint
     microbatch_size: int
     layers: tuple[LayerExecutionResult, ...]
     schema_version: int = PROFILE_SCHEMA_VERSION
 
     def __post_init__(self) -> None:
+        """Reject stale schemas and profiles without contiguous layer identities."""
+
         if self.schema_version != PROFILE_SCHEMA_VERSION:
             raise ValueError(f"unsupported profile schema {self.schema_version}")
         if self.microbatch_size < 1 or not self.layers:
@@ -62,6 +74,8 @@ class ModelProfile:
             raise ValueError("profile layers must have contiguous global indices")
 
     def save(self, path: str | Path) -> None:
+        """Write a deterministic JSON profile, creating parent directories."""
+
         target = Path(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(
@@ -72,6 +86,8 @@ class ModelProfile:
     def load(
         cls, path: str | Path, expected: CompatibilityFingerprint | None = None
     ) -> "ModelProfile":
+        """Decode a profile and optionally enforce an exact fingerprint match."""
+
         target = Path(path)
         try:
             value = json.loads(target.read_text())
@@ -110,6 +126,8 @@ class ProfilingWorkload:
     loss_factory: ProfileLossFactory | None = None
 
     def __post_init__(self) -> None:
+        """Require at least one layer and callable input/loss factories."""
+
         if not self.layers or not callable(self.input_factory):
             raise ValueError("a profiling workload requires layers and an input factory")
         if self.loss_factory is not None and not callable(self.loss_factory):
@@ -127,6 +145,8 @@ class ModelProfiler:
         base_dir: str | Path = ".",
         **legacy: Any,
     ) -> None:
+        """Bind cache layout and optional compatibility identity for this run."""
+
         self.tag = tag
         self.fingerprint = fingerprint
         self.profile_dir = Path(base_dir) / tag / "profile"
@@ -136,6 +156,8 @@ class ModelProfiler:
     def get_profile_path(
         profile_dir: Path, tp_size: int, microbatch_size: int, precision: str
     ) -> Path:
+        """Return the legacy cache path keyed by TP, batch size, and precision."""
+
         profile_dir.mkdir(parents=True, exist_ok=True)
         return profile_dir / f"profile_tp{tp_size}_mb{microbatch_size}_{precision}.json"
 
@@ -145,6 +167,8 @@ class ModelProfiler:
         microbatch_size: int,
         layers: Sequence[LayerExecutionResult],
     ) -> ModelProfile:
+        """Validate, persist, and return a newly measured profile."""
+
         if self.fingerprint is None:
             raise ValueError("a compatibility fingerprint is required to record profiles")
         profile = ModelProfile(self.fingerprint, microbatch_size, tuple(layers))
@@ -152,10 +176,14 @@ class ModelProfiler:
         return profile
 
     def load(self, path: str | Path) -> ModelProfile:
+        """Load a profile under this profiler's compatibility requirement."""
+
         return ModelProfile.load(path, self.fingerprint)
 
     @staticmethod
     def _arguments(value: object) -> tuple[tuple[object, ...], dict[str, object]]:
+        """Normalize flexible input-factory results into call args and kwargs."""
+
         if (
             isinstance(value, tuple)
             and len(value) == 2
@@ -171,9 +199,13 @@ class ModelProfiler:
 
     @staticmethod
     def _default_loss(output: object) -> torch.Tensor:
+        """Sum every differentiable floating output into a synthetic scalar loss."""
+
         tensors: list[torch.Tensor] = []
 
         def collect(value: object) -> None:
+            """Recursively find floating tensor leaves in common containers."""
+
             if isinstance(value, torch.Tensor) and value.is_floating_point():
                 tensors.append(value)
             elif isinstance(value, dict):
@@ -195,6 +227,8 @@ class ModelProfiler:
 
     @staticmethod
     def _persistent_bytes(layer: torch.nn.Module) -> int:
+        """Count parameter and buffer storage owned by a materialized layer."""
+
         state = tuple(layer.parameters(recurse=True)) + tuple(layer.buffers(recurse=True))
         return sum(item.numel() * item.element_size() for item in state)
 
@@ -283,6 +317,8 @@ class ModelProfiler:
         warmup_steps: int = 2,
         measurement_steps: int = 5,
     ) -> ModelProfile:
+        """Measure a workload and atomically feed the results into profile storage."""
+
         return self.record(
             path,
             microbatch_size,
@@ -294,6 +330,8 @@ class ModelProfiler:
         )
 
     def load_profile(self, microbatch_size: int) -> list[LayerExecutionResult]:
+        """Load layers from the retained legacy cache naming convention."""
+
         precision = str(self.legacy.get("precision", "unknown"))
         tp_size = int(self.legacy.get("tp_size", 1))
         path = self.get_profile_path(self.profile_dir, tp_size, microbatch_size, precision)

--- a/oobleck/planning/reconfiguration.py
+++ b/oobleck/planning/reconfiguration.py
@@ -43,7 +43,15 @@ def reconfigure_pipelines(
     *,
     state_bytes_by_node: Mapping[str, int] | None = None,
 ) -> ReconfigurationResult:
-    """Apply simple, borrow, and merge with throughput/state-stable ties."""
+    """Reassign complete survivor membership using simple, borrow, or merge.
+
+    Pure joins/replacements use global composition because new resources may change
+    the throughput optimum. Failure-only changes first retain each surviving
+    pipeline identity, borrow low-state nodes from viable donors, and merge only
+    groups that still lack a supported template. The final allocation must satisfy
+    the replica threshold and assign every survivor exactly once; ties prefer
+    throughput, retained state, minimal movement, and stable identities.
+    """
 
     survivors = set(surviving_node_ids)
     weights = dict(state_bytes_by_node or {})

--- a/oobleck/planning/reconfiguration.py
+++ b/oobleck/planning/reconfiguration.py
@@ -15,6 +15,8 @@ from oobleck.types import PipelineInstance, PipelineTemplate, RecoveryUnavailabl
 
 @dataclass(frozen=True, slots=True)
 class ReconfigurationResult:
+    """A complete survivor assignment plus recovery-strategy accounting."""
+
     instances: tuple[PipelineInstance, ...]
     strategies: tuple[str, ...]
     retained_nodes: int
@@ -25,6 +27,8 @@ class ReconfigurationResult:
 def _instance(
     identity: str, nodes: Iterable[str], templates: Sequence[PipelineTemplate]
 ) -> PipelineInstance | None:
+    """Create an ordered instance when its resource count is supported."""
+
     selected_nodes = tuple(sorted(nodes))
     template = template_for_resources(templates, len(selected_nodes))
     return None if template is None else PipelineInstance(identity, template, selected_nodes)
@@ -49,6 +53,8 @@ def reconfigure_pipelines(
     old_owner = {node: item.instance_id for item in previous for node in item.node_ids}
 
     def retained_bytes(identity: str, nodes: Iterable[str]) -> int:
+        """Score state that stays under the same logical pipeline identity."""
+
         return sum(weights.get(node, 1) for node in nodes if old_owner.get(node) == identity)
 
     if not survivors <= known:
@@ -136,6 +142,8 @@ def reconfigure_pipelines(
             )
 
         def partner_objective(partner: list) -> tuple[object, ...]:
+            """Rank merge partners by throughput, retained state, size, and ID."""
+
             combined = target[1] | partner[1]
             template = template_for_resources(templates, len(combined))
             predicted = float("inf") if template is None else template.iteration_time(1)

--- a/oobleck/recovery.py
+++ b/oobleck/recovery.py
@@ -30,6 +30,8 @@ import torch
 def _gather_new_manifests(
     manifest: StateManifest, *, dist: Any, world_size: int
 ) -> tuple[StateManifest, ...]:
+    """Exchange every destination manifest before deriving a global schedule."""
+
     if dist is None:
         return (manifest,)
     gathered: list[StateManifest | None] = [None] * world_size
@@ -40,6 +42,8 @@ def _gather_new_manifests(
 
 
 def _rank_to_node(context: Any) -> dict[int, str] | None:
+    """Project the active execution rank map into transfer-locality metadata."""
+
     execution_plan = getattr(context, "execution_plan", None)
     rank_map = getattr(execution_plan, "rank_map", None)
     if rank_map is None:

--- a/oobleck/recovery.py
+++ b/oobleck/recovery.py
@@ -52,7 +52,16 @@ def _rank_to_node(context: Any) -> dict[int, str] | None:
 
 
 def restore_context_state(context: Any, snapshot: RecoverySnapshot | None) -> RecoveryReport:
-    """Redistribute a committed snapshot into every rank of the active generation."""
+    """Restore one agreed committed transaction into the entire replacement generation.
+
+    Surviving ranks exchange tensor-free source metadata, agree on one committed step, and build
+    model/optimizer destination manifests for every new rank—including joining workers with no
+    snapshot. All ranks derive and checksum one global redistribution schedule before retained
+    local shards are copied and remote chunks execute collectively. Completeness is verified for
+    every destination, then optimizer groups/slots, scheduler, scaler, and committed step are
+    reconstructed. A final WORLD barrier prevents any rank from training on partially restored
+    state; phase and load metrics describe the completed recovery.
+    """
 
     started = time.perf_counter()
     dist, rank, world_size = _distributed_identity(context.owner_plan.rank)

--- a/oobleck/recovery_base.py
+++ b/oobleck/recovery_base.py
@@ -129,7 +129,14 @@ def logical_state_bindings(
     model: torch.nn.Module,
     manifest: StateManifest,
 ) -> tuple[dict[str, torch.nn.Parameter], dict[StateTensorKey, torch.Tensor]]:
-    """Bind stable manifest identities to the active partition's local tensors."""
+    """Bind manifest identities to concrete tensors in the activated partition.
+
+    Local module names are expanded through Cornstarch global-key converters so partitioned
+    modules still match generation-independent logical names. Each binding must agree with
+    manifest shape and dtype, shared parameters may appear under aliases, and every declared
+    parameter/buffer shard must resolve. The result separates optimizer-facing Parameter
+    objects from raw local tensor storage used by transfer.
+    """
 
     parameters: dict[str, torch.nn.Parameter] = {}
     states: dict[StateTensorKey, torch.Tensor] = {}
@@ -179,7 +186,14 @@ def _combined_manifest(
 
 
 def capture_context_state(context: Any) -> RecoverySnapshot:
-    """Clone the last committed rank-local state before retiring a generation."""
+    """Capture an immutable rank-local snapshot at the committed transaction boundary.
+
+    Model manifest entries are stamped with ``committed_step`` and all bound local tensors are
+    cloned contiguously before WORLD teardown. Optimizer state is serialized by logical key and
+    merged into the same transfer manifest; scheduler and scaler dictionaries are deep-copied as
+    replicated metadata. No uncommitted gradients or DataLoader progress enter the snapshot, so
+    it remains valid through multiple superseded recovery attempts.
+    """
 
     model_manifest = version_manifest(context.partition.manifest, context.committed_step)
     named_parameters, model_tensors = logical_state_bindings(context.model, model_manifest)
@@ -321,7 +335,14 @@ def _copy_retained(
 
 
 def restore_context_state(context: Any, snapshot: RecoverySnapshot) -> RecoveryReport:
-    """Redistribute a committed snapshot into the context's active generation."""
+    """Restore committed state through the retained single-destination recovery path.
+
+    Surviving metadata must agree on committed step and WORLD size. The local replacement manifest
+    binds model tensors, derives optimizer destinations, and plans transfers from all source manifests.
+    Ranks checksum the schedule, copy locally retained shards, execute collective transfers, and verify
+    every destination was initialized before rebuilding optimizer, scheduler, and scaler state. The
+    public recovery layer extends this algorithm by planning all destination manifests together.
+    """
 
     dist, rank, world_size = _distributed_identity(context.owner_plan.rank)
     if context.compiled.world_size != world_size:

--- a/oobleck/recovery_base.py
+++ b/oobleck/recovery_base.py
@@ -20,6 +20,8 @@ from oobleck.state_transfer import StateTensorKey, execute_transfer_schedule
 
 @dataclass(slots=True)
 class RecoverySnapshot:
+    """Cloned rank-local state retained across process-group replacement."""
+
     manifest: StateManifest
     tensors: dict[StateTensorKey, torch.Tensor]
     optimizer_schema: OptimizerStateSchema | None
@@ -30,6 +32,8 @@ class RecoverySnapshot:
 
 @dataclass(frozen=True, slots=True)
 class RecoveryMetadata:
+    """Tensor-free recovery description exchanged among surviving/new ranks."""
+
     manifest: StateManifest
     optimizer_schema: OptimizerStateSchema | None
     scheduler_state: Mapping[str, Any] | None
@@ -39,6 +43,8 @@ class RecoveryMetadata:
 
 @dataclass(frozen=True, slots=True)
 class RecoveryReport:
+    """Planned versus observed recovery load and phase timing."""
+
     schedule: TransferSchedule
     source_bytes: tuple[tuple[int, int], ...]
     destination_bytes: tuple[tuple[int, int], ...]
@@ -55,14 +61,20 @@ class RecoveryReport:
 
     @property
     def maximum_source_bytes(self) -> int:
+        """Return the largest planned source egress load."""
+
         return max((value for _, value in self.source_bytes), default=0)
 
     @property
     def maximum_destination_bytes(self) -> int:
+        """Return the largest planned destination ingress load."""
+
         return max((value for _, value in self.destination_bytes), default=0)
 
     @property
     def source_scheduling_error_bytes(self) -> int:
+        """Return the worst absolute deviation from planned source traffic."""
+
         planned = dict(self.source_bytes)
         actual = dict(self.actual_source_bytes)
         ranks = set(planned) | set(actual)
@@ -70,10 +82,14 @@ class RecoveryReport:
 
     @property
     def straggler_round_seconds(self) -> float:
+        """Return the longest globally observed transfer round."""
+
         return max((duration for _, _, duration in self.round_durations), default=0.0)
 
 
 def version_manifest(manifest: StateManifest, committed_step: int) -> StateManifest:
+    """Stamp every logical shard with the transaction version being captured."""
+
     return StateManifest(
         manifest.rank,
         tuple(replace(entry, version=committed_step) for entry in manifest.entries),
@@ -82,10 +98,14 @@ def version_manifest(manifest: StateManifest, committed_step: int) -> StateManif
 
 
 def _local_tensor(value: torch.Tensor) -> torch.Tensor:
+    """Resolve DTensor wrappers to the local storage described by a manifest."""
+
     return value.to_local() if hasattr(value, "to_local") else value
 
 
 def _logical_candidates(root: torch.nn.Module, local_name: str) -> tuple[str, ...]:
+    """Translate local Cornstarch names back to candidate global logical keys."""
+
     candidates = [local_name]
     modules = sorted(root.named_modules(), key=lambda item: len(item[0]), reverse=True)
     for prefix, module in modules:
@@ -150,6 +170,8 @@ def _combined_manifest(
     model_manifest: StateManifest,
     optimizer_schema: OptimizerStateSchema | None,
 ) -> StateManifest:
+    """Combine model state and tensor optimizer slots into one transfer manifest."""
+
     entries = list(model_manifest.entries)
     if optimizer_schema is not None:
         entries.extend(optimizer_schema.tensor_entries)
@@ -205,6 +227,8 @@ def capture_context_state(context: Any) -> RecoverySnapshot:
 
 
 def _distributed_identity(fallback_rank: int) -> tuple[Any, int, int]:
+    """Return active WORLD identity or a deterministic single-process fallback."""
+
     try:
         import torch.distributed as dist
 
@@ -216,6 +240,8 @@ def _distributed_identity(fallback_rank: int) -> tuple[Any, int, int]:
 
 
 def _reown_manifest(manifest: StateManifest, rank: int) -> StateManifest:
+    """Rewrite ownership when gathered metadata moves into a replacement WORLD."""
+
     return StateManifest(
         rank,
         tuple(replace(entry, owner_rank=rank) for entry in manifest.entries),
@@ -224,6 +250,8 @@ def _reown_manifest(manifest: StateManifest, rank: int) -> StateManifest:
 
 
 def _reown_schema(schema: OptimizerStateSchema | None, rank: int) -> OptimizerStateSchema | None:
+    """Rewrite optimizer tensor owners alongside their model manifest."""
+
     if schema is None:
         return None
     return replace(
@@ -239,6 +267,8 @@ def _gather_metadata(
     dist: Any,
     world_size: int,
 ) -> tuple[RecoveryMetadata, ...]:
+    """Exchange tensor-free snapshots; ranks without surviving state send None."""
+
     local = (
         None
         if snapshot is None
@@ -258,6 +288,8 @@ def _gather_metadata(
 
 
 def _dtype(value: str) -> torch.dtype:
+    """Resolve a manifest dtype name to a concrete torch dtype."""
+
     name = value.removeprefix("torch.")
     dtype = getattr(torch, name, None)
     if not isinstance(dtype, torch.dtype):
@@ -271,6 +303,8 @@ def _copy_retained(
     sources: Mapping[StateTensorKey, torch.Tensor],
     destinations: MutableMapping[StateTensorKey, torch.Tensor],
 ) -> set[StateTensorKey]:
+    """Copy shards retained locally and report which destinations are initialized."""
+
     old_entries = {
         (entry.logical_key, entry.state_kind, entry.tp_lane): entry
         for entry in old_manifest.entries

--- a/oobleck/runtime.py
+++ b/oobleck/runtime.py
@@ -25,6 +25,8 @@ _base_close = OobleckParallelContext.close
 
 @dataclass(frozen=True, slots=True)
 class GenerationTransitionMetrics:
+    """Per-phase latency, balancing, and supersession data for one generation."""
+
     generation: int
     snapshot_seconds: float
     teardown_seconds: float
@@ -44,6 +46,8 @@ class GenerationTransitionMetrics:
 
 @dataclass(slots=True)
 class _PreparedGenerationTransition:
+    """Snapshot and compiled ownership held between control-plane barriers."""
+
     target: Any
     compiled: Any
     snapshot: Any
@@ -58,6 +62,8 @@ class _PreparedGenerationTransition:
 
 
 def _init_with_recovery(self: OobleckParallelContext, *args: Any, **kwargs: Any) -> None:
+    """Extend the base context with recovery factories, barriers, and topology."""
+
     _base_init(self, *args, **kwargs)
     self._optimizer_factory: (
         Callable[[Iterable[torch.nn.Parameter]], torch.optim.Optimizer] | None
@@ -89,6 +95,8 @@ def _configure_optimization(
     scheduler_factory: Callable[[torch.optim.Optimizer], Any] | None = None,
     scaler: Any = None,
 ) -> None:
+    """Retain optimizer factories so replacement partitions can rebuild state."""
+
     _base_configure_optimization(
         self,
         optimizer_factory=optimizer_factory,
@@ -100,6 +108,8 @@ def _configure_optimization(
 
 
 def _world_initialized() -> bool:
+    """Safely query WORLD without requiring distributed support to be importable."""
+
     try:
         import torch.distributed as dist
 
@@ -109,6 +119,8 @@ def _world_initialized() -> bool:
 
 
 def _retire_world(self: OobleckParallelContext) -> None:
+    """Close logical topology and partition before destroying every process group."""
+
     if self._heterogeneous_gradient_sync is not None:
         self._heterogeneous_gradient_sync.close()
         self._heterogeneous_gradient_sync = None
@@ -125,6 +137,8 @@ def _record_superseded(
     activation_seconds: float = 0.0,
     recovery_seconds: float = 0.0,
 ) -> None:
+    """Record an abandoned attempt exactly once with all completed phase metrics."""
+
     if transition.superseded_recorded:
         return
     transition.superseded_recorded = True
@@ -342,11 +356,15 @@ def _apply_membership(self: OobleckParallelContext, snapshot: MembershipSnapshot
 
 
 def _enable_control_plane_barrier(self: OobleckParallelContext) -> None:
+    """Require future steps to wait for master-published generation activation."""
+
     self._control_plane_managed = True
     self._control_active_generation = self.generation
 
 
 def _prepare_generation(self: OobleckParallelContext) -> None:
+    """Run snapshot, teardown, and compile after local preparation consensus."""
+
     if not self._control_plane_managed:
         raise RuntimeError("enable the control-plane barrier before preparation")
     if not _prepare_latest_generation(self):
@@ -354,6 +372,8 @@ def _prepare_generation(self: OobleckParallelContext) -> None:
 
 
 def _activate_generation(self: OobleckParallelContext) -> None:
+    """Build WORLD, materialize, and recover after rendezvous publication."""
+
     if not self._control_plane_managed:
         raise RuntimeError("enable the control-plane barrier before activation")
     if not _activate_prepared_generation(self):
@@ -361,11 +381,15 @@ def _activate_generation(self: OobleckParallelContext) -> None:
 
 
 def _prepared_execution_plan(self: OobleckParallelContext) -> Any:
+    """Expose the target plan whose checksum local workers must acknowledge."""
+
     transition = self._prepared_transition
     return self.execution_plan if transition is None else transition.target
 
 
 def _generation_transition_pending(self: OobleckParallelContext) -> bool:
+    """Report whether transactional commit is blocked on generation activation."""
+
     return self._control_plane_managed and (
         self._pending_plan is not None
         or self._prepared_transition is not None
@@ -374,6 +398,8 @@ def _generation_transition_pending(self: OobleckParallelContext) -> bool:
 
 
 def _wait_for_generation_barrier(self: OobleckParallelContext) -> None:
+    """Block the training thread until activation or the rendezvous timeout."""
+
     deadline = time.monotonic() + self.config.rendezvous_timeout_s
     with self._generation_condition:
         while _generation_transition_pending(self):
@@ -384,6 +410,8 @@ def _wait_for_generation_barrier(self: OobleckParallelContext) -> None:
 
 
 def _mark_generation_active(self: OobleckParallelContext, generation: int) -> None:
+    """Publish matching master activation to every waiting local step."""
+
     if generation != self.generation:
         raise RuntimeError(
             f"cannot activate generation {generation}; prepared generation is {self.generation}"
@@ -394,6 +422,8 @@ def _mark_generation_active(self: OobleckParallelContext, generation: int) -> No
 
 
 def _step_with_control_barrier(self: OobleckParallelContext, *args: Any, **kwargs: Any) -> Any:
+    """Prevent a new transaction attempt from entering an inactive generation."""
+
     if _generation_transition_pending(self):
         _wait_for_generation_barrier(self)
     return _base_step(self, *args, **kwargs)
@@ -415,6 +445,8 @@ def _recover_from_survivors(self: OobleckParallelContext) -> None:
 
 
 def _close_with_topology(self: OobleckParallelContext) -> None:
+    """Retire synchronization topology, partition state, and the entire WORLD."""
+
     if self._heterogeneous_gradient_sync is not None:
         self._heterogeneous_gradient_sync.close()
         self._heterogeneous_gradient_sync = None

--- a/oobleck/runtime.py
+++ b/oobleck/runtime.py
@@ -137,7 +137,13 @@ def _record_superseded(
     activation_seconds: float = 0.0,
     recovery_seconds: float = 0.0,
 ) -> None:
-    """Record an abandoned attempt exactly once with all completed phase metrics."""
+    """Record one superseded generation attempt without double-counting recovery work.
+
+    The transition remembers whether it was already emitted because supersession can be observed at
+    compile, activation, or post-recovery boundaries. Completed phase durations and any available state
+    transfer metrics are preserved, while the record is marked superseded so acceptance analysis can
+    distinguish abandoned work from the generation that ultimately became active.
+    """
 
     if transition.superseded_recorded:
         return
@@ -167,7 +173,15 @@ def _record_superseded(
 
 
 def _prepare_latest_generation(self: OobleckParallelContext) -> bool:
-    """Retire WORLD and compile the newest ownership without creating a new WORLD."""
+    """Perform the first generation barrier: snapshot, teardown, and compile.
+
+    The first pending proposal clones the last committed state, invalidates loader
+    prefetch, and completely retires the old process-group universe. Superseding
+    proposals reuse that same committed snapshot rather than snapshotting partial
+    recovery state, record the abandoned attempt, and compile only the newest plan.
+    The resulting transition is process-group-free and safe to checksum before the
+    master publishes rendezvous.
+    """
 
     existing = self._prepared_transition
     if self._pending_plan is None:
@@ -223,7 +237,15 @@ def _prepare_latest_generation(self: OobleckParallelContext) -> bool:
 
 
 def _activate_prepared_generation(self: OobleckParallelContext) -> bool:
-    """Create WORLD, activate ownership, and recover after rendezvous publication."""
+    """Perform the second generation barrier: rendezvous, activation, and recovery.
+
+    Replacement WORLD is initialized before Cornstarch materializes local ownership.
+    All ranks then redistribute the shared committed snapshot, rebuild heterogeneous
+    gradient groups, and reconfigure attached DataLoaders. A newer proposal at any
+    point retires partially initialized resources and returns to preparation using
+    the original committed snapshot; only an unsuperseded transition enters recovery
+    history as the active generation.
+    """
 
     transition = self._prepared_transition
     if transition is None:
@@ -314,7 +336,15 @@ def _activate_latest_generation(self: OobleckParallelContext) -> None:
 
 
 def _apply_membership(self: OobleckParallelContext, snapshot: MembershipSnapshot) -> bool:
-    """Convert one complete control-plane snapshot into a pending generation."""
+    """Validate and plan from one complete membership snapshot.
+
+    Stale snapshots are ignored, while every node must preserve the fixed per-node
+    tensor-parallel width. The lowest stable node ID supplies rendezvous, the owner
+    plan recomputes topology from the entire membership rather than an incremental
+    failure, and detection/configuration timings are retained for acceptance metrics.
+    Announcing the plan only queues it; transaction commit and activation barriers
+    decide when it can replace the running generation.
+    """
 
     newest_generation = max(
         self.generation,

--- a/oobleck/runtime_base.py
+++ b/oobleck/runtime_base.py
@@ -221,7 +221,15 @@ class OobleckParallelizationPlan:
         )
 
     def build_execution_plan(self) -> OobleckExecutionPlan:
-        """Compose or reconfigure pipelines and assign deterministic concrete ranks."""
+        """Derive the immutable execution plan for the current membership generation.
+
+        Initial generations compose profiled templates globally; later generations run
+        the survivor-aware reconfiguration planner with estimated retained-state bytes.
+        The method then assigns stable per-node TP rank blocks, records generation
+        ancestry and compatibility, and caches the plan used to score the next change.
+        No process group is created here, so every worker can independently checksum
+        the same ownership before entering rendezvous.
+        """
 
         if self.model is None or self.parallel_config is None:
             raise RuntimeError("call parallelize() before building or materializing a plan")
@@ -312,7 +320,13 @@ class OobleckParallelizationPlan:
         )
 
     def compile(self, execution_plan: OobleckExecutionPlan | None = None) -> CompiledLocalPartition:
-        """Compile rank-local ownership before WORLD, after compatibility validation."""
+        """Compile this worker's rank-local ownership without creating WORLD.
+
+        The plan compatibility digest is checked before rank remapping. Stable node and
+        TP-lane identity select the worker's new global rank, after which Cornstarch
+        receives only the local stage override and global plan metadata. Materialization
+        and real tensor allocation remain deferred until the activation barrier.
+        """
 
         if self.model is None or self.parallel_config is None:
             raise RuntimeError("call parallelize() before compile()")
@@ -469,7 +483,13 @@ class OobleckParallelContext:
             return True
 
     def _activate_latest_generation(self) -> None:
-        """Retire WORLD completely and activate the newest queued generation."""
+        """Synchronously replace the active generation for unmanaged callers.
+
+        Prefetched batches are invalidated before the partition and every process group
+        are retired. Ownership is recompiled without WORLD, replacement WORLD is then
+        initialized, and only afterward is local storage materialized. The loop consumes
+        newer pending plans so an older generation is never left active accidentally.
+        """
 
         while self._pending_plan is not None:
             target = self._pending_plan
@@ -526,7 +546,14 @@ class OobleckParallelContext:
         output_reference: Any,
         criterion: Callable[..., torch.Tensor] | None,
     ) -> tuple[torch.Tensor | None, Any]:
-        """Run one forward/backward attempt with replay-stable stochastic seeds."""
+        """Execute local microbatches without committing any training state.
+
+        A native schedule may own the complete attempt; otherwise each local microbatch
+        runs under a seed derived from logical epoch, committed step, and global
+        microbatch ID. Losses are normalized before backward so replay on a different
+        pipeline layout preserves stochastic behavior and global-batch scaling.
+        Optimizer, scheduler, scaler, and sampler state are deliberately untouched.
+        """
 
         assert self.optimizer is not None
         local_microbatches = self._local_microbatches(batch)
@@ -576,8 +603,13 @@ class OobleckParallelContext:
     ) -> OobleckStepResult:
         """Execute and atomically commit a logical batch, replaying on generation change.
 
-        Optimizer, scheduler, scaler, step, and sampler cursors advance together
-        only after gradient synchronization and a final membership check.
+        Each attempt starts with clean gradients, executes deterministically, and
+        completes both Cornstarch and heterogeneous replica synchronization. Under the
+        commit lock, a final generation/barrier check decides whether the attempt may
+        update optimizer, scheduler, scaler, committed step, and sampler cursor together.
+        A membership event discards partial gradients and retries the same descriptor;
+        execution exceptions are replayed only when a concurrent transition explains
+        them, otherwise the original error is propagated.
         """
 
         if self._closed:

--- a/oobleck/runtime_base.py
+++ b/oobleck/runtime_base.py
@@ -35,6 +35,8 @@ from oobleck.types import (
 
 @dataclass(frozen=True, slots=True)
 class OobleckStepResult:
+    """Outcome of one logical batch, including retries across generations."""
+
     committed: bool
     committed_step: int
     generation: int
@@ -56,6 +58,8 @@ class OobleckPreparedContext:
     _activated: bool = False
 
     def activate(self) -> "OobleckParallelContext":
+        """Initialize WORLD, materialize local state, and consume this preparation once."""
+
         if self._activated:
             raise RuntimeError("prepared context has already been activated")
         if self.owner_plan.world_initializer is not None:
@@ -88,6 +92,8 @@ class OobleckParallelizationPlan:
         world_initializer: Callable[[OobleckExecutionPlan], None] | None = None,
         compatibility: RuntimeCompatibility | None = None,
     ) -> None:
+        """Record planning inputs without touching the distributed data plane."""
+
         self.config = config
         self.templates = tuple(templates)
         self.node_ids = tuple(node_ids)
@@ -106,6 +112,8 @@ class OobleckParallelizationPlan:
         self._rendezvous_address: str | None = None
 
     def parallelize(self, model: torch.nn.Module, parallel_config: object) -> None:
+        """Register the reusable model blueprint and validate Oobleck-owned dimensions."""
+
         if self.model is not None:
             raise RuntimeError("parallelize() may be called only once in the first release")
         required = {
@@ -136,11 +144,15 @@ class OobleckParallelizationPlan:
                 register(model, parallel_config)
 
     def set_templates(self, templates: Sequence[PipelineTemplate]) -> None:
+        """Replace the candidate template catalog used for future generations."""
+
         if not templates:
             raise ValueError("templates must not be empty")
         self.templates = tuple(templates)
 
     def set_membership(self, node_ids: Sequence[str], generation: int | None = None) -> None:
+        """Install a sorted membership and monotonically advance its generation."""
+
         if len(node_ids) != len(set(node_ids)):
             raise ValueError("node IDs must be unique")
         if len(node_ids) > self.config.max_nodes:
@@ -156,6 +168,8 @@ class OobleckParallelizationPlan:
             self._generation += 1
 
     def set_rendezvous_address(self, address: str) -> None:
+        """Select the coordinator address used when creating replacement WORLDs."""
+
         if not address:
             raise ValueError("rendezvous address must not be empty")
         self._rendezvous_address = address
@@ -184,6 +198,8 @@ class OobleckParallelizationPlan:
         )
 
     def _default_template(self) -> PipelineTemplate:
+        """Build a local single-stage fallback when no profiled templates were supplied."""
+
         assert self.model is not None and self.parallel_config is not None
         layer_count = 1
         repeated_layers = getattr(self.model, "_repeated_layers", None)
@@ -205,6 +221,8 @@ class OobleckParallelizationPlan:
         )
 
     def build_execution_plan(self) -> OobleckExecutionPlan:
+        """Compose or reconfigure pipelines and assign deterministic concrete ranks."""
+
         if self.model is None or self.parallel_config is None:
             raise RuntimeError("call parallelize() before building or materializing a plan")
         tp = int(getattr(self.parallel_config, "tensor_parallel_size"))
@@ -278,6 +296,8 @@ class OobleckParallelizationPlan:
         return result
 
     def rank_for_plan(self, execution_plan: OobleckExecutionPlan) -> int:
+        """Preserve this worker's node and TP-lane identity across rank remapping."""
+
         if self._local_node_id is None:
             return self.rank
         for node_id, ranks in execution_plan.rank_map:
@@ -292,6 +312,8 @@ class OobleckParallelizationPlan:
         )
 
     def compile(self, execution_plan: OobleckExecutionPlan | None = None) -> CompiledLocalPartition:
+        """Compile rank-local ownership before WORLD, after compatibility validation."""
+
         if self.model is None or self.parallel_config is None:
             raise RuntimeError("call parallelize() before compile()")
         plan = execution_plan or self.build_execution_plan()
@@ -320,6 +342,8 @@ class OobleckParallelizationPlan:
         *,
         recover_from_survivors: bool = False,
     ) -> "OobleckParallelContext":
+        """Compatibility wrapper that prepares and immediately activates a partition."""
+
         return self.prepare(
             device,
             dtype,
@@ -348,6 +372,8 @@ class OobleckParallelizationPlan:
 
 
 class OobleckParallelContext:
+    """Active generation plus transactional training and reconfiguration state."""
+
     def __init__(
         self,
         *,
@@ -360,6 +386,8 @@ class OobleckParallelContext:
         dtype: torch.dtype | None,
         needs_survivor_recovery: bool = False,
     ) -> None:
+        """Bind an activated local partition to one immutable execution plan."""
+
         self.config = config
         self.owner_plan = owner_plan
         self.execution_plan = execution_plan
@@ -379,10 +407,14 @@ class OobleckParallelContext:
 
     @property
     def model(self) -> torch.nn.Module:
+        """Return the currently active rank-local model view."""
+
         return self.partition.model
 
     @property
     def generation(self) -> int:
+        """Return the active membership generation."""
+
         return self.execution_plan.generation
 
     def create_batch_sampler(
@@ -392,6 +424,8 @@ class OobleckParallelContext:
         shuffle: bool,
         drop_last: bool = True,
     ) -> OobleckBatchSampler:
+        """Create a commit-aware sampler using this generation's allocation."""
+
         return OobleckBatchSampler(
             dataset,
             global_batch_size=self.config.global_batch_size,
@@ -403,6 +437,8 @@ class OobleckParallelContext:
         )
 
     def prepare_dataloader(self, dataloader: DataLoader) -> PreparedDataLoader:
+        """Attach a validated loader so reconfiguration can invalidate its prefetch."""
+
         loader = prepare_dataloader(dataloader)
         self._loaders.append(loader)
         return loader
@@ -414,6 +450,8 @@ class OobleckParallelContext:
         scheduler_factory: Callable[[torch.optim.Optimizer], Any] | None = None,
         scaler: Any = None,
     ) -> None:
+        """Construct optimization state only after local parameters are materialized."""
+
         if self.optimizer is not None:
             raise RuntimeError("optimization is already configured")
         self.optimizer = optimizer_factory(self.model.parameters())
@@ -421,6 +459,8 @@ class OobleckParallelContext:
         self.scaler = scaler
 
     def announce_generation(self, plan: OobleckExecutionPlan) -> bool:
+        """Queue only the newest future plan under the optimizer commit lock."""
+
         with self._commit_lock:
             if plan.generation <= self.generation:
                 return False
@@ -429,6 +469,8 @@ class OobleckParallelContext:
             return True
 
     def _activate_latest_generation(self) -> None:
+        """Retire WORLD completely and activate the newest queued generation."""
+
         while self._pending_plan is not None:
             target = self._pending_plan
             self._pending_plan = None
@@ -451,11 +493,15 @@ class OobleckParallelContext:
             self.execution_plan = target
 
     def _call_model(self, microbatch: Any) -> Any:
+        """Dispatch mapping batches as keyword arguments and other batches positionally."""
+
         if isinstance(microbatch, Mapping):
             return self.model(**microbatch)
         return self.model(microbatch)
 
     def _local_microbatches(self, batch: OobleckBatch) -> tuple[tuple[int, Any], ...]:
+        """Select this pipeline's global microbatch IDs from the logical batch."""
+
         pipeline_id = self.execution_plan.rank_local_stage(self.owner_plan.rank).pipeline_id
         cursor = 0
         selected: tuple[int, ...] | None = None
@@ -480,6 +526,8 @@ class OobleckParallelContext:
         output_reference: Any,
         criterion: Callable[..., torch.Tensor] | None,
     ) -> tuple[torch.Tensor | None, Any]:
+        """Run one forward/backward attempt with replay-stable stochastic seeds."""
+
         assert self.optimizer is not None
         local_microbatches = self._local_microbatches(batch)
         if hasattr(execution, "step") and callable(execution.step):
@@ -526,6 +574,12 @@ class OobleckParallelContext:
         output: Any = None,
         criterion: Callable[..., torch.Tensor] | None = None,
     ) -> OobleckStepResult:
+        """Execute and atomically commit a logical batch, replaying on generation change.
+
+        Optimizer, scheduler, scaler, step, and sampler cursors advance together
+        only after gradient synchronization and a final membership check.
+        """
+
         if self._closed:
             raise RuntimeError("context is closed")
         if self.optimizer is None:
@@ -535,9 +589,13 @@ class OobleckParallelContext:
         wait_for_generation = getattr(self, "_wait_for_generation_barrier", None)
 
         def managed_transition_pending() -> bool:
+            """Consult the optional control-plane barrier installed by runtime.py."""
+
             return callable(transition_pending) and bool(transition_pending())
 
         def wait_if_managed() -> None:
+            """Block commits while the master coordinates a two-phase transition."""
+
             if managed_transition_pending():
                 if not callable(wait_for_generation):
                     raise RuntimeError("managed generation has no control-plane waiter")
@@ -607,6 +665,8 @@ class OobleckParallelContext:
             )
 
     def close(self) -> None:
+        """Idempotently retire the local partition and attached loader references."""
+
         if self._closed:
             return
         self.partition.close()
@@ -614,7 +674,11 @@ class OobleckParallelContext:
         self._closed = True
 
     def __enter__(self) -> "OobleckParallelContext":
+        """Return the active context for managed use."""
+
         return self
 
     def __exit__(self, *exc_info: object) -> None:
+        """Retire resources regardless of how the managed block exits."""
+
         self.close()

--- a/oobleck/state.py
+++ b/oobleck/state.py
@@ -27,6 +27,13 @@ def plan_state_redistribution(
     bandwidth_bytes_per_s: Mapping[int, float] | None = None,
     link_classifier: Callable[[int, int], tuple[str, float]] | None = None,
 ) -> TransferSchedule:
+    """Plan public redistribution without inventing destination bottlenecks.
+
+    When no measured bandwidth is supplied, destination ingress is common to
+    every source candidate. Treating it as unbounded preserves source-egress
+    load balancing while the lower layers still account for transferred bytes.
+    """
+
     # In the topology-free model destination ingress is identical for every
     # candidate and must not erase the source-egress tie-break.  Infinite
     # destination bandwidth removes only that common term; measured bandwidth

--- a/oobleck/state_base.py
+++ b/oobleck/state_base.py
@@ -31,11 +31,15 @@ _DTYPE_BYTES = {
 
 
 def _dtype_name(value: str) -> str:
+    """Normalize torch-qualified dtype names for stable manifests and grouping."""
+
     return value.removeprefix("torch.")
 
 
 @dataclass(frozen=True, slots=True)
 class LogicalStateEntry:
+    """Versioned ownership metadata for one logical parameter, buffer, or slot."""
+
     logical_key: str
     global_shape: tuple[int, ...]
     local_shape: tuple[int, ...]
@@ -50,6 +54,8 @@ class LogicalStateEntry:
     byte_count: int | None = None
 
     def __post_init__(self) -> None:
+        """Validate shard identity and ensure its storage size is computable."""
+
         if not self.logical_key:
             raise ValueError("logical_key must not be empty")
         if any(size < 0 for size in (*self.global_shape, *self.local_shape)):
@@ -63,6 +69,8 @@ class LogicalStateEntry:
 
     @property
     def nbytes(self) -> int:
+        """Return explicit storage bytes or derive them from local shape and dtype."""
+
         if self.byte_count is not None:
             return self.byte_count
         elements = reduce(mul, self.local_shape, 1)
@@ -70,6 +78,8 @@ class LogicalStateEntry:
 
     @property
     def shard_identity(self) -> tuple[object, ...]:
+        """Return the fields that must match for a committed shard to be reused."""
+
         return (
             self.logical_key,
             self.tp_lane,
@@ -82,12 +92,16 @@ class LogicalStateEntry:
 
 @dataclass(frozen=True, slots=True)
 class StateManifest:
+    """Checksummed committed-state inventory owned by one rank."""
+
     rank: int
     entries: tuple[LogicalStateEntry, ...]
     committed_step: int
     manifest_hash: str = field(default="", compare=False)
 
     def __post_init__(self) -> None:
+        """Validate ownership uniqueness and compute the consensus hash."""
+
         if self.rank < 0 or self.committed_step < 0:
             raise ValueError("rank and committed_step must be non-negative")
         if any(entry.owner_rank != self.rank for entry in self.entries):
@@ -110,6 +124,8 @@ class StateManifest:
 
 @dataclass(frozen=True, slots=True)
 class Transfer:
+    """One byte range assigned to a source, destination, dtype, and round."""
+
     source_rank: int
     destination_rank: int
     logical_key: str
@@ -124,11 +140,15 @@ class Transfer:
 
     @property
     def byte_count(self) -> int:
+        """Return the half-open chunk length in bytes."""
+
         return self.chunk_end - self.chunk_start
 
 
 @dataclass(frozen=True, slots=True)
 class TransferSchedule:
+    """Immutable redistribution plan with deterministic load accounting."""
+
     transfers: tuple[Transfer, ...]
     retained: tuple[tuple[int, str, int], ...]
     per_source_bytes: tuple[tuple[int, int], ...]
@@ -137,6 +157,8 @@ class TransferSchedule:
     schedule_hash: str = field(default="", compare=False)
 
     def __post_init__(self) -> None:
+        """Compute or verify the schedule hash exchanged by all ranks."""
+
         payload = {
             "transfers": [asdict(item) for item in self.transfers],
             "retained": self.retained,
@@ -151,6 +173,8 @@ class TransferSchedule:
     def split_sizes(
         self, rank: int, world_size: int, *, round: int = 0, dtype: str | None = None
     ) -> tuple[list[int], list[int]]:
+        """Build all-to-all input/output byte splits for one rank and round."""
+
         inputs = [0] * world_size
         outputs = [0] * world_size
         for item in self.transfers:
@@ -164,6 +188,8 @@ class TransferSchedule:
 
 
 def _chunks(size: int, chunk_bytes: int, alignment: int) -> Iterable[tuple[int, int]]:
+    """Yield aligned half-open byte ranges without padding the final chunk."""
+
     if size == 0:
         return
     effective = max(alignment, (chunk_bytes // alignment) * alignment)
@@ -175,6 +201,8 @@ def _chunks(size: int, chunk_bytes: int, alignment: int) -> Iterable[tuple[int, 
 
 
 def _bundle_key(entry: LogicalStateEntry) -> tuple[str, int, int]:
+    """Keep a parameter and all of its optimizer slots on one complete source."""
+
     parameter_key = entry.logical_key.split("::optimizer::", 1)[0]
     return parameter_key, entry.tp_lane, entry.version
 
@@ -276,6 +304,8 @@ def plan_state_redistribution(
     round_destination_loads: list[dict[int, int]] = []
 
     def locality(source: int, destination: int) -> tuple[str, float]:
+        """Classify a candidate link and return its relative transfer cost."""
+
         if link_classifier is not None:
             return link_classifier(source, destination)
         if rank_to_node and rank_to_node.get(source) == rank_to_node.get(destination):

--- a/oobleck/state_base.py
+++ b/oobleck/state_base.py
@@ -218,7 +218,17 @@ def plan_state_redistribution(
     bandwidth_bytes_per_s: Mapping[int, float] | None = None,
     link_classifier: Callable[[int, int], tuple[str, float]] | None = None,
 ) -> TransferSchedule:
-    """Assign largest chunks to candidates by projected byte makespan."""
+    """Plan deterministic, balanced redistribution of one committed state version.
+
+    Old manifests are indexed by full shard identity. For every destination parameter,
+    buffer, and optimizer slot, the planner first requires a surviving rank that owns the
+    complete parameter bundle; a locally complete bundle is retained without transfer.
+    Remaining tensors are split into aligned chunks and scheduled largest-first to the
+    source minimizing projected source egress, destination ingress, and link-class load,
+    adjusted by optional measured bandwidth/locality. Per-round byte caps bound collective
+    memory. Stable sort keys and the final schedule hash let every rank independently derive
+    and verify the identical all-to-all program.
+    """
 
     if chunk_bytes < 1 or alignment < 1:
         raise ValueError("chunk_bytes and alignment must be positive")

--- a/oobleck/state_public_base.py
+++ b/oobleck/state_public_base.py
@@ -33,6 +33,8 @@ def plan_state_redistribution(
     if link_classifier is None:
 
         def link_classifier(source: int, destination: int) -> tuple[str, float]:
+            """Give each homogeneous pair an independent scheduler load bucket."""
+
             if rank_to_node and rank_to_node.get(source) == rank_to_node.get(destination):
                 return f"same-node:{source}:{destination}", 0.25
             return f"network:{source}:{destination}", 1.0

--- a/oobleck/state_public_base.py
+++ b/oobleck/state_public_base.py
@@ -27,7 +27,14 @@ def plan_state_redistribution(
     bandwidth_bytes_per_s: Mapping[int, float] | None = None,
     link_classifier: Callable[[int, int], tuple[str, float]] | None = None,
 ) -> TransferSchedule:
-    """Plan transfers, balancing homogeneous links per source/destination pair."""
+    """Refine base transfer planning so homogeneous links stripe across source pairs.
+
+    Without an operator classifier, each source/destination pair receives an independent temporary
+    link bucket, with same-node pairs retaining their lower relative cost. This prevents aggregate
+    ``network`` load from collapsing otherwise equal source choices. After planning, pair-specific
+    labels are normalized back to public ``same-node``/``network`` classes and byte totals recomputed;
+    explicit operator classifiers pass through unchanged.
+    """
 
     normalize_default_links = link_classifier is None
     if link_classifier is None:

--- a/oobleck/state_transfer.py
+++ b/oobleck/state_transfer.py
@@ -16,6 +16,8 @@ StateTensorKey = tuple[str, str, int]
 
 @dataclass(frozen=True, slots=True)
 class TransferExecutionMetrics:
+    """Observed byte accounting and collective duration for schedule execution."""
+
     actual_source_bytes: tuple[tuple[int, int], ...]
     actual_destination_bytes: tuple[tuple[int, int], ...]
     actual_link_class_bytes: tuple[tuple[str, int], ...]
@@ -23,6 +25,8 @@ class TransferExecutionMetrics:
 
 
 def _bytes(tensor: torch.Tensor) -> torch.Tensor:
+    """Expose contiguous tensor storage as a flat byte view, including scalars."""
+
     if not tensor.is_contiguous():
         raise ValueError("state transfer tensors must be contiguous")
     # ``view(dtype)`` rejects zero-dimensional tensors when element sizes
@@ -32,6 +36,8 @@ def _bytes(tensor: torch.Tensor) -> torch.Tensor:
 
 
 def _transfer_identity(item) -> tuple[object, ...]:
+    """Key checksum metadata by every field that identifies a scheduled chunk."""
+
     return (
         item.round,
         item.source_rank,
@@ -46,10 +52,14 @@ def _transfer_identity(item) -> tuple[object, ...]:
 
 
 def _checksum(payload: torch.Tensor) -> str:
+    """Hash payload bytes on CPU so corruption is detected after transfer."""
+
     return hashlib.sha256(payload.detach().cpu().numpy().tobytes()).hexdigest()
 
 
 def _validate_dtype(tensor: torch.Tensor, expected: str, key: StateTensorKey) -> None:
+    """Prevent byte unpacking into a storage layout with a different dtype."""
+
     actual = str(tensor.dtype).removeprefix("torch.")
     if actual != expected.removeprefix("torch."):
         raise ValueError(

--- a/oobleck/state_transfer.py
+++ b/oobleck/state_transfer.py
@@ -78,11 +78,15 @@ def execute_transfer_schedule(
     group=None,
     verify_checksums: bool = True,
 ) -> TransferExecutionMetrics:
-    """Pack, all-to-all, validate, and unpack every collective round.
+    """Execute every immutable schedule round through collective all-to-all.
 
-    Each rank calls this with the same schedule and participates with zero-sized
-    splits when it has no payload. Destination tensors are preallocated from the
-    new manifest, allowing unpacking directly into their storage.
+    Each rank selects outgoing/incoming chunks using the same stable ordering, validates
+    source dtype and bounds, and packs raw bytes by destination. Ranks with no payload still
+    participate using zero-sized splits. Optional pre-transfer checksums are exchanged as
+    objects and verified after bytes are copied directly into manifest-sized destination
+    storage. Round durations use the slowest rank, and planned traffic accounting is returned
+    for recovery diagnostics. Any missing tensor, byte mismatch, dtype mismatch, or checksum
+    failure aborts activation before recovered state can be committed.
     """
 
     if not 0 <= rank < world_size:

--- a/oobleck/topology.py
+++ b/oobleck/topology.py
@@ -175,7 +175,14 @@ def activate_gradient_synchronizer(
     *,
     microbatch_size: int,
 ) -> HeterogeneousGradientSynchronizer | None:
-    """Gather ownership, create every logical group, and bind local parameters."""
+    """Build generation-local gradient synchronization from logical ownership.
+
+    Every rank gathers state manifests, groups parameter replicas by logical/shared key, TP lane,
+    and placement, and derives sample weights from each pipeline's microbatch allocation. Process
+    groups are created in identical global order, including on non-members, before local parameters
+    are bound through shared-state aliases. The returned synchronizer reduces only groups containing
+    this rank and must be retired with the generation's process-group universe.
+    """
 
     import torch.distributed as dist
 

--- a/oobleck/topology.py
+++ b/oobleck/topology.py
@@ -14,6 +14,8 @@ from oobleck.types import OobleckExecutionPlan
 
 @dataclass(frozen=True, slots=True)
 class GradientSyncGroup:
+    """Replica ranks and sample weights for one logical parameter shard."""
+
     logical_key: str
     tp_lane: int
     placements: tuple[str, ...]
@@ -21,6 +23,8 @@ class GradientSyncGroup:
     sample_weights: tuple[float, ...]
 
     def __post_init__(self) -> None:
+        """Require deterministic membership and a normalized weighted reduction."""
+
         if len(self.ranks) != len(self.sample_weights) or not self.ranks:
             raise ValueError("gradient group ranks and sample weights must align")
         if tuple(sorted(self.ranks)) != self.ranks or len(set(self.ranks)) != len(self.ranks):
@@ -34,6 +38,12 @@ def build_gradient_sync_groups(
     rank_to_pipeline: Mapping[int, str],
     pipeline_sample_counts: Mapping[str, int],
 ) -> tuple[GradientSyncGroup, ...]:
+    """Group parameter owners by logical identity, TP lane, and placement.
+
+    Each pipeline contributes in proportion to the number of samples it processed,
+    which preserves global-batch gradient semantics under heterogeneous allocation.
+    """
+
     owners: dict[tuple[str, int, tuple[str, ...]], set[int]] = {}
     for manifest in manifests:
         for entry in manifest.entries:
@@ -99,11 +109,19 @@ class HeterogeneousGradientSynchronizer:
     """Sample-weighted logical-parameter reduction across pipeline replicas."""
 
     def __init__(self, bindings, process_groups) -> None:
+        """Capture local parameters and the deterministically created groups."""
+
         self._bindings = tuple(bindings)
         self._process_groups = process_groups
         self._closed = False
 
     def sync(self) -> None:
+        """Sample-weight and all-reduce every present logical gradient.
+
+        A presence collective distinguishes an unused parameter from a missing
+        local gradient; Gloo reductions stage CUDA payloads through CPU storage.
+        """
+
         if self._closed:
             raise RuntimeError("gradient synchronizer is closed")
         import torch.distributed as dist
@@ -143,6 +161,8 @@ class HeterogeneousGradientSynchronizer:
             local_gradient.copy_(payload.to(local_gradient.device))
 
     def close(self) -> None:
+        """Drop generation-local parameter and process-group references."""
+
         self._bindings = ()
         self._process_groups = {}
         self._closed = True

--- a/oobleck/types.py
+++ b/oobleck/types.py
@@ -19,6 +19,8 @@ class RecoveryUnavailable(RuntimeError):
 
 
 def _canonical_json(value: Any) -> bytes:
+    """Encode a JSON value identically on every worker for checksumming."""
+
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
         "utf-8"
     )
@@ -32,6 +34,8 @@ def checksum(value: Any) -> str:
 
 @dataclass(frozen=True, slots=True)
 class CompatibilityFingerprint:
+    """Offline template-cache identity for model, TP width, and hardware."""
+
     model: str
     dtype: str
     tensor_parallel_size: int
@@ -40,6 +44,8 @@ class CompatibilityFingerprint:
     schema_version: int = 1
 
     def __post_init__(self) -> None:
+        """Reject fingerprints that cannot describe the current cache schema."""
+
         if self.tensor_parallel_size < 1:
             raise ValueError("tensor_parallel_size must be >= 1")
         if self.schema_version != 1:
@@ -49,6 +55,8 @@ class CompatibilityFingerprint:
 
     @property
     def digest(self) -> str:
+        """Return the worker-independent identity used by template caches."""
+
         return checksum(asdict(self))
 
 
@@ -70,6 +78,8 @@ class RuntimeCompatibility:
     schema_version: int = 1
 
     def __post_init__(self) -> None:
+        """Validate fields required for exact cross-worker compatibility."""
+
         required = (
             self.oobleck_commit,
             self.cornstarch_commit,
@@ -88,9 +98,13 @@ class RuntimeCompatibility:
 
     @property
     def digest(self) -> str:
+        """Return the compatibility identity embedded in generation plans."""
+
         return checksum(asdict(self))
 
     def assert_matches(self, other: "RuntimeCompatibility") -> None:
+        """Raise with the differing fields when two workers cannot share a generation."""
+
         if self != other:
             left = asdict(self)
             right = asdict(other)
@@ -119,6 +133,8 @@ class PipelineStageSpec:
     tied_parameter_owner: str | None = None
 
     def __post_init__(self) -> None:
+        """Validate a non-empty global layer range and its ordered TP lanes."""
+
         if not self.pipeline_id:
             raise ValueError("pipeline_id must not be empty")
         if self.stage_id < 0:
@@ -148,6 +164,8 @@ class PipelineTemplate:
     schema_version: int = 1
 
     def __post_init__(self) -> None:
+        """Validate that the template is a contiguous, feasible stage partition."""
+
         if not self.template_id:
             raise ValueError("template_id must not be empty")
         if self.schema_version != 1:
@@ -175,6 +193,8 @@ class PipelineTemplate:
 
     @property
     def num_stages(self) -> int:
+        """Return the pipeline depth encoded by the ordered layer ranges."""
+
         return len(self.layer_ranges)
 
     @property
@@ -184,6 +204,12 @@ class PipelineTemplate:
         return self.num_stages
 
     def iteration_time(self, microbatches: int) -> float:
+        """Estimate flush plus steady-state time for a microbatch allocation.
+
+        Returning infinity for allocations beyond ``max_microbatches`` lets the
+        composer treat memory-infeasible choices like any other bad candidate.
+        """
+
         if microbatches < 0:
             raise ValueError("microbatches must be non-negative")
         if self.max_microbatches is not None and microbatches > self.max_microbatches:
@@ -197,6 +223,8 @@ class PipelineTemplate:
         return bubble + microbatches * stage_work + self.communication_time
 
     def assert_compatible(self, fingerprint: CompatibilityFingerprint) -> None:
+        """Reject cache entries produced for a different model or runtime."""
+
         if self.fingerprint is None:
             raise ValueError(f"Template {self.template_id!r} has no compatibility fingerprint")
         if self.fingerprint != fingerprint:
@@ -207,12 +235,16 @@ class PipelineTemplate:
             )
 
     def to_dict(self) -> dict[str, Any]:
+        """Convert the immutable template into its JSON-compatible cache form."""
+
         result = asdict(self)
         result["layer_ranges"] = [list(item) for item in self.layer_ranges]
         return result
 
     @classmethod
     def from_dict(cls, value: Mapping[str, Any]) -> "PipelineTemplate":
+        """Reconstruct a validated template from its serialized cache form."""
+
         data = dict(value)
         data["layer_ranges"] = tuple(tuple(item) for item in data["layer_ranges"])
         fingerprint = data.get("fingerprint")
@@ -223,6 +255,8 @@ class PipelineTemplate:
 
 @dataclass(frozen=True, slots=True)
 class PipelineInstance:
+    """A template assigned to concrete nodes, ranks, and logical microbatches."""
+
     instance_id: str
     template: PipelineTemplate
     node_ids: tuple[str, ...]
@@ -230,6 +264,8 @@ class PipelineInstance:
     microbatches: int = 0
 
     def __post_init__(self) -> None:
+        """Ensure concrete ownership has exactly the template's shape."""
+
         if not self.instance_id:
             raise ValueError("instance_id must not be empty")
         if len(self.node_ids) != self.template.num_stages:
@@ -245,6 +281,8 @@ class PipelineInstance:
 
     @property
     def stage_specs(self) -> tuple[PipelineStageSpec, ...]:
+        """Expand concrete rank groups into Cornstarch-compatible stage ownership."""
+
         if not self.ranks:
             return ()
         return tuple(
@@ -273,6 +311,8 @@ class OobleckExecutionPlan:
     plan_checksum: str = field(default="", compare=False)
 
     def __post_init__(self) -> None:
+        """Validate complete ownership and seal the plan with a content checksum."""
+
         if self.generation < 0:
             raise ValueError("generation must be non-negative")
         if self.previous_generation is not None and self.previous_generation >= self.generation:
@@ -292,6 +332,8 @@ class OobleckExecutionPlan:
         object.__setattr__(self, "plan_checksum", expected)
 
     def _unsigned_dict(self) -> dict[str, Any]:
+        """Return the canonical payload covered by ``plan_checksum``."""
+
         return {
             "generation": self.generation,
             "previous_generation": self.previous_generation,
@@ -310,6 +352,8 @@ class OobleckExecutionPlan:
         }
 
     def rank_local_stage(self, rank: int) -> PipelineStageSpec:
+        """Find the single pipeline stage owned by a global rank."""
+
         for instance in self.instances:
             for spec in instance.stage_specs:
                 if rank in spec.ranks:
@@ -319,6 +363,8 @@ class OobleckExecutionPlan:
 
 @dataclass(frozen=True, slots=True)
 class OobleckConfig:
+    """Training, elasticity, control-plane, and transfer limits for one job."""
+
     global_batch_size: int
     microbatch_size: int
     fault_tolerance_threshold: int = 0
@@ -335,6 +381,8 @@ class OobleckConfig:
     transfer_alignment_bytes: int = 256
 
     def __post_init__(self) -> None:
+        """Reject settings that would break batching or generation invariants."""
+
         if self.global_batch_size < 1 or self.microbatch_size < 1:
             raise ValueError("global_batch_size and microbatch_size must be >= 1")
         if self.global_batch_size % self.microbatch_size:
@@ -366,12 +414,20 @@ class OobleckConfig:
 
     @property
     def global_num_microbatches(self) -> int:
+        """Return the fixed number of logical microbatches committed per step."""
+
         return self.global_batch_size // self.microbatch_size
 
 
 def stable_rank_map(
     node_ids: Sequence[str], tensor_parallel_size: int
 ) -> tuple[tuple[str, tuple[int, ...]], ...]:
+    """Assign contiguous rank blocks to sorted node IDs deterministically.
+
+    The control plane and every worker can call this independently before
+    process-group initialization and still derive the same WORLD rank order.
+    """
+
     if tensor_parallel_size < 1:
         raise ValueError("tensor_parallel_size must be >= 1")
     if len(set(node_ids)) != len(node_ids):


### PR DESCRIPTION
## Summary

- add behavior-focused docstrings to every Python class and function under `oobleck/`
- connect implementation details to the refactor lifecycle: deterministic planning and replay, generation/incarnation barriers, process-group replacement, state redistribution, optimizer recovery, and operator/acceptance flows
- document lower-level retained `*_base.py` paths as well as the current public facades
- merge the latest `refactor` branch and revise core comments for PR #46 removal/addition membership semantics and graceful pure-addition cutover

## Why

The refactored implementation has rich design documentation in `README.md`, `lifecycle.md`, `docs/`, and `tasks/plan.md`, but many implementation entry points did not explain their invariants or lifecycle role. This makes it difficult to trace those specifications into the code.

## Impact

Documentation only relative to the current `refactor` branch. A normalized AST comparison against `origin/refactor` confirms that executable Python structure is unchanged after removing docstrings.

## Validation

- `python -m compileall -q oobleck`
- `ruff check .`
- `ruff format --check .`
- `pyright`
- `pytest -q` — 95 passed
- `cargo test` — 9 passed
- `git diff --check`